### PR TITLE
Department Leader / 2차 평가 작성 화면 추가

### DIFF
--- a/src/components/departmentleader/hr/DepartmentLeaderEvalFormPanel.vue
+++ b/src/components/departmentleader/hr/DepartmentLeaderEvalFormPanel.vue
@@ -1,0 +1,416 @@
+<script setup>
+import { ref, watch, computed } from 'vue'
+
+const props = defineProps({
+  member: { type: Object, default: null },
+})
+
+const emit = defineEmits(['save', 'submit'])
+
+// Local copy of evaluations so edits don't mutate prop directly
+const localEvals = ref([])
+
+watch(
+  () => props.member,
+  (m) => {
+    if (!m) return
+    localEvals.value = m.evaluations.map((e) => ({ ...e }))
+  },
+  { immediate: true },
+)
+
+function scoreToStars(score) {
+  if (score >= 81) return 5
+  if (score >= 61) return 4
+  if (score >= 41) return 3
+  if (score >= 21) return 2
+  return 1
+}
+
+function updateScore(idx, raw) {
+  const score = Math.min(100, Math.max(0, Number(raw) || 0))
+  localEvals.value[idx].score = score
+  localEvals.value[idx].stars = scoreToStars(score)
+}
+
+function setStars(idx, stars) {
+  localEvals.value[idx].stars = stars
+}
+
+const canSubmit = computed(() =>
+  localEvals.value.every(
+    (e) => e.score > 0 && String(e.comment).trim() !== '',
+  ),
+)
+
+const tierColors = {
+  S: { bg: '#00BF95', text: '#fff' },
+  A: { bg: '#5B4FCF', text: '#fff' },
+  B: { bg: '#FFD166', text: '#855900' },
+  C: { bg: '#EF476F', text: '#fff' },
+}
+</script>
+
+<template>
+  <section v-if="member" class="eval-form">
+    <!-- Member header -->
+    <div class="eval-form__header">
+      <div class="eval-form__avatar" :style="{ background: member.avatarColor }">
+        {{ member.avatar }}
+      </div>
+      <div class="eval-form__member-info">
+        <div class="eval-form__name-row">
+          <span class="eval-form__name">{{ member.name }}</span>
+          <span
+            class="eval-form__tier-badge"
+            :style="{ background: tierColors[member.tier]?.bg, color: tierColors[member.tier]?.text }"
+          >{{ member.tier }}</span>
+        </div>
+        <span class="eval-form__meta">2차인 · {{ member.tier }}-Tier · {{ member.experience }}</span>
+      </div>
+    </div>
+
+    <!-- AI recommendation -->
+    <div class="eval-form__ai-box">
+      <span class="eval-form__ai-label">AI 산출 정량 평균 점수 권고</span>
+      <div class="eval-form__ai-scores">
+        <div class="eval-form__ai-score">
+          <span class="eval-form__ai-value">{{ member.aiRecommended.quantitative }}</span>
+          <span class="eval-form__ai-kind">정량</span>
+        </div>
+        <div class="eval-form__ai-divider" />
+        <div class="eval-form__ai-score">
+          <span class="eval-form__ai-value">{{ member.aiRecommended.qualitative }}</span>
+          <span class="eval-form__ai-kind">정성</span>
+        </div>
+        <div class="eval-form__ai-divider" />
+        <div class="eval-form__ai-score">
+          <span class="eval-form__ai-value">{{ member.aiRecommended.composite }}</span>
+          <span class="eval-form__ai-kind">종합</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Evaluation categories -->
+    <div class="eval-form__categories">
+      <div
+        v-for="(item, idx) in localEvals"
+        :key="item.category"
+        class="eval-category"
+      >
+        <div class="eval-category__title-row">
+          <span class="eval-category__name">{{ item.category }}</span>
+          <input
+            class="eval-category__score"
+            type="number"
+            min="0"
+            max="100"
+            :value="localEvals[idx].score"
+            @input="updateScore(idx, $event.target.value)"
+          />
+        </div>
+
+        <!-- Stars -->
+        <div class="eval-category__stars">
+          <span
+            v-for="s in 5"
+            :key="s"
+            class="eval-category__star"
+            :class="{ 'eval-category__star--filled': s <= item.stars }"
+            @click="setStars(idx, s)"
+          >★</span>
+        </div>
+
+        <!-- Comment input -->
+        <input
+          v-model="localEvals[idx].comment"
+          class="eval-category__input"
+          type="text"
+          :placeholder="`${item.category} 코멘트 입력...`"
+        />
+      </div>
+    </div>
+
+    <!-- Action buttons -->
+    <div class="eval-form__actions">
+      <span v-if="!canSubmit" class="eval-form__submit-hint">
+        모든 항목의 점수와 코멘트를 입력해야 제출할 수 있습니다.
+      </span>
+      <button class="eval-form__btn eval-form__btn--save" @click="emit('save', localEvals)">
+        임시저장
+      </button>
+      <button
+        class="eval-form__btn eval-form__btn--submit"
+        :disabled="!canSubmit"
+        @click="emit('submit', localEvals)"
+      >
+        최종 제출
+      </button>
+    </div>
+  </section>
+
+  <section v-else class="eval-form eval-form--empty">
+    <p>좌측 목록에서 팀원을 선택하세요.</p>
+  </section>
+</template>
+
+<style scoped>
+.eval-form {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 24px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 24px;
+  background: var(--color-bg-surface);
+  overflow-y: auto;
+  max-height: calc(100vh - 200px);
+}
+
+.eval-form--empty {
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-muted);
+  font-size: 14px;
+}
+
+/* Header */
+.eval-form__header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.eval-form__avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 22px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.eval-form__member-info {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.eval-form__name-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.eval-form__name {
+  font-size: 20px;
+  font-weight: 800;
+  color: var(--color-primary-800);
+}
+
+.eval-form__tier-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.eval-form__meta {
+  font-size: 13px;
+  color: var(--color-text-muted);
+}
+
+/* AI recommendation box */
+.eval-form__ai-box {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 20px;
+  border-radius: 14px;
+  background: #f0eeff;
+}
+
+.eval-form__ai-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-primary-700);
+  white-space: nowrap;
+}
+
+.eval-form__ai-scores {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.eval-form__ai-score {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.eval-form__ai-value {
+  font-size: 18px;
+  font-weight: 800;
+  color: var(--color-primary-800);
+}
+
+.eval-form__ai-kind {
+  font-size: 11px;
+  color: var(--color-text-muted);
+}
+
+.eval-form__ai-divider {
+  width: 1px;
+  height: 28px;
+  background: var(--color-border-default);
+}
+
+/* Categories */
+.eval-form__categories {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.eval-category {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.eval-category__title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.eval-category__name {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--color-primary-800);
+}
+
+.eval-category__score {
+  width: 72px;
+  text-align: center;
+  font-size: 16px;
+  font-weight: 800;
+  color: var(--color-primary-600);
+  border: 1.5px solid var(--color-primary-300);
+  border-radius: 8px;
+  padding: 4px 8px;
+  background: var(--color-primary-50, #f5f3ff);
+  outline: none;
+  -moz-appearance: textfield;
+  transition: border-color 0.15s;
+}
+.eval-category__score:focus {
+  border-color: var(--color-primary-500);
+}
+.eval-category__score::-webkit-inner-spin-button,
+.eval-category__score::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+}
+
+/* Stars */
+.eval-category__stars {
+  display: flex;
+  gap: 4px;
+}
+
+.eval-category__star {
+  font-size: 22px;
+  color: #ddd;
+  cursor: pointer;
+  line-height: 1;
+  transition: color 0.1s;
+}
+
+.eval-category__star--filled {
+  color: #f5a623;
+}
+
+.eval-category__star:hover {
+  color: #f5c060;
+}
+
+/* Comment input */
+.eval-category__input {
+  width: 100%;
+  height: 40px;
+  padding: 0 14px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 10px;
+  font-size: 13px;
+  color: var(--color-text-default);
+  background: var(--color-bg-surface-muted);
+  box-sizing: border-box;
+  outline: none;
+}
+.eval-category__input::placeholder {
+  color: var(--color-text-muted);
+}
+.eval-category__input:focus {
+  border-color: var(--color-primary-400);
+}
+
+/* Action buttons */
+.eval-form__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  justify-content: flex-end;
+  padding-top: 4px;
+  flex-wrap: wrap;
+}
+
+.eval-form__submit-hint {
+  flex: 1;
+  font-size: 12px;
+  color: #e05a5a;
+  text-align: left;
+}
+
+.eval-form__btn {
+  height: 42px;
+  padding: 0 24px;
+  border-radius: 12px;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  border: none;
+  transition: opacity 0.15s;
+}
+.eval-form__btn:hover {
+  opacity: 0.85;
+}
+
+.eval-form__btn--save {
+  background: var(--color-bg-surface-muted);
+  color: var(--color-text-default);
+  border: 1px solid var(--color-border-default);
+}
+
+.eval-form__btn--submit {
+  background: var(--color-primary-600);
+  color: #fff;
+}
+
+.eval-form__btn--submit:disabled {
+  background: var(--color-border-default);
+  color: var(--color-text-muted);
+  cursor: not-allowed;
+  opacity: 1;
+}
+</style>

--- a/src/components/departmentleader/hr/DepartmentLeaderEvalMemberListPanel.vue
+++ b/src/components/departmentleader/hr/DepartmentLeaderEvalMemberListPanel.vue
@@ -1,0 +1,207 @@
+<script setup>
+defineProps({
+  members: { type: Array, default: () => [] },
+  selectedId: { type: Number, default: null },
+})
+
+const emit = defineEmits(['select'])
+
+const statusConfig = {
+  submitted:    { label: '제출 완료', icon: '✓', cardClass: 'card--submitted' },
+  in_progress:  { label: '작성 중',   icon: '✏', cardClass: 'card--in-progress' },
+  not_started:  { label: '미작성',    icon: '⊘', cardClass: 'card--not-started' },
+}
+
+const tierColors = {
+  S: { bg: '#00BF95', text: '#fff' },
+  A: { bg: '#5B4FCF', text: '#fff' },
+  B: { bg: '#FFD166', text: '#855900' },
+  C: { bg: '#EF476F', text: '#fff' },
+}
+</script>
+
+<template>
+  <section class="eval-member-list">
+    <h3 class="eval-member-list__title">팀원 평가 현황</h3>
+
+    <ul class="eval-member-list__list">
+      <li
+        v-for="m in members"
+        :key="m.id"
+        class="eval-card"
+        :class="[statusConfig[m.status]?.cardClass, { 'eval-card--selected': m.id === selectedId }]"
+        @click="emit('select', m)"
+      >
+        <div class="eval-card__left">
+          <div class="eval-card__avatar" :style="{ background: m.avatarColor }">
+            {{ m.avatar }}
+          </div>
+          <div class="eval-card__info">
+            <div class="eval-card__name-row">
+              <span class="eval-card__name">{{ m.name }}</span>
+              <span
+                class="eval-card__tier"
+                :style="{ background: tierColors[m.tier]?.bg, color: tierColors[m.tier]?.text }"
+              >{{ m.tier }}</span>
+            </div>
+            <span class="eval-card__status">
+              {{ statusConfig[m.status]?.icon }} {{ statusConfig[m.status]?.label }}
+            </span>
+          </div>
+        </div>
+        <span class="eval-card__date">{{ m.statusDate }}</span>
+      </li>
+    </ul>
+  </section>
+</template>
+
+<style scoped>
+.eval-member-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 20px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 24px;
+  background: var(--color-bg-surface);
+}
+
+.eval-member-list__title {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--color-primary-600);
+  margin: 0;
+}
+
+.eval-member-list__list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 0;
+  margin: 0;
+}
+
+/* Card base */
+.eval-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background 0.15s;
+}
+
+.eval-card__left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+/* Status variants */
+.card--submitted {
+  background: #e8faf4;
+  border-color: #a7e9d0;
+}
+
+.card--in-progress {
+  background: #1e1650;
+  border-color: #3d2fa0;
+}
+
+.card--not-started {
+  background: #f7f7f9;
+  border-color: var(--color-border-soft);
+}
+
+.eval-card--selected {
+  outline: 2px solid var(--color-primary-400);
+}
+
+/* Avatar */
+.eval-card__avatar {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 17px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+/* Info */
+.eval-card__info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.eval-card__name-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.eval-card__name {
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.card--submitted .eval-card__name,
+.card--not-started .eval-card__name {
+  color: var(--color-primary-800);
+}
+
+.card--in-progress .eval-card__name {
+  color: #fff;
+}
+
+.eval-card__tier {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.eval-card__status {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.card--submitted .eval-card__status {
+  color: #16a37a;
+}
+
+.card--in-progress .eval-card__status {
+  color: #c4b8ff;
+}
+
+.card--not-started .eval-card__status {
+  color: var(--color-text-muted);
+}
+
+/* Date */
+.eval-card__date {
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+.card--submitted .eval-card__date,
+.card--not-started .eval-card__date {
+  color: var(--color-text-muted);
+}
+
+.card--in-progress .eval-card__date {
+  color: #c4b8ff;
+}
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -206,7 +206,7 @@ const routes = [
       {
         path: 'evaluation',
         name: 'DepartmentLeaderDashboardEvaluation',
-        component: Placeholder,
+        component: () => import('@/views/departmentleader/DepartmentLeaderSecondEvaluationView.vue'),
       },
       {
         path: 'notification',

--- a/src/views/departmentleader/DepartmentLeaderSecondEvaluationView.vue
+++ b/src/views/departmentleader/DepartmentLeaderSecondEvaluationView.vue
@@ -1,0 +1,217 @@
+<script setup>
+import { ref, computed } from 'vue'
+import DepartmentLeaderEvalMemberListPanel from '@/components/departmentleader/hr/DepartmentLeaderEvalMemberListPanel.vue'
+import DepartmentLeaderEvalFormPanel from '@/components/departmentleader/hr/DepartmentLeaderEvalFormPanel.vue'
+
+const members = ref([
+  {
+    id: 1,
+    name: '손창우',
+    avatar: '손',
+    avatarColor: '#5f50d6',
+    tier: 'S',
+    code: 'MCH-01',
+    team: '정밀가공 1팀',
+    experience: '경력 3년 2월',
+    status: 'submitted',
+    statusDate: '03.05',
+    aiRecommended: { quantitative: 94.2, qualitative: 89.4, composite: 91.8 },
+    evaluations: [
+      { category: '직무 태도',   stars: 5, score: 95, comment: '작업 숙련도 매우 높음' },
+      { category: '팀 기여도',   stars: 5, score: 93, comment: '팀 전체 생산성 향상 기여' },
+      { category: '문제 해결',   stars: 5, score: 92, comment: '설비 이상 신속 대응' },
+      { category: '커뮤니케이션', stars: 4, score: 88, comment: '명확한 의사소통' },
+      { category: '성장 가능성', stars: 5, score: 96, comment: '꾸준한 자기 개발' },
+    ],
+  },
+  {
+    id: 2,
+    name: '김신우',
+    avatar: '김',
+    avatarColor: '#5f50d6',
+    tier: 'A',
+    code: 'MCH-02',
+    team: '정밀가공 1팀',
+    experience: '경력 2년 5월',
+    status: 'submitted',
+    statusDate: '03.06',
+    aiRecommended: { quantitative: 86.1, qualitative: 82.7, composite: 84.0 },
+    evaluations: [
+      { category: '직무 태도',   stars: 4, score: 85, comment: '성실한 업무 태도' },
+      { category: '팀 기여도',   stars: 4, score: 82, comment: '팀 작업 적극 참여' },
+      { category: '문제 해결',   stars: 4, score: 80, comment: '문제 인식 및 보고 우수' },
+      { category: '커뮤니케이션', stars: 4, score: 84, comment: '원활한 소통' },
+      { category: '성장 가능성', stars: 4, score: 83, comment: '기술 습득 속도 양호' },
+    ],
+  },
+  {
+    id: 3,
+    name: '황자현',
+    avatar: '황',
+    avatarColor: '#269063',
+    tier: 'A',
+    code: 'PRS-01',
+    team: '정밀가공 2팀',
+    experience: '경력 2년 8월',
+    status: 'in_progress',
+    statusDate: '오늘',
+    aiRecommended: { quantitative: 83.4, qualitative: 79.1, composite: 81.2 },
+    evaluations: [
+      { category: '직무 태도',   stars: 4, score: 82, comment: '팀 내 협력 우수, 지각 없음' },
+      { category: '팀 기여도',   stars: 4, score: 80, comment: 'PRS-01 설비 최적화 기여' },
+      { category: '문제 해결',   stars: 4, score: 79, comment: '트러블슈팅 능력 향상 중' },
+      { category: '커뮤니케이션', stars: 3, score: 75, comment: '' },
+      { category: '성장 가능성', stars: 4, score: 85, comment: '' },
+    ],
+  },
+  {
+    id: 4,
+    name: '임원석',
+    avatar: '임',
+    avatarColor: '#c08b00',
+    tier: 'B',
+    code: 'WLD-01',
+    team: '정밀가공 2팀',
+    experience: '경력 1년 3월',
+    status: 'not_started',
+    statusDate: '—',
+    aiRecommended: { quantitative: 72.8, qualitative: 75.3, composite: 74.0 },
+    evaluations: [
+      { category: '직무 태도',   stars: 3, score: 72, comment: '' },
+      { category: '팀 기여도',   stars: 3, score: 70, comment: '' },
+      { category: '문제 해결',   stars: 3, score: 68, comment: '' },
+      { category: '커뮤니케이션', stars: 3, score: 74, comment: '' },
+      { category: '성장 가능성', stars: 4, score: 76, comment: '' },
+    ],
+  },
+])
+
+const selectedMember = ref(members.value[2]) // 황자현 selected by default
+
+const deadline = '2026.03.10'
+const totalCount = members.value.length
+const submittedCount = computed(() => members.value.filter((m) => m.status === 'submitted').length)
+const progressPercent = computed(() => (submittedCount.value / totalCount) * 100)
+
+function handleSave(evals) {
+  const m = members.value.find((m) => m.id === selectedMember.value.id)
+  if (!m) return
+  m.evaluations = evals.map((e) => ({ ...e }))
+  if (m.status === 'not_started') m.status = 'in_progress'
+  selectedMember.value = { ...m }
+  alert('임시저장 되었습니다.')
+}
+
+function handleSubmit(evals) {
+  const m = members.value.find((m) => m.id === selectedMember.value.id)
+  if (!m) return
+  m.evaluations = evals.map((e) => ({ ...e }))
+  m.status = 'submitted'
+  const today = new Date()
+  m.statusDate = `${String(today.getMonth() + 1).padStart(2, '0')}.${String(today.getDate()).padStart(2, '0')}`
+  selectedMember.value = { ...m }
+  alert('최종 제출 완료되었습니다.')
+}
+</script>
+
+<template>
+  <section class="dl-eval-view">
+    <!-- Progress bar -->
+    <div class="dl-eval-view__progress-bar">
+      <span class="dl-eval-view__progress-label">1분기 평가 진행률</span>
+      <div class="dl-eval-view__bar-track">
+        <div class="dl-eval-view__bar-fill" :style="{ width: progressPercent + '%' }" />
+      </div>
+      <span class="dl-eval-view__progress-count">{{ submittedCount }} / {{ totalCount }}명 완료</span>
+      <span class="dl-eval-view__deadline">마감: {{ deadline }}</span>
+    </div>
+
+    <!-- Content -->
+    <div class="dl-eval-view__content">
+      <DepartmentLeaderEvalMemberListPanel
+        :members="members"
+        :selected-id="selectedMember?.id ?? null"
+        @select="selectedMember = $event"
+      />
+      <DepartmentLeaderEvalFormPanel
+        :member="selectedMember"
+        @save="handleSave"
+        @submit="handleSubmit"
+      />
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.dl-eval-view {
+  width: 100%;
+  min-width: 0;
+  padding: 20px 28px 28px;
+  background: var(--color-bg-app);
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+/* Progress bar */
+.dl-eval-view__progress-bar {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 20px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 14px;
+  background: var(--color-bg-surface);
+}
+
+.dl-eval-view__progress-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
+.dl-eval-view__bar-track {
+  flex: 1;
+  height: 10px;
+  border-radius: 99px;
+  background: var(--color-border-soft);
+  overflow: hidden;
+}
+
+.dl-eval-view__bar-fill {
+  height: 100%;
+  border-radius: 99px;
+  background: var(--color-primary-600);
+  transition: width 0.4s ease;
+}
+
+.dl-eval-view__progress-count {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--color-primary-700);
+  white-space: nowrap;
+}
+
+.dl-eval-view__deadline {
+  font-size: 13px;
+  color: #e05a5a;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+/* Content grid */
+.dl-eval-view__content {
+  display: grid;
+  grid-template-columns: 300px 1fr;
+  gap: 20px;
+  align-items: start;
+}
+
+@media (max-width: 900px) {
+  .dl-eval-view__content {
+    grid-template-columns: 1fr;
+  }
+}
+</style>


### PR DESCRIPTION
  ## 변경 사항
                                                                                                                                                                                                         
  ### 신규 파일                                                 

  - src/views/departmentleader/DepartmentLeaderSecondEvaluationView.vue
    - 1분기 평가 진행률 바 — computed로 제출 완료 인원 실시간 반영, 마감일 표시
    - 팀원 목록 패널 + 평가 작성 폼 패널 2단 레이아웃
  - src/components/departmentleader/hr/DepartmentLeaderEvalMemberListPanel.vue
    - 팀원별 평가 상태 카드 (제출 완료 / 작성 중 / 미작성)
    - 상태별 카드 색상 및 아이콘 구분 (✓ / ✏ / ⊘)
  - src/components/departmentleader/hr/DepartmentLeaderEvalFormPanel.vue
    - 선택된 팀원의 AI 권고 점수 표시 (정량 / 정성 / 종합)
    - 평가 항목별 별점, 점수 입력, 코멘트 입력
    - 점수 입력 시 별점 자동 연동 (0 ~ 20 → ★, 21 ~ 40 → ★★, 41 ~ 60 → ★★★, 61 ~ 80 → ★★★★, 81 ~ 100 → ★★★★★)
    - 모든 항목 미입력 시 최종 제출 버튼 비활성화 및 안내 문구 표시

  ### 수정 파일

  - src/router/index.js
    - /departmentleader/evaluation 라우트를 Placeholder → 신규 View로 연결

  ### 주요 동작 흐름

  - 임시저장 클릭 → 미작성 → 작성 중 상태 변경, 입력 내용 보존
  - 최종 제출 클릭 → 작성 중 → 제출 완료 상태 변경, 진행률 바 즉시 반영
  - 점수(> 0) 및 코멘트(공백 제외)가 모든 항목에 입력된 경우에만 최종 제출 가능