### PR TITLE
Department Leader / kms 지식 허브 화면 구현

### DIFF
--- a/src/mocks/departmentleader/knowledgeHub.js
+++ b/src/mocks/departmentleader/knowledgeHub.js
@@ -1,0 +1,16 @@
+export const knowledgeHubSummaryCards = [
+  { key: 'totalArticles', label: '등록 지식 수',  value: '1,247건', helper: '전월 대비 +19건' },
+  { key: 'newThisMonth',  label: '이달 신규',     value: '38건',    helper: '▲12' },
+  { key: 'avgViews',      label: '평균 조회수',   value: '18.4',    helper: '▲0.6' },
+]
+
+export const knowledgeHubContributors = [
+  { rank: 1, name: '손창우', initial: '손', tier: 'S', articles: 12, points: '+18.2', avatarColor: '#5b50d6' },
+  { rank: 2, name: '김신우', initial: '김', tier: 'A', articles:  7, points: '+10.8', avatarColor: '#5b50d6' },
+  { rank: 3, name: '황자현', initial: '황', tier: 'A', articles:  4, points: '+6.3',  avatarColor: '#269063' },
+]
+
+export const knowledgeHubAiRecommendations = [
+  { id: 1, title: 'S측 가공 심화 과정',  subtitle: '손창우 등록 문서 기반 추천' },
+  { id: 2, title: 'GD&T 공차 분석',      subtitle: '품질관리 카테고리 인기 주제' },
+]

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -226,7 +226,7 @@ const routes = [
       {
         path: 'knowledgehub',
         name: 'DLKnowledgeHub',
-        component: Placeholder,
+        component: () => import('@/views/departmentleader/DepartmentLeaderKnowledgeHubView.vue'),
       },
       {
         path: 'knowledgeapproval',

--- a/src/views/departmentleader/DepartmentLeaderKnowledgeHubView.vue
+++ b/src/views/departmentleader/DepartmentLeaderKnowledgeHubView.vue
@@ -1,0 +1,194 @@
+<script setup>
+import { computed, reactive, ref } from 'vue'
+import TeamLeaderKnowledgeHubHeader from '@/components/teamleader/kms/TeamLeaderKnowledgeHubHeader.vue'
+import TeamLeaderKnowledgeHubFeed from '@/components/teamleader/kms/TeamLeaderKnowledgeHubFeed.vue'
+import TeamLeaderKnowledgeHubContributors from '@/components/teamleader/kms/TeamLeaderKnowledgeHubContributors.vue'
+import TeamLeaderKnowledgeHubMentoring from '@/components/teamleader/kms/TeamLeaderKnowledgeHubMentoring.vue'
+import TeamLeaderKnowledgeHubAiPanel from '@/components/teamleader/kms/TeamLeaderKnowledgeHubAiPanel.vue'
+import TeamLeaderKnowledgeWriteModal from '@/components/teamleader/kms/TeamLeaderKnowledgeWriteModal.vue'
+import TeamLeaderKnowledgeDetailModal from '@/components/teamleader/kms/TeamLeaderKnowledgeDetailModal.vue'
+import TeamLeaderKnowledgeMentoringReviewModal from '@/components/teamleader/kms/TeamLeaderKnowledgeMentoringReviewModal.vue'
+import TeamLeaderKnowledgeMentoringRequestModal from '@/components/teamleader/kms/TeamLeaderKnowledgeMentoringRequestModal.vue'
+import {
+  knowledgeHubCategories,
+  knowledgeHubArticles,
+  knowledgeHubMentoring,
+  knowledgeHubMentoringRequestDefaults,
+  knowledgeWriteModalOptions,
+} from '@/mocks/teamleader'
+import {
+  knowledgeHubSummaryCards,
+  knowledgeHubContributors,
+  knowledgeHubAiRecommendations,
+} from '@/mocks/departmentleader/knowledgeHub'
+
+const showWriteModal = ref(false)
+const selectedArticle = ref(null)
+const selectedMentoringRequest = ref(null)
+const showMentoringRequestModal = ref(false)
+const articles = ref([...knowledgeHubArticles])
+const mentoringState = reactive({
+  ongoing: [...knowledgeHubMentoring.ongoing],
+  pending: [...knowledgeHubMentoring.pending],
+})
+const statState = reactive({
+  totalArticles: 1247,
+  newThisMonth: 38,
+})
+
+const summaryCards = computed(() =>
+  knowledgeHubSummaryCards.map((card) => {
+    if (card.key === 'totalArticles') return { ...card, value: `${statState.totalArticles.toLocaleString()}건` }
+    if (card.key === 'newThisMonth')  return { ...card, value: `${statState.newThisMonth}건` }
+    return card
+  }),
+)
+
+function openDetailModal(article)  { selectedArticle.value = article }
+function closeDetailModal()        { selectedArticle.value = null }
+
+function submitDetailComment(body) {
+  if (!selectedArticle.value) return
+  const article = selectedArticle.value
+  const nextId = Math.max(...(article.commentList ?? []).map((c) => c.id), 0) + 1
+  article.commentList = [...(article.commentList ?? []), { id: nextId, author: '이수연', date: '03.17 18:05', body }]
+  article.comments = article.commentList.length
+  const idx = articles.value.findIndex((a) => a.id === article.id)
+  if (idx !== -1) {
+    articles.value[idx] = { ...articles.value[idx], commentList: [...article.commentList], comments: article.comments }
+    selectedArticle.value = articles.value[idx]
+  }
+}
+
+function openMentoringReview(request) { selectedMentoringRequest.value = request }
+function closeMentoringReview()       { selectedMentoringRequest.value = null }
+function confirmMentoringReview(request) {
+  mentoringState.pending = mentoringState.pending.filter((i) => i.id !== request.id)
+  closeMentoringReview()
+}
+
+function openMentoringRequestModal()  { showMentoringRequestModal.value = true }
+function closeMentoringRequestModal() { showMentoringRequestModal.value = false }
+function submitMentoringRequest(payload) {
+  const nextId = Math.max(...mentoringState.pending.map((i) => i.id), 0) + 1
+  mentoringState.pending.unshift({
+    id: nextId,
+    name: payload.field,
+    requester: 'DL-REQ',
+    summary: payload.purpose,
+    requestedBy: '이수연',
+    requestedAt: '03.17 16:40',
+    priority: '중간',
+    reason: payload.purpose,
+    details: payload.requestDetails,
+  })
+  showMentoringRequestModal.value = false
+}
+
+function handleSubmitKnowledge(payload) {
+  const nextId = Math.max(...articles.value.map((a) => a.id), 0) + 1
+  articles.value.unshift({
+    id: nextId,
+    code: `KMS-${2100 + nextId}`,
+    title: payload.title,
+    preview: payload.summary || payload.content.slice(0, 90),
+    category: payload.category,
+    equipment: payload.equipment,
+    date: '03.17',
+    author: '이수연',
+    authorInitial: '이',
+    authorTier: 'A',
+    comments: 0,
+    content: payload.content,
+    commentList: [],
+    isPopular: false,
+    isSubscribed: true,
+  })
+  statState.totalArticles += 1
+  statState.newThisMonth += 1
+  showWriteModal.value = false
+}
+</script>
+
+<template>
+  <section class="dl-knowledge-view">
+    <TeamLeaderKnowledgeHubHeader :cards="summaryCards" />
+
+    <section class="dl-knowledge-view__grid">
+      <TeamLeaderKnowledgeHubFeed
+        :categories="knowledgeHubCategories"
+        :articles="articles"
+        @open-write="showWriteModal = true"
+        @open-detail="openDetailModal"
+      />
+
+      <div class="dl-knowledge-view__sidebar">
+        <TeamLeaderKnowledgeHubContributors :ranking="knowledgeHubContributors" />
+        <TeamLeaderKnowledgeHubMentoring
+          :mentoring="mentoringState"
+          @review-request="openMentoringReview"
+          @open-request="openMentoringRequestModal"
+        />
+        <TeamLeaderKnowledgeHubAiPanel :recommendations="knowledgeHubAiRecommendations" />
+      </div>
+    </section>
+
+    <TeamLeaderKnowledgeWriteModal
+      v-if="showWriteModal"
+      :options="knowledgeWriteModalOptions"
+      @close="showWriteModal = false"
+      @submit="handleSubmitKnowledge"
+    />
+
+    <TeamLeaderKnowledgeDetailModal
+      v-if="selectedArticle"
+      :article="selectedArticle"
+      @close="closeDetailModal"
+      @submit-comment="submitDetailComment"
+    />
+
+    <TeamLeaderKnowledgeMentoringReviewModal
+      v-if="selectedMentoringRequest"
+      :request="selectedMentoringRequest"
+      @close="closeMentoringReview"
+      @confirm="confirmMentoringReview"
+    />
+
+    <TeamLeaderKnowledgeMentoringRequestModal
+      v-if="showMentoringRequestModal"
+      :defaults="knowledgeHubMentoringRequestDefaults"
+      @close="closeMentoringRequestModal"
+      @submit="submitMentoringRequest"
+    />
+  </section>
+</template>
+
+<style scoped>
+.dl-knowledge-view {
+  width: 100%;
+  min-width: 0;
+  padding: 12px 10px 18px;
+  box-sizing: border-box;
+  background: var(--color-bg-app);
+  display: grid;
+  gap: 16px;
+}
+
+.dl-knowledge-view__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.55fr) minmax(300px, 0.92fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.dl-knowledge-view__sidebar {
+  display: grid;
+  gap: 16px;
+}
+
+@media (max-width: 1180px) {
+  .dl-knowledge-view__grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>


### PR DESCRIPTION
관련 이슈 번호 #57 

### 생성된 파일 (2개)

  src/mocks/departmentleader/knowledgeHub.js
  - 이미지 기반 DL 전용 수치로 구성
    - 요약 카드: 등록 지식 수 1,247건 / 이달 신규 38건 ▲12 / 평균 조회수 18.4 ▲0.6
    - 기여자 TOP 3: 손창우 12건, 김신우 7건, 황자현 4건
    - AI 추천: S측 가공 심화 과정 / GD&T 공차 분석

  src/views/departmentleader/DepartmentLeaderKnowledgeHubView.vue
  - TL KMS 컴포넌트 전체 재사용
  - 피드·카테고리·멘토링·글쓰기 모달은 @/mocks/teamleader에서 공유
  - 요약 카드·기여자·AI 추천만 DL mock 사용

### 수정된 파일 (1개)

  src/router/index.js
  - /departmentleader/knowledgehub → 신규 View 연결