### PR TITLE
departmentleader / 그룹 성과 현황 수정

### DIFF
--- a/src/components/hr/departmentleader/perfomance/DLPerformanceSummary.vue
+++ b/src/components/hr/departmentleader/perfomance/DLPerformanceSummary.vue
@@ -2,12 +2,19 @@
 import { computed } from 'vue'
 
 const props = defineProps({
-  summary: { type: Object, required: true },
+  summary:      { type: Object, required: true },
+  teamTabs:     { type: Array,  default: () => [] },
+  selectedTeam: { type: String, default: '전체' },
 })
+
+const emit = defineEmits(['update:selectedTeam'])
 
 const progressPercent = computed(() =>
   Math.round((props.summary.evalCompleted / props.summary.evalTotal) * 100),
 )
+
+const avgLabel   = computed(() => props.selectedTeam === '전체' ? '부서 평균 점수' : '팀 평균 점수')
+const deltaLabel = computed(() => props.selectedTeam === '전체' ? '전년 동기 대비'  : '부서 평균 대비')
 </script>
 
 <template>
@@ -25,6 +32,16 @@ const progressPercent = computed(() =>
           <span class="dl-perf-summary__big">{{ summary.totalTeams }}<span class="dl-perf-summary__unit">팀</span></span>
           <span class="dl-perf-summary__sub">소속 팀</span>
         </div>
+      </div>
+      <!-- 팀 선택 탭 -->
+      <div class="dl-perf-summary__team-tabs">
+        <button
+          v-for="team in teamTabs"
+          :key="team"
+          class="dl-perf-summary__team-tab"
+          :class="{ 'dl-perf-summary__team-tab--active': selectedTeam === team }"
+          @click="emit('update:selectedTeam', team)"
+        >{{ team }}</button>
       </div>
     </div>
 
@@ -45,9 +62,9 @@ const progressPercent = computed(() =>
       <p class="dl-perf-summary__period">{{ summary.period }}</p>
     </div>
 
-    <!-- 부서 평균 점수 -->
+    <!-- 평균 점수 -->
     <div class="dl-perf-summary__card">
-      <p class="dl-perf-summary__label">부서 평균 점수</p>
+      <p class="dl-perf-summary__label">{{ avgLabel }}</p>
       <span class="dl-perf-summary__big dl-perf-summary__big--primary">
         {{ summary.deptAvg }}<span class="dl-perf-summary__unit">점</span>
       </span>
@@ -55,7 +72,7 @@ const progressPercent = computed(() =>
         class="dl-perf-summary__delta"
         :class="summary.deptAvgDelta >= 0 ? 'dl-perf-summary__delta--up' : 'dl-perf-summary__delta--down'"
       >
-        {{ summary.deptAvgDelta >= 0 ? '▲' : '▼' }} {{ Math.abs(summary.deptAvgDelta) }} 전년 동기 대비
+        {{ summary.deptAvgDelta >= 0 ? '▲' : '▼' }} {{ Math.abs(summary.deptAvgDelta) }} {{ deltaLabel }}
       </span>
     </div>
   </section>
@@ -124,6 +141,33 @@ const progressPercent = computed(() =>
 .dl-perf-summary__sub {
   font-size: 12px;
   color: var(--color-text-muted);
+}
+
+/* 팀 선택 탭 */
+.dl-perf-summary__team-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: auto;
+}
+
+.dl-perf-summary__team-tab {
+  height: 28px;
+  padding: 0 12px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 99px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  background: var(--color-bg-surface);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+
+.dl-perf-summary__team-tab--active {
+  background: var(--color-primary-600);
+  color: #fff;
+  border-color: var(--color-primary-600);
 }
 
 /* 진행률 */

--- a/src/components/hr/departmentleader/perfomance/DLPerformanceTable.vue
+++ b/src/components/hr/departmentleader/perfomance/DLPerformanceTable.vue
@@ -8,7 +8,7 @@ const props = defineProps({
   periodOptions: { type: Array, default: () => [] },
 })
 
-const emit = defineEmits(['view-capability'])
+const emit = defineEmits(['view-capability', 'go-evaluation'])
 
 const filterPeriod = ref(props.periodOptions[0] ?? '')
 const filterTeam   = ref('전체')
@@ -55,7 +55,7 @@ function closeDetail()      { selectedMember.value = null }
         <option v-for="p in periodOptions" :key="p" :value="p">{{ p }}</option>
       </select>
       <select v-model="filterTeam" class="dl-filter-select">
-        <option v-for="t in teamOptions" :key="t" :value="t">{{ t }}</option>
+        <option v-for="t in teamOptions" :key="t" :value="t">팀: {{ t }}</option>
       </select>
       <select v-model="filterGrade" class="dl-filter-select">
         <option v-for="g in gradeOptions" :key="g" :value="g">등급: {{ g }}</option>
@@ -78,13 +78,12 @@ function closeDetail()      { selectedMember.value = null }
         <thead>
           <tr>
             <th>사번</th>
+            <th>등급</th>
             <th>이름</th>
-            <th>직급</th>
             <th>소속팀</th>
             <th>정량</th>
             <th>정성</th>
             <th>총점</th>
-            <th>등급</th>
             <th>평가 상태</th>
           </tr>
         </thead>
@@ -96,18 +95,17 @@ function closeDetail()      { selectedMember.value = null }
             @click="openDetail(m)"
           >
             <td class="dl-perf-table__empid">{{ m.empId }}</td>
-            <td class="dl-perf-table__name">{{ m.name }}</td>
-            <td>{{ m.position }}</td>
-            <td>{{ m.team }}</td>
-            <td class="dl-perf-table__score">{{ m.quantitative }}</td>
-            <td class="dl-perf-table__score">{{ m.qualitative }}</td>
-            <td class="dl-perf-table__total">{{ m.total }}</td>
             <td>
               <span
                 class="dl-perf-table__grade"
                 :style="{ background: gradeColors[m.grade]?.bg, color: gradeColors[m.grade]?.text }"
               >{{ m.grade }}</span>
             </td>
+            <td class="dl-perf-table__name">{{ m.name }}</td>
+            <td>{{ m.team }}</td>
+            <td class="dl-perf-table__score">{{ m.quantitative }}</td>
+            <td class="dl-perf-table__score">{{ m.qualitative }}</td>
+            <td class="dl-perf-table__total">{{ m.total }}</td>
             <td>
               <span class="dl-perf-table__status" :style="{ color: statusColors[m.status]?.color }">
                 {{ m.status }}
@@ -115,7 +113,7 @@ function closeDetail()      { selectedMember.value = null }
             </td>
           </tr>
           <tr v-if="filtered.length === 0">
-            <td colspan="9" class="dl-perf-table__empty">검색 결과가 없습니다.</td>
+            <td colspan="8" class="dl-perf-table__empty">검색 결과가 없습니다.</td>
           </tr>
         </tbody>
       </table>
@@ -139,7 +137,7 @@ function closeDetail()      { selectedMember.value = null }
                 :style="{ background: gradeColors[selectedMember.grade]?.bg, color: gradeColors[selectedMember.grade]?.text }"
               >{{ selectedMember.grade }}</span>
             </div>
-            <span class="dl-detail-modal__meta">{{ selectedMember.position }} · {{ selectedMember.team }} · {{ selectedMember.empId }}</span>
+            <span class="dl-detail-modal__meta">{{ selectedMember.team }} · {{ selectedMember.empId }}</span>
           </div>
         </div>
 
@@ -167,6 +165,13 @@ function closeDetail()      { selectedMember.value = null }
 
         <div class="dl-detail-modal__actions">
           <button class="dl-detail-modal__btn dl-detail-modal__btn--secondary" @click="closeDetail">닫기</button>
+          <button
+            v-if="selectedMember.status !== '완료'"
+            class="dl-detail-modal__btn dl-detail-modal__btn--warn"
+            @click="emit('go-evaluation', selectedMember); closeDetail()"
+          >
+            2차 평가 작성 →
+          </button>
           <button
             class="dl-detail-modal__btn dl-detail-modal__btn--primary"
             @click="emit('view-capability', selectedMember); closeDetail()"
@@ -434,5 +439,11 @@ function closeDetail()      { selectedMember.value = null }
 .dl-detail-modal__btn--primary {
   background: var(--color-primary-600);
   color: #fff;
+}
+
+.dl-detail-modal__btn--warn {
+  background: #fff4e6;
+  color: #c47a00;
+  border: 1px solid #f4c54b;
 }
 </style>

--- a/src/mocks/departmentleader/performance.js
+++ b/src/mocks/departmentleader/performance.js
@@ -1,4 +1,5 @@
 export const performanceSummary = {
+  deptName: '정밀가공 부서',
   totalMembers: 14,
   totalTeams: 4,
   evalCompleted: 12,
@@ -45,5 +46,5 @@ export const performanceMembers = [
 ]
 
 export const teamOptions = ['전체', '정밀가공 1팀', '정밀가공 2팀', '프레스라인팀', '용접팀']
-export const gradeOptions = ['전체', 'S', 'A', 'B', 'C', 'D']
+export const gradeOptions = ['전체', 'S', 'A', 'B', 'C']
 export const periodOptions = ['2026 1분기', '2025 4분기', '2025 3분기', '2025 2분기']

--- a/src/views/departmentleader/DepartmentLeaderPerformanceView.vue
+++ b/src/views/departmentleader/DepartmentLeaderPerformanceView.vue
@@ -1,14 +1,10 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
-import DLPerformanceSummary        from '@/components/hr/departmentleader/perfomance/DLPerformanceSummary.vue'
-import DLGradeDistributionChart    from '@/components/hr/departmentleader/perfomance/DLGradeDistributionChart.vue'
-import DLTeamComparisonChart       from '@/components/hr/departmentleader/perfomance/DLTeamComparisonChart.vue'
-import DLPerformanceTable          from '@/components/hr/departmentleader/perfomance/DLPerformanceTable.vue'
+import DLPerformanceSummary from '@/components/hr/departmentleader/perfomance/DLPerformanceSummary.vue'
+import DLPerformanceTable   from '@/components/hr/departmentleader/perfomance/DLPerformanceTable.vue'
 import {
   performanceSummary,
-  gradeDistribution,
-  teamComparison,
   performanceMembers,
   teamOptions,
   gradeOptions,
@@ -17,8 +13,36 @@ import {
 
 const router = useRouter()
 
+const selectedTeam = ref('전체')
+const teamTabs = teamOptions // ['전체', '정밀가공 1팀', ...]
+
+const activeSummary = computed(() => {
+  if (selectedTeam.value === '전체') return performanceSummary
+
+  const members = performanceMembers.filter(m => m.team === selectedTeam.value)
+  const completed = members.filter(m => m.status === '완료').length
+  const avg = members.length
+    ? +(members.reduce((s, m) => s + m.total, 0) / members.length).toFixed(1)
+    : 0
+  const delta = +(avg - performanceSummary.deptAvg).toFixed(1)
+
+  return {
+    totalMembers: members.length,
+    totalTeams: 1,
+    evalCompleted: completed,
+    evalTotal: members.length,
+    deptAvg: avg,
+    deptAvgDelta: delta,
+    period: performanceSummary.period,
+  }
+})
+
 function handleViewCapability(member) {
   router.push({ path: '/departmentleader/team-capability', query: { empId: member.empId } })
+}
+
+function handleGoEvaluation() {
+  router.push({ path: '/departmentleader/evaluation' })
 }
 </script>
 
@@ -26,28 +50,25 @@ function handleViewCapability(member) {
   <div class="dl-performance">
     <header class="dl-performance__header">
       <h2 class="dl-performance__title">그룹 성과 현황</h2>
+      <span class="dl-performance__dept-name">{{ performanceSummary.deptName }}</span>
       <span class="dl-performance__period">{{ performanceSummary.period }}</span>
     </header>
 
-    <!-- 1. 상단: 부서 성과 요약 -->
-    <DLPerformanceSummary :summary="performanceSummary" />
+    <!-- 성과 요약 (팀 선택 탭 포함) -->
+    <DLPerformanceSummary
+      :summary="activeSummary"
+      :team-tabs="teamTabs"
+      v-model:selectedTeam="selectedTeam"
+    />
 
-    <!-- 2&3. 중앙: 등급 분포 + 팀별 비교 -->
-    <div class="dl-performance__charts">
-      <DLGradeDistributionChart
-        :distribution="gradeDistribution"
-        :total-members="performanceSummary.totalMembers"
-      />
-      <DLTeamComparisonChart :team-data="teamComparison" />
-    </div>
-
-    <!-- 4. 하단: 상세 데이터 그리드 -->
+    <!-- 직원 상세 테이블 -->
     <DLPerformanceTable
       :members="performanceMembers"
       :team-options="teamOptions"
       :grade-options="gradeOptions"
       :period-options="periodOptions"
       @view-capability="handleViewCapability"
+      @go-evaluation="handleGoEvaluation"
     />
   </div>
 </template>
@@ -78,6 +99,16 @@ function handleViewCapability(member) {
   margin: 0;
 }
 
+.dl-performance__dept-name {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--color-primary-700);
+  background: var(--color-primary-50, #f5f4ff);
+  border: 1px solid var(--color-primary-200, #d4cfff);
+  border-radius: 99px;
+  padding: 3px 12px;
+}
+
 .dl-performance__period {
   font-size: 13px;
   font-weight: 600;
@@ -88,16 +119,7 @@ function handleViewCapability(member) {
   padding: 3px 12px;
 }
 
-.dl-performance__charts {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 20px;
-}
-
 @media (max-width: 960px) {
-  .dl-performance__charts {
-    grid-template-columns: 1fr;
-  }
   .dl-performance {
     padding: 20px 16px;
   }


### PR DESCRIPTION
### 수정된 파일 (3개)                                                                                                                                                                                      
                                                            
  src/mocks/departmentleader/performance.js                                                                                                                                                              
  - gradeOptions에서 'D' 제거 → S/A/B/C만 존재                                                                                                                                                           
  - performanceSummary에 deptName: '정밀가공 부서' 필드 추가                                                                                                                                             
                                                            
  src/components/hr/departmentleader/perfomance/DLPerformanceSummary.vue                                                                                                                                 
  - teamTabs, selectedTeam props 추가 + update:selectedTeam emit                                                                                                                                         
  - 조직 개요 카드 하단에 팀 선택 탭 배치 (전체 / 각 팀)                                                                                                                                                 
  - 세 번째 카드 라벨: 전체 선택 시 부서 평균 점수 / 팀 선택 시 팀 평균 점수                                                                                                                             
  - 증감 라벨: 전체 선택 시 전년 동기 대비 / 팀 선택 시 부서 평균 대비                                                                                                                                   
                                                                                                                                                                                                         
  src/components/hr/departmentleader/perfomance/DLPerformanceTable.vue                                                                                                                                   
  - 팀 필터 표시 형식 → 팀: 전체, 팀: 정밀가공 1팀 형식으로 통일                                                                                                                                         
  - go-evaluation emit 추가                                                                                                                                                                              
  - 평가 상태가 완료가 아닌 직원의 모달에 2차 평가 작성 → 버튼 추가 (노란 계열 스타일)                                                                                                                   
                                                                                                                                                                                                         
  src/views/departmentleader/DepartmentLeaderPerformanceView.vue                                                                                                                                         
  - 차트 2개(DLGradeDistributionChart, DLTeamComparisonChart) 제거                                                                                                                                       
  - 별도 팀 탭 제거 → DLPerformanceSummary에 v-model:selectedTeam으로 위임                                                                                                                               
  - 팀 선택 시 조직 개요·진행률·평균 점수를 해당 팀 데이터로 재계산 (computed)
  - 헤더에 부서명(deptName) 배지 추가 — 제목 바로 옆 왼쪽 배치                                                                                                                                           
  - go-evaluation 이벤트 처리 → /departmentleader/evaluation 라우팅