### PR TITLE
refactor: 전역 폰트 변수 도입 및 HRM컴포넌트 적용

### DIFF
--- a/src/assets/styles/variables.css
+++ b/src/assets/styles/variables.css
@@ -135,6 +135,24 @@
   --font-family-base: 'Pretendard', -apple-system, BlinkMacSystemFont, sans-serif;
   --font-family-num: 'Inter', var(--font-family-base);
   --font-family-mono: 'JetBrains Mono', monospace;
+
+  /* --- Font Size (B2B Dashboard) --- */
+  --font-size-2xs: 10px;      /* 극소 보조, 오버레이 레이블 */
+  --font-size-xs: 11px;       /* 뱃지, 태그, 칩 */
+  --font-size-sm: 13px;       /* 날짜, 보조 텍스트 */
+  --font-size-base: 14px;     /* 메인 본문 */
+  --font-size-md: 16px;       /* 강조 본문 */
+  --font-size-lg: 18px;       /* 서브타이틀, 이름 */
+  --font-size-xl: 24px;       /* 섹션 헤더 */
+  --font-size-2xl: 36px;      /* 대형 수치 */
+  --font-size-display: 46px;  /* 대형 수치 (티어 카드, 메트릭 카드) */
+
+  /* --- Font Weight --- */
+  --font-weight-regular: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+  --font-weight-extrabold: 800;  /* 타이틀 강조, 뱃지 */
 }
 
 *,

--- a/src/components/dashboard/common/HRMDashboardNotice.vue
+++ b/src/components/dashboard/common/HRMDashboardNotice.vue
@@ -31,17 +31,17 @@ defineProps({
   border-radius: 999px;
   background: rgba(24, 195, 170, 0.16);
   color: var(--color-info);
-  font-size: 14px;
-  font-weight: 700;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-bold);
 }
 .notice__title {
   margin-top: 16px;
-  font-size: 20px;
+  font-size: var(--font-size-lg);
   color: var(--color-primary-800);
 }
 .notice__description {
   margin-top: 12px;
-  font-size: 14px;
+  font-size: var(--font-size-base);
   line-height: 1.6;
   color: var(--color-primary-500);
 }

--- a/src/components/dashboard/hrmanager/HRMTeamStatsTable.vue
+++ b/src/components/dashboard/hrmanager/HRMTeamStatsTable.vue
@@ -49,8 +49,8 @@ defineProps({
 }
 
 .team-stats__title {
-  font-size: 18px;
-  font-weight: 700;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-800);
   margin-bottom: 18px;
 }
@@ -62,7 +62,7 @@ defineProps({
 .team-stats__table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 14px;
+  font-size: var(--font-size-base);
 }
 
 .team-stats__table thead tr {
@@ -72,8 +72,8 @@ defineProps({
 .team-stats__table th {
   padding: 10px 14px;
   text-align: center;
-  font-size: 13px;
-  font-weight: 600;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-text-muted);
 }
 
@@ -94,16 +94,16 @@ defineProps({
 
 .team-name {
   text-align: left !important;
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .avg-col {
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-700) !important;
 }
 
-.tier-col--s { color: var(--tier-s) !important; font-weight: 700; }
-.tier-col--a { color: var(--tier-a) !important; font-weight: 700; }
-.tier-col--b { color: var(--tier-b) !important; font-weight: 700; }
-.tier-col--c { color: var(--tier-c) !important; font-weight: 700; }
+.tier-col--s { color: var(--tier-s) !important; font-weight: var(--font-weight-bold); }
+.tier-col--a { color: var(--tier-a) !important; font-weight: var(--font-weight-bold); }
+.tier-col--b { color: var(--tier-b) !important; font-weight: var(--font-weight-bold); }
+.tier-col--c { color: var(--tier-c) !important; font-weight: var(--font-weight-bold); }
 </style>

--- a/src/components/dashboard/hrmanager/HRMTierDistCard.vue
+++ b/src/components/dashboard/hrmanager/HRMTierDistCard.vue
@@ -48,8 +48,8 @@ defineProps({
 }
 
 .tier-dist-card__title {
-  font-size: 18px;
-  font-weight: 700;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-800);
 }
 
@@ -68,14 +68,14 @@ defineProps({
 }
 
 .tier-num__value {
-  font-size: 48px;
-  font-weight: 700;
+  font-size: var(--font-size-display);
+  font-weight: var(--font-weight-bold);
   line-height: 1;
 }
 
 .tier-num__label {
-  font-size: 13px;
-  font-weight: 600;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-text-muted);
 }
 
@@ -90,7 +90,7 @@ defineProps({
 }
 
 .process-label {
-  font-size: 13px;
+  font-size: var(--font-size-sm);
   color: var(--color-text-muted);
 }
 

--- a/src/components/dashboard/hrmanager/HRMTierDonutChart.vue
+++ b/src/components/dashboard/hrmanager/HRMTierDonutChart.vue
@@ -120,8 +120,8 @@ onBeforeUnmount(() => chartInstance?.destroy())
 }
 
 .donut-card__eyebrow {
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-500);
 }
 
@@ -149,7 +149,7 @@ onBeforeUnmount(() => chartInstance?.destroy())
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 13px;
+  font-size: var(--font-size-sm);
 }
 
 .legend-item__dot {
@@ -160,7 +160,7 @@ onBeforeUnmount(() => chartInstance?.destroy())
 }
 
 .legend-item__tier {
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-800);
   width: 12px;
 }

--- a/src/components/dashboard/hrmanager/HRMTierTrendChart.vue
+++ b/src/components/dashboard/hrmanager/HRMTierTrendChart.vue
@@ -124,8 +124,8 @@ onBeforeUnmount(() => chartInstance?.destroy())
 }
 
 .trend-card__eyebrow {
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-500);
 }
 
@@ -135,8 +135,8 @@ onBeforeUnmount(() => chartInstance?.destroy())
 }
 
 .trend-card__delta {
-  font-size: 13px;
-  font-weight: 600;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-primary-500);
   text-align: center;
 }

--- a/src/components/hr/common/notices/HRMNoticeFormModal.vue
+++ b/src/components/hr/common/notices/HRMNoticeFormModal.vue
@@ -121,7 +121,7 @@ function handleDraft() { emit('draft', buildPayload('임시')) }
   max-height: 90vh; overflow-y: auto;
 }
 .modal__title {
-  font-size: 18px; font-weight: 800;
+  font-size: var(--font-size-lg); font-weight: var(--font-weight-extrabold);
   color: var(--color-primary-800);
   margin-bottom: 4px;
 }
@@ -130,7 +130,7 @@ function handleDraft() { emit('draft', buildPayload('임시')) }
 .modal__toggles { display: flex; justify-content: flex-end; gap: 8px; }
 .modal__toggle {
   height: 34px; padding: 0 16px;
-  border-radius: 8px; font-size: 13px; font-weight: 700;
+  border-radius: 8px; font-size: var(--font-size-sm); font-weight: var(--font-weight-bold);
   cursor: pointer;
   border: 1.5px solid var(--color-border-default);
   background: var(--color-bg-app);
@@ -143,7 +143,7 @@ function handleDraft() { emit('draft', buildPayload('임시')) }
 }
 
 .modal__label {
-  font-size: 12px; font-weight: 700;
+  font-size: var(--font-size-xs); font-weight: var(--font-weight-bold);
   color: var(--color-primary-600);
   margin-top: 4px;
 }
@@ -152,7 +152,7 @@ function handleDraft() { emit('draft', buildPayload('임시')) }
   padding: 0 14px;
   border: 1.5px solid var(--color-border-default);
   border-radius: 8px;
-  font-size: 13px; color: var(--color-primary-800);
+  font-size: var(--font-size-sm); color: var(--color-primary-800);
   background: var(--color-bg-app);
   box-sizing: border-box;
 }
@@ -176,7 +176,7 @@ function handleDraft() { emit('draft', buildPayload('임시')) }
   padding: 10px 14px;
   border: 1.5px solid var(--color-border-default);
   border-radius: 8px;
-  font-size: 13px; color: var(--color-primary-800);
+  font-size: var(--font-size-sm); color: var(--color-primary-800);
   background: var(--color-bg-app);
   resize: none; box-sizing: border-box;
   font-family: inherit;
@@ -189,7 +189,7 @@ function handleDraft() { emit('draft', buildPayload('임시')) }
 .modal__file-btn {
   height: 42px; padding: 0 16px; flex-shrink: 0;
   background: var(--color-primary-600); color: var(--color-white);
-  border: none; border-radius: 8px; font-size: 13px; font-weight: 700;
+  border: none; border-radius: 8px; font-size: var(--font-size-sm); font-weight: var(--font-weight-bold);
   cursor: pointer;
 }
 
@@ -200,7 +200,7 @@ function handleDraft() { emit('draft', buildPayload('임시')) }
 }
 .modal__btn {
   height: 40px; padding: 0 20px;
-  border-radius: 8px; font-size: 14px; font-weight: 700;
+  border-radius: 8px; font-size: var(--font-size-base); font-weight: var(--font-weight-bold);
   cursor: pointer; border: none;
 }
 .modal__btn--close {

--- a/src/components/hr/common/notices/HRMNoticeTeamFilter.vue
+++ b/src/components/hr/common/notices/HRMNoticeTeamFilter.vue
@@ -91,9 +91,9 @@ function apply() {
   padding: 6px 4px; cursor: pointer; border-radius: 6px;
 }
 .team-filter__item:hover { background: var(--color-primary-100); }
-.team-filter__check { font-size: 12px; color: transparent; width: 16px; flex-shrink: 0; }
+.team-filter__check { font-size: var(--font-size-xs); color: transparent; width: 16px; flex-shrink: 0; }
 .team-filter__check--on { color: var(--color-primary-600); }
-.team-filter__name { font-size: 13px; color: var(--color-primary-800); }
+.team-filter__name { font-size: var(--font-size-sm); color: var(--color-primary-800); }
 
 .team-filter__tags {
   display: flex; flex-wrap: wrap; gap: 4px;
@@ -103,7 +103,7 @@ function apply() {
   display: inline-flex; align-items: center; gap: 4px;
   padding: 3px 8px;
   background: var(--color-primary-100); color: var(--color-primary-700);
-  border-radius: 20px; font-size: 11px; font-weight: 600;
+  border-radius: 20px; font-size: var(--font-size-xs); font-weight: var(--font-weight-semibold);
 }
 .team-filter__tag-x {
   background: none; border: none; cursor: pointer;
@@ -113,7 +113,7 @@ function apply() {
 .team-filter__actions { display: flex; justify-content: space-between; align-items: center; }
 .team-filter__btn {
   height: 30px; padding: 0 12px;
-  border-radius: 8px; font-size: 12px; font-weight: 700;
+  border-radius: 8px; font-size: var(--font-size-xs); font-weight: var(--font-weight-bold);
   cursor: pointer; border: none;
   display: flex; align-items: center; gap: 4px;
 }

--- a/src/components/hr/hrmanager/evaluation-approval/HRMApprovalBanner.vue
+++ b/src/components/hr/hrmanager/evaluation-approval/HRMApprovalBanner.vue
@@ -23,9 +23,9 @@ defineEmits(['bulk-review'])
   border-left: 3px solid var(--tier-b);
   border-radius: 8px; flex-shrink: 0;
 }
-.hrm-banner__text { font-size: 13px; color: #a07000; }
+.hrm-banner__text { font-size: var(--font-size-sm); color: #a07000; }
 .hrm-banner__btn {
-  height: 34px; padding: 0 14px; font-size: 11px; font-weight: 700;
+  height: 34px; padding: 0 14px; font-size: var(--font-size-xs); font-weight: var(--font-weight-bold);
   color: #7a6fa8;
   background: var(--color-bg-surface);
   border: 1.5px solid var(--color-border-default);

--- a/src/components/hr/hrmanager/evaluation-approval/HRMApprovalDetail.vue
+++ b/src/components/hr/hrmanager/evaluation-approval/HRMApprovalDetail.vue
@@ -87,13 +87,13 @@ defineEmits(['approve', 'reject', 'hold'])
   background: var(--color-primary-600);
   border-radius: 50%;
   display: flex; align-items: center; justify-content: center;
-  font-size: 20px; font-weight: 900; color: var(--color-white); flex-shrink: 0;
+  font-size: var(--font-size-lg); font-weight: 900; color: var(--color-white); flex-shrink: 0;
 }
-.hrm-detail__name { font-size: 18px; font-weight: 900; color: var(--color-primary-800); line-height: 1.4; }
-.hrm-detail__dept { font-size: 11px; color: #a89ed8; }
+.hrm-detail__name { font-size: var(--font-size-lg); font-weight: 900; color: var(--color-primary-800); line-height: 1.4; }
+.hrm-detail__dept { font-size: var(--font-size-xs); color: #a89ed8; }
 .hrm-badge {
   display: inline-flex; align-items: center; height: 18px; padding: 0 8px;
-  border-radius: 3px; font-size: 12px; font-weight: 900; white-space: nowrap;
+  border-radius: 3px; font-size: var(--font-size-xs); font-weight: 900; white-space: nowrap;
 }
 
 .hrm-score-box {
@@ -103,10 +103,10 @@ defineEmits(['approve', 'reject', 'hold'])
   border-radius: 8px;
 }
 .hrm-score-item { display: flex; flex-direction: column; gap: 2px; }
-.hrm-score-label { font-size: 10px; color: #a89ed8; }
-.hrm-score-value { font-size: 36px; font-weight: 400; color: var(--color-primary-800); line-height: 1; font-family: 'Inter', sans-serif; }
+.hrm-score-label { font-size: var(--font-size-xs); color: #a89ed8; }
+.hrm-score-value { font-size: var(--font-size-2xl); font-weight: var(--font-weight-regular); color: var(--color-primary-800); line-height: 1; font-family: 'Inter', sans-serif; }
 .hrm-score-value--total { color: var(--tier-s); }
-.hrm-score-diff { font-size: 10px; color: #7a6fa8; }
+.hrm-score-diff { font-size: var(--font-size-2xs); color: #7a6fa8; }
 
 .hrm-ai-box {
   padding: 16px;
@@ -114,14 +114,14 @@ defineEmits(['approve', 'reject', 'hold'])
   border: 1.5px solid var(--color-border-default);
   border-radius: 8px; display: flex; flex-direction: column; gap: 8px;
 }
-.hrm-ai-box__title { font-size: 11px; font-weight: 700; color: var(--color-primary-600); }
+.hrm-ai-box__title { font-size: var(--font-size-xs); font-weight: var(--font-weight-bold); color: var(--color-primary-600); }
 .hrm-ai-tags { display: flex; flex-wrap: wrap; gap: 6px; }
 .hrm-ai-tag {
   display: inline-block; padding: 2px 8px; height: 19px;
   background: var(--color-success-soft); color: var(--color-info);
-  font-size: 10px; font-weight: 700; border-radius: 3px; line-height: 15px;
+  font-size: var(--font-size-2xs); font-weight: var(--font-weight-bold); border-radius: 3px; line-height: 15px;
 }
-.hrm-ai-box__trust { font-size: 11px; color: #7a6fa8; }
+.hrm-ai-box__trust { font-size: var(--font-size-xs); color: #7a6fa8; }
 
 .hrm-comment-box {
   padding: 15px; background: var(--color-bg-surface);
@@ -132,20 +132,20 @@ defineEmits(['approve', 'reject', 'hold'])
 .hrm-comment-box__avatar {
   width: 24px; height: 24px; background: #1a8060; border-radius: 50%;
   display: flex; align-items: center; justify-content: center;
-  font-size: 11px; font-weight: 700; color: var(--color-white); flex-shrink: 0;
+  font-size: var(--font-size-xs); font-weight: var(--font-weight-bold); color: var(--color-white); flex-shrink: 0;
 }
 .hrm-comment-box__role,
-.hrm-comment-box__date { font-size: 10px; color: #a89ed8; }
-.hrm-comment-box__text { font-size: 12px; color: #7a6fa8; line-height: 1.5; }
+.hrm-comment-box__date { font-size: var(--font-size-2xs); color: #a89ed8; }
+.hrm-comment-box__text { font-size: var(--font-size-sm); color: #7a6fa8; line-height: 1.5; }
 
 .hrm-objection { text-align: center; padding: 8px 0; }
-.hrm-objection__none   { font-size: 11px; color: #a89ed8; }
-.hrm-objection__exists { font-size: 11px; color: #c0103e; font-weight: 700; }
+.hrm-objection__none   { font-size: var(--font-size-xs); color: #a89ed8; }
+.hrm-objection__exists { font-size: var(--font-size-xs); color: #c0103e; font-weight: var(--font-weight-bold); }
 
 .hrm-actions { display: flex; justify-content: flex-end; gap: 8px; }
 .hrm-btn {
   height: 40px; padding: 0 16px; border-radius: 4px;
-  font-size: 12px; font-weight: 700; cursor: pointer; border: 1.5px solid transparent;
+  font-size: var(--font-size-sm); font-weight: var(--font-weight-bold); cursor: pointer; border: 1.5px solid transparent;
 }
 .hrm-btn--reject  { background: #de152d; border-color: var(--color-danger); color: var(--color-white); }
 .hrm-btn--reject:hover  { background: #c0103e; }

--- a/src/components/hr/hrmanager/evaluation-approval/HRMApprovalList.vue
+++ b/src/components/hr/hrmanager/evaluation-approval/HRMApprovalList.vue
@@ -57,20 +57,20 @@ defineEmits(['tab-change', 'select'])
   border-radius: 12px; padding: 20px;
 }
 .hrm-panel__header {
-  font-size: 9px; font-weight: 700; color: #a89ed8;
+  font-size: var(--font-size-sm); font-weight: var(--font-weight-bold); color: #a89ed8;
   letter-spacing: 0.5px; text-transform: uppercase; margin-bottom: 16px;
 }
 
 .hrm-tabs { display: flex; gap: 16px; border-bottom: 1.5px solid var(--color-border-muted); margin-bottom: 12px; }
 .hrm-tab {
-  height: 34px; font-size: 11px; font-weight: 700; color: #a89ed8;
+  height: 34px; font-size: var(--font-size-xs); font-weight: var(--font-weight-bold); color: #a89ed8;
   background: none; border: none; border-bottom: 3px solid transparent;
   margin-bottom: -3px; cursor: pointer; padding: 0 2px;
 }
 .hrm-tab--active { color: var(--color-primary-600); border-bottom-color: var(--color-primary-600); }
 
 .hrm-list { display: flex; flex-direction: column; gap: 8px; }
-.hrm-list__empty { padding: 32px 0; text-align: center; font-size: 13px; color: #a89ed8; }
+.hrm-list__empty { padding: 32px 0; text-align: center; font-size: var(--font-size-sm); color: #a89ed8; }
 
 .hrm-list-item {
   display: flex; align-items: center; justify-content: space-between;
@@ -83,17 +83,17 @@ defineEmits(['tab-change', 'select'])
 .hrm-list-item--selected { border-color: var(--color-primary-600); background: var(--color-primary-100); }
 .hrm-list-item__info { display: flex; flex-direction: column; gap: 2px; }
 .hrm-list-item__row1 { display: flex; align-items: center; gap: 6px; }
-.hrm-list-item__name { font-size: 12px; font-weight: 700; color: var(--color-primary-800); }
-.hrm-list-item__desc { font-size: 11px; color: #7a6fa8; }
-.hrm-list-item__date { font-size: 10px; color: #a89ed8; }
+.hrm-list-item__name { font-size: var(--font-size-sm); font-weight: var(--font-weight-bold); color: var(--color-primary-800); }
+.hrm-list-item__desc { font-size: var(--font-size-sm); color: #7a6fa8; }
+.hrm-list-item__date { font-size: var(--font-size-2xs); color: #a89ed8; }
 
 .hrm-badge {
   display: inline-flex; align-items: center; height: 14px; padding: 0 7px;
-  border-radius: 3px; font-size: 10px; font-weight: 900; white-space: nowrap;
+  border-radius: 3px; font-size: var(--font-size-2xs); font-weight: 900; white-space: nowrap;
 }
 .hrm-grade {
   display: inline-flex; align-items: center; height: 14px; padding: 0 7px;
-  border-radius: 3px; font-size: 10px; font-weight: 900;
+  border-radius: 3px; font-size: var(--font-size-2xs); font-weight: 900;
 }
 
 .hrm-list-item__check {

--- a/src/components/hr/hrmanager/evaluation-criteria/HRMEvalQuantPanel.vue
+++ b/src/components/hr/hrmanager/evaluation-criteria/HRMEvalQuantPanel.vue
@@ -67,12 +67,12 @@ function updateWeight(index, value) {
   gap: 16px;
 }
 .eval-quant-card__title {
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-500);
 }
 .eval-quant-card__subtitle {
-  font-size: 12px;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
   margin-top: -8px;
 }
@@ -92,8 +92,8 @@ function updateWeight(index, value) {
   justify-content: space-between;
 }
 .eval-quant-card__label {
-  font-size: 13px;
-  font-weight: 600;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-primary-800);
 }
 .eval-quant-card__input-wrap {
@@ -106,14 +106,14 @@ function updateWeight(index, value) {
   padding: 3px 6px;
   border: 1px solid var(--color-border-default);
   border-radius: 6px;
-  font-size: 12px;
-  font-weight: 700;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
   text-align: center;
   color: var(--color-primary-800);
   background: var(--color-bg-app);
 }
 .eval-quant-card__unit {
-  font-size: 12px;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 .eval-slider {
@@ -122,8 +122,8 @@ function updateWeight(index, value) {
   cursor: pointer;
 }
 .eval-quant-card__total {
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-600);
   text-align: right;
 }

--- a/src/components/hr/hrmanager/evaluation-criteria/HRMEvalTierPanel.vue
+++ b/src/components/hr/hrmanager/evaluation-criteria/HRMEvalTierPanel.vue
@@ -72,8 +72,8 @@ function updateThreshold(tier, value) {
   gap: 12px;
 }
 .eval-tier-card__title {
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-500);
   margin-bottom: 4px;
 }
@@ -95,7 +95,7 @@ function updateThreshold(tier, value) {
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   font-weight: 900;
   flex-shrink: 0;
   color: var(--color-white);
@@ -106,8 +106,8 @@ function updateThreshold(tier, value) {
 .eval-tier-card__badge--c { background: var(--tier-c); }
 
 .eval-tier-card__label {
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-800);
   width: 48px;
   flex-shrink: 0;
@@ -117,23 +117,23 @@ function updateThreshold(tier, value) {
   padding: 4px 8px;
   border: 1px solid var(--color-border-default);
   border-radius: 6px;
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   text-align: center;
   color: var(--color-primary-800);
   background: var(--color-bg-surface);
 }
 .eval-tier-card__auto {
-  font-size: 12px;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 .eval-tier-card__desc {
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
   margin-left: auto;
 }
 .eval-tier-card__note {
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   color: var(--color-mint-500);
   background: #e3fbef;
   padding: 10px 14px;

--- a/src/components/hr/hrmanager/evaluation-criteria/HRMEvalWeightPanel.vue
+++ b/src/components/hr/hrmanager/evaluation-criteria/HRMEvalWeightPanel.vue
@@ -62,8 +62,8 @@ const qualWeight = computed(() => 100 - props.quantWeight)
   gap: 20px;
 }
 .eval-weight-card__title {
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-500);
 }
 .eval-weight-card__bar {
@@ -83,8 +83,8 @@ const qualWeight = computed(() => 100 - props.quantWeight)
 .eval-weight-card__bar-labels {
   display: flex;
   justify-content: space-between;
-  font-size: 12px;
-  font-weight: 700;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
   margin-top: -12px;
 }
 .eval-weight-card__bar-label--quant { color: var(--color-primary-600); }
@@ -101,13 +101,13 @@ const qualWeight = computed(() => 100 - props.quantWeight)
   align-items: center;
 }
 .eval-weight-card__item-label {
-  font-size: 13px;
-  font-weight: 600;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-primary-800);
 }
 .eval-weight-card__item-value {
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-600);
 }
 .eval-slider {
@@ -127,8 +127,8 @@ const qualWeight = computed(() => 100 - props.quantWeight)
   transition: width 0.2s;
 }
 .eval-weight-card__total {
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-600);
   text-align: right;
 }

--- a/src/components/hr/hrmanager/kpi-report/HRMKpiCompletionDonut.vue
+++ b/src/components/hr/hrmanager/kpi-report/HRMKpiCompletionDonut.vue
@@ -106,8 +106,8 @@ onBeforeUnmount(() => chartInstance?.destroy())
   gap: 16px;
 }
 .kpi-donut-card__title {
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-500);
   align-self: flex-start;
 }
@@ -127,7 +127,7 @@ onBeforeUnmount(() => chartInstance?.destroy())
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 13px;
+  font-size: var(--font-size-sm);
   color: var(--color-text-default);
 }
 .kpi-donut-card__dot {

--- a/src/components/hr/hrmanager/kpi-report/HRMKpiTeamBarChart.vue
+++ b/src/components/hr/hrmanager/kpi-report/HRMKpiTeamBarChart.vue
@@ -106,8 +106,8 @@ onBeforeUnmount(() => chartInstance?.destroy())
   gap: 10px;
 }
 .kpi-bar-card__title {
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-500);
 }
 .kpi-bar-card__chart {

--- a/src/components/hr/hrmanager/kpi-report/HRMKpiTeamTable.vue
+++ b/src/components/hr/hrmanager/kpi-report/HRMKpiTeamTable.vue
@@ -63,8 +63,8 @@ function rateColor(rate) {
   gap: 16px;
 }
 .kpi-team-table__title {
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-500);
 }
 
@@ -73,15 +73,15 @@ function rateColor(rate) {
   border-collapse: collapse;
 }
 .kpi-table th {
-  font-size: 12px;
-  font-weight: 600;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-text-muted);
   text-align: left;
   padding: 8px 12px;
   border-bottom: 1px solid var(--color-border-default);
 }
 .kpi-table td {
-  font-size: 13px;
+  font-size: var(--font-size-sm);
   color: var(--color-text-default);
   padding: 14px 12px;
   border-bottom: 1px solid var(--color-border-muted);
@@ -106,21 +106,21 @@ function rateColor(rate) {
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 14px;
-  font-weight: 700;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-bold);
   color: var(--color-white);
   flex-shrink: 0;
 }
 .kpi-table__name {
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   color: var(--color-text-strong);
 }
 .kpi-table__score {
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-800);
 }
 .kpi-table__tier {
-  font-size: 12px;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 

--- a/src/components/hr/hrmanager/kpi-report/HRMKpiTierTrendChart.vue
+++ b/src/components/hr/hrmanager/kpi-report/HRMKpiTierTrendChart.vue
@@ -111,8 +111,8 @@ onBeforeUnmount(() => chartInstance?.destroy())
   gap: 16px;
 }
 .kpi-trend-card__title {
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-500);
 }
 .kpi-trend-card__chart {

--- a/src/components/hr/hrmanager/kpi-report/HRMMetricCard.vue
+++ b/src/components/hr/hrmanager/kpi-report/HRMMetricCard.vue
@@ -52,20 +52,20 @@ const toneClassMap = {
   background: var(--color-bg-surface);
 }
 .metric-card__label {
-  font-size: 13px;
-  font-weight: 600;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-primary-300);
 }
 .metric-card__value {
-  font-size: 52px;
+  font-size: var(--font-size-display);
   line-height: 1;
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-800);
 }
 .metric-card__delta,
 .metric-card__helper {
-  font-size: 14px;
-  font-weight: 700;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-bold);
 }
 .metric-card--primary .metric-card__delta,
 .metric-card--primary .metric-card__helper {

--- a/src/components/hr/hrmanager/organization-management/HRMGroupAddModal.vue
+++ b/src/components/hr/hrmanager/organization-management/HRMGroupAddModal.vue
@@ -78,12 +78,12 @@ function handleSubmit() {
   box-shadow: 0 8px 40px rgba(0,0,0,.18);
 }
 .modal__title {
-  font-size: 18px; font-weight: 800;
+  font-size: var(--font-size-lg); font-weight: var(--font-weight-extrabold);
   color: var(--color-primary-800);
   margin-bottom: 6px;
 }
 .modal__label {
-  font-size: 12px; font-weight: 700;
+  font-size: var(--font-size-xs); font-weight: var(--font-weight-bold);
   color: var(--color-primary-600);
   margin-top: 6px;
 }
@@ -93,7 +93,7 @@ function handleSubmit() {
   padding: 0 14px;
   border: 1.5px solid var(--color-border-default);
   border-radius: 8px;
-  font-size: 13px; color: var(--color-primary-800);
+  font-size: var(--font-size-sm); color: var(--color-primary-800);
   background: var(--color-bg-app);
   box-sizing: border-box;
 }
@@ -103,7 +103,7 @@ function handleSubmit() {
   padding: 10px 14px;
   border: 1.5px solid var(--color-border-default);
   border-radius: 8px;
-  font-size: 13px; color: var(--color-primary-800);
+  font-size: var(--font-size-sm); color: var(--color-primary-800);
   background: var(--color-bg-app);
   resize: none; box-sizing: border-box;
   font-family: inherit;
@@ -128,7 +128,7 @@ function handleSubmit() {
 }
 .modal__btn {
   height: 40px; padding: 0 24px;
-  border-radius: 8px; font-size: 14px; font-weight: 700;
+  border-radius: 8px; font-size: var(--font-size-base); font-weight: var(--font-weight-bold);
   cursor: pointer; border: none;
 }
 .modal__btn--cancel {

--- a/src/components/hr/hrmanager/organization-management/HRMTeamAddModal.vue
+++ b/src/components/hr/hrmanager/organization-management/HRMTeamAddModal.vue
@@ -188,7 +188,7 @@ function handleSubmit() {
   box-shadow: 0 8px 40px rgba(0,0,0,.18);
 }
 .modal__title {
-  font-size: 18px; font-weight: 800;
+  font-size: var(--font-size-lg); font-weight: var(--font-weight-extrabold);
   color: var(--color-primary-800);
 }
 .modal__body {
@@ -201,7 +201,7 @@ function handleSubmit() {
   display: flex; flex-direction: column; gap: 8px;
 }
 .modal__label {
-  font-size: 12px; font-weight: 700;
+  font-size: var(--font-size-xs); font-weight: var(--font-weight-bold);
   color: var(--color-primary-600);
   margin-top: 4px;
 }
@@ -211,7 +211,7 @@ function handleSubmit() {
   padding: 0 14px;
   border: 1.5px solid var(--color-border-default);
   border-radius: 8px;
-  font-size: 13px; color: var(--color-primary-800);
+  font-size: var(--font-size-sm); color: var(--color-primary-800);
   background: var(--color-bg-app);
   box-sizing: border-box;
 }
@@ -221,7 +221,7 @@ function handleSubmit() {
   padding: 10px 14px;
   border: 1.5px solid var(--color-border-default);
   border-radius: 8px;
-  font-size: 13px; color: var(--color-primary-800);
+  font-size: var(--font-size-sm); color: var(--color-primary-800);
   background: var(--color-bg-app);
   resize: none; box-sizing: border-box;
   font-family: inherit;
@@ -237,7 +237,7 @@ function handleSubmit() {
   background: var(--color-bg-app);
 }
 .selected-box__empty {
-  font-size: 12px; color: #a89ed8;
+  font-size: var(--font-size-xs); color: #a89ed8;
   display: flex; align-items: center; justify-content: center;
   height: 100%;
 }
@@ -247,15 +247,15 @@ function handleSubmit() {
   padding: 4px 8px;
   background: var(--color-primary-100);
   border-radius: 20px;
-  font-size: 12px; font-weight: 600; color: var(--color-primary-800);
+  font-size: var(--font-size-xs); font-weight: var(--font-weight-semibold); color: var(--color-primary-800);
   cursor: pointer;
 }
 .selected-tag__tier {
   display: inline-flex; align-items: center; justify-content: center;
   width: 16px; height: 16px; border-radius: 50%;
-  font-size: 9px; font-weight: 800;
+  font-size: var(--font-size-2xs); font-weight: var(--font-weight-extrabold);
 }
-.selected-tag__remove { font-size: 11px; color: #a89ed8; }
+.selected-tag__remove { font-size: var(--font-size-xs); color: #a89ed8; }
 
 /* 우측 */
 .modal__right {
@@ -263,7 +263,7 @@ function handleSubmit() {
   min-height: 0;
 }
 .modal__section-title {
-  font-size: 13px; font-weight: 700; color: var(--color-primary-800);
+  font-size: var(--font-size-sm); font-weight: var(--font-weight-bold); color: var(--color-primary-800);
 }
 .pool__filters {
   display: flex; gap: 8px; align-items: center; flex-wrap: wrap;
@@ -272,7 +272,7 @@ function handleSubmit() {
   height: 32px; padding: 0 10px;
   border: 1.5px solid var(--color-border-default);
   border-radius: 8px;
-  font-size: 12px; color: var(--color-primary-600);
+  font-size: var(--font-size-xs); color: var(--color-primary-600);
   background: var(--color-bg-app); cursor: pointer;
 }
 .pool__search-wrap {
@@ -282,10 +282,10 @@ function handleSubmit() {
   background: var(--color-bg-app);
   height: 32px;
 }
-.pool__search-icon { font-size: 12px; color: #a89ed8; margin-right: 4px; }
+.pool__search-icon { font-size: var(--font-size-xs); color: #a89ed8; margin-right: 4px; }
 .pool__search {
   border: none; outline: none; background: transparent;
-  font-size: 12px; width: 100%; color: var(--color-primary-800);
+  font-size: var(--font-size-xs); width: 100%; color: var(--color-primary-800);
 }
 .pool__list {
   flex: 1; overflow-y: auto;
@@ -293,7 +293,7 @@ function handleSubmit() {
   padding-right: 4px;
 }
 .pool__empty {
-  font-size: 12px; color: #a89ed8;
+  font-size: var(--font-size-xs); color: #a89ed8;
   text-align: center; padding: 24px 0;
 }
 .pool-item {
@@ -309,20 +309,20 @@ function handleSubmit() {
 .pool-item__avatar {
   width: 34px; height: 34px; border-radius: 50%;
   display: flex; align-items: center; justify-content: center;
-  font-size: 13px; font-weight: 800; color: var(--color-white);
+  font-size: var(--font-size-sm); font-weight: var(--font-weight-extrabold); color: var(--color-white);
   flex-shrink: 0;
 }
 .pool-item__info { flex: 1; }
 .pool-item__row1 { display: flex; align-items: center; gap: 6px; }
-.pool-item__name { font-size: 13px; font-weight: 700; color: var(--color-primary-800); }
+.pool-item__name { font-size: var(--font-size-sm); font-weight: var(--font-weight-bold); color: var(--color-primary-800); }
 .pool-item__tier {
   display: inline-flex; align-items: center; justify-content: center;
   width: 18px; height: 18px; border-radius: 50%;
-  font-size: 10px; font-weight: 800;
+  font-size: var(--font-size-2xs); font-weight: var(--font-weight-extrabold);
 }
-.pool-item__sub { font-size: 11px; color: #7a6fa8; margin-top: 1px; }
+.pool-item__sub { font-size: var(--font-size-xs); color: #7a6fa8; margin-top: 1px; }
 .pool-item__check {
-  font-size: 14px; font-weight: 800; color: var(--color-primary-600);
+  font-size: var(--font-size-base); font-weight: var(--font-weight-extrabold); color: var(--color-primary-600);
 }
 
 .modal__actions {
@@ -331,7 +331,7 @@ function handleSubmit() {
 }
 .modal__btn {
   height: 40px; padding: 0 24px;
-  border-radius: 8px; font-size: 14px; font-weight: 700;
+  border-radius: 8px; font-size: var(--font-size-base); font-weight: var(--font-weight-bold);
   cursor: pointer; border: none;
 }
 .modal__btn--cancel {

--- a/src/components/hr/hrmanager/promotion-review/HRMPromotionDetail.vue
+++ b/src/components/hr/hrmanager/promotion-review/HRMPromotionDetail.vue
@@ -87,8 +87,8 @@ const comment = ref('')
   gap: 16px;
 }
 .promo-detail__title {
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-500);
 }
 
@@ -105,24 +105,24 @@ const comment = ref('')
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 16px;
+  font-size: var(--font-size-md);
   font-weight: 900;
   color: #fff;
   flex-shrink: 0;
 }
 .promo-detail__name {
-  font-size: 15px;
-  font-weight: 700;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-800);
 }
 .promo-detail__subtitle {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--color-text-muted);
 }
 .promo-detail__score {
   margin-left: auto;
-  font-size: 18px;
-  font-weight: 700;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-800);
 }
 
@@ -133,8 +133,8 @@ const comment = ref('')
   gap: 8px;
 }
 .promo-detail__section-title {
-  font-size: 12px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-600);
 }
 
@@ -150,14 +150,14 @@ const comment = ref('')
   gap: 8px;
   padding: 8px 12px;
   border-radius: 8px;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
 }
 .promo-req--met  { background: #e3fbef; }
 .promo-req--fail { background: #fff0f0; }
 
 .promo-req__icon {
   font-weight: 900;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   width: 14px;
   flex-shrink: 0;
 }
@@ -167,10 +167,10 @@ const comment = ref('')
 .promo-req__label {
   flex: 1;
   color: var(--color-primary-800);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 .promo-req__value {
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
 }
 .promo-req--met  .promo-req__value { color: var(--color-mint-500); }
 .promo-req--fail .promo-req__value { color: var(--color-danger); }
@@ -187,7 +187,7 @@ const comment = ref('')
   padding: 10px 12px;
   border: 1px solid var(--color-border-default);
   border-radius: 8px;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   color: var(--color-primary-800);
   background: var(--color-bg-app);
   resize: none;
@@ -204,7 +204,7 @@ const comment = ref('')
   gap: 4px;
 }
 .promo-detail__history-item {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--color-text-muted);
 }
 
@@ -218,8 +218,8 @@ const comment = ref('')
   flex: 1;
   height: 40px;
   border-radius: 8px;
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   cursor: pointer;
   border: none;
 }

--- a/src/components/hr/hrmanager/promotion-review/HRMPromotionList.vue
+++ b/src/components/hr/hrmanager/promotion-review/HRMPromotionList.vue
@@ -124,8 +124,8 @@ function resultStyle(result) {
   min-width: 0;
 }
 .promo-list__title {
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-500);
 }
 .promo-list__tabs {
@@ -138,8 +138,8 @@ function resultStyle(result) {
   border-radius: 20px;
   border: 1.5px solid var(--color-border-default);
   background: var(--color-bg-app);
-  font-size: 12px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--color-text-muted);
   cursor: pointer;
 }
@@ -153,13 +153,13 @@ function resultStyle(result) {
 .promo-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
 }
 .promo-table th {
   text-align: left;
   padding: 8px 10px;
-  font-size: 11px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--color-text-muted);
   border-bottom: 1.5px solid var(--color-border-default);
 }
@@ -178,7 +178,7 @@ function resultStyle(result) {
   display: flex;
   align-items: center;
   gap: 8px;
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-800);
 }
 .promo-table__avatar {
@@ -188,18 +188,18 @@ function resultStyle(result) {
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   font-weight: 900;
   color: #fff;
   flex-shrink: 0;
 }
 .promo-table__tier {
-  font-size: 11px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-600);
 }
 .promo-table__score {
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-800);
 }
 .promo-table__bar-wrap {
@@ -218,8 +218,8 @@ function resultStyle(result) {
 .promo-table__bar--high  { background: var(--color-mint-500); }
 .promo-table__bar--low   { background: #ffd166; }
 
-.promo-table__missing--red { color: var(--color-danger); font-weight: 700; }
-.promo-table__trend { color: var(--color-mint-500); font-weight: 700; }
+.promo-table__missing--red { color: var(--color-danger); font-weight: var(--font-weight-bold); }
+.promo-table__trend { color: var(--color-mint-500); font-weight: var(--font-weight-bold); }
 
 .promo-table__result {
   display: inline-flex;
@@ -227,16 +227,16 @@ function resultStyle(result) {
   height: 20px;
   padding: 0 8px;
   border-radius: 10px;
-  font-size: 10px;
-  font-weight: 700;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
   white-space: nowrap;
 }
 .promo-table__btn {
   height: 24px;
   padding: 0 10px;
   border-radius: 6px;
-  font-size: 11px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   cursor: pointer;
   border: none;
   white-space: nowrap;
@@ -262,8 +262,8 @@ function resultStyle(result) {
   height: 38px;
   padding: 0 20px;
   border-radius: 8px;
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   cursor: pointer;
   border: none;
 }

--- a/src/views/common/DashboardView.vue
+++ b/src/views/common/DashboardView.vue
@@ -142,7 +142,14 @@ function handleLogout() {
   cursor: pointer;
 }
 
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
 .dashboard-content {
   display: flex;
+  flex: 1;
 }
 </style>

--- a/src/views/hrmanager/HRMApprovalView.vue
+++ b/src/views/hrmanager/HRMApprovalView.vue
@@ -240,7 +240,7 @@ function handleHold()    { alert(`${selectedItem.value.name} 보류`) }
   overflow: auto;
   min-height: 0;
 }
-.hrm-approval__loading { color: #a89ed8; font-size: 14px; }
-.hrm-approval__error   { color: var(--color-danger); font-size: 14px; }
+.hrm-approval__loading { color: #a89ed8; font-size: var(--font-size-base); }
+.hrm-approval__error   { color: var(--color-danger); font-size: var(--font-size-base); }
 .hrm-approval__content { display: flex; gap: 16px; align-items: flex-start; flex: 1; min-height: 0; }
 </style>

--- a/src/views/hrmanager/HRMDashboardView.vue
+++ b/src/views/hrmanager/HRMDashboardView.vue
@@ -121,7 +121,7 @@ function metricValue(key, suffix) {
   padding: 60px;
   text-align: center;
   color: var(--color-text-muted);
-  font-size: 15px;
+  font-size: var(--font-size-base);
 }
 
 .hrm-dashboard__metrics {

--- a/src/views/hrmanager/HRMEvaluationCriteriaView.vue
+++ b/src/views/hrmanager/HRMEvaluationCriteriaView.vue
@@ -84,8 +84,8 @@ function handleApply() {
   background: var(--color-primary-100);
   border: 1px solid var(--color-primary-200);
   border-radius: 10px;
-  font-size: 13px;
-  font-weight: 600;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-primary-600);
 }
 .eval-view__panels {
@@ -103,8 +103,8 @@ function handleApply() {
   height: 40px;
   padding: 0 24px;
   border-radius: 8px;
-  font-size: 14px;
-  font-weight: 700;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-bold);
   cursor: pointer;
   border: none;
 }

--- a/src/views/hrmanager/HRMKpiReportView.vue
+++ b/src/views/hrmanager/HRMKpiReportView.vue
@@ -119,7 +119,7 @@ onMounted(async () => {
   padding: 60px;
   text-align: center;
   color: var(--color-text-muted);
-  font-size: 15px;
+  font-size: var(--font-size-base);
 }
 
 /* 툴바 */
@@ -135,8 +135,8 @@ onMounted(async () => {
   border: 1px solid var(--color-border-default);
   border-radius: 8px;
   background: var(--color-bg-surface);
-  font-size: 13px;
-  font-weight: 600;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-text-strong);
   cursor: pointer;
 }
@@ -148,8 +148,8 @@ onMounted(async () => {
   height: 38px;
   padding: 0 16px;
   border-radius: 8px;
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   cursor: pointer;
   white-space: nowrap;
 }

--- a/src/views/hrmanager/HRMNoticeBoardView.vue
+++ b/src/views/hrmanager/HRMNoticeBoardView.vue
@@ -179,11 +179,11 @@ function deleteNotice(id) {
   display: flex; align-items: baseline; gap: 12px;
 }
 .notice-header__title {
-  font-size: 20px; font-weight: 800; color: var(--color-primary-800);
+  font-size: var(--font-size-lg); font-weight: var(--font-weight-extrabold); color: var(--color-primary-800);
 }
 .notice-header__count {
   margin-left: auto;
-  font-size: 13px; color: #a89ed8;
+  font-size: var(--font-size-sm); color: #a89ed8;
 }
 
 /* 툴바 */
@@ -193,7 +193,7 @@ function deleteNotice(id) {
 .notice-tabs { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 .notice-tab {
   height: 34px; padding: 0 16px;
-  border-radius: 20px; font-size: 13px; font-weight: 600;
+  border-radius: 20px; font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold);
   cursor: pointer;
   border: 1.5px solid var(--color-border-default);
   background: var(--color-bg-surface);
@@ -216,7 +216,7 @@ function deleteNotice(id) {
 .notice-create-btn {
   height: 38px; padding: 0 20px; flex-shrink: 0;
   background: var(--color-primary-600); color: var(--color-white);
-  border: none; border-radius: 10px; font-size: 14px; font-weight: 700;
+  border: none; border-radius: 10px; font-size: var(--font-size-base); font-weight: var(--font-weight-bold);
   cursor: pointer;
 }
 
@@ -231,7 +231,7 @@ function deleteNotice(id) {
 .notice-table-head {
   padding: 0 16px 10px;
   border-bottom: 1.5px solid var(--color-border-default);
-  font-size: 12px; font-weight: 700; color: #a89ed8;
+  font-size: var(--font-size-xs); font-weight: var(--font-weight-bold); color: #a89ed8;
   text-align: center;
 }
 .notice-table-head .col-title { text-align: left; }
@@ -239,7 +239,7 @@ function deleteNotice(id) {
 .notice-list { display: flex; flex-direction: column; gap: 6px; }
 .notice-list__empty {
   padding: 32px 0; text-align: center;
-  font-size: 13px; color: #a89ed8;
+  font-size: var(--font-size-sm); color: #a89ed8;
 }
 
 .notice-row {
@@ -249,21 +249,21 @@ function deleteNotice(id) {
   border-radius: 10px;
 }
 .notice-row__title {
-  font-size: 14px; font-weight: 600; color: var(--color-primary-800);
+  font-size: var(--font-size-base); font-weight: var(--font-weight-semibold); color: var(--color-primary-800);
 }
 .notice-row__target {
-  font-size: 13px; color: var(--color-primary-600);
+  font-size: var(--font-size-sm); color: var(--color-primary-600);
   text-align: center;
 }
 .notice-row__date {
-  font-size: 13px; color: #7a6fa8;
+  font-size: var(--font-size-sm); color: #7a6fa8;
   text-align: center;
 }
 
 .notice-badge {
   display: inline-flex; align-items: center; justify-content: center;
   padding: 3px 10px; border-radius: 20px;
-  font-size: 12px; font-weight: 700;
+  font-size: var(--font-size-xs); font-weight: var(--font-weight-bold);
   margin: auto;
 }
 .col-status { display: flex; justify-content: center; }
@@ -275,14 +275,14 @@ function deleteNotice(id) {
   height: 30px; padding: 0 14px;
   background: var(--color-bg-surface);
   border: 1.5px solid var(--color-border-default);
-  border-radius: 7px; font-size: 12px; font-weight: 700;
+  border-radius: 7px; font-size: var(--font-size-xs); font-weight: var(--font-weight-bold);
   color: var(--color-primary-600); cursor: pointer;
 }
 .notice-row__delete-btn {
   height: 30px; padding: 0 14px;
   background: var(--color-danger-soft);
   border: 1.5px solid var(--color-danger);
-  border-radius: 7px; font-size: 12px; font-weight: 700;
+  border-radius: 7px; font-size: var(--font-size-xs); font-weight: var(--font-weight-bold);
   color: var(--color-danger); cursor: pointer;
 }
 </style>

--- a/src/views/hrmanager/HRMOrganizationView.vue
+++ b/src/views/hrmanager/HRMOrganizationView.vue
@@ -301,12 +301,12 @@ function removeMember(team, emp) {
   display: flex; align-items: center; justify-content: space-between;
 }
 .org-tree__title {
-  font-size: 15px; font-weight: 800; color: var(--color-primary-800);
+  font-size: var(--font-size-base); font-weight: var(--font-weight-extrabold); color: var(--color-primary-800);
 }
 .org-tree__add-btn {
   height: 30px; padding: 0 14px;
   background: var(--color-primary-600); color: var(--color-white);
-  border: none; border-radius: 8px; font-size: 12px; font-weight: 700;
+  border: none; border-radius: 8px; font-size: var(--font-size-xs); font-weight: var(--font-weight-bold);
   cursor: pointer;
 }
 .org-tree__search-wrap {
@@ -315,13 +315,13 @@ function removeMember(team, emp) {
   border-radius: 8px; padding: 0 10px; height: 36px;
   background: var(--color-bg-app);
 }
-.org-tree__search-icon { font-size: 12px; color: #a89ed8; margin-right: 6px; }
+.org-tree__search-icon { font-size: var(--font-size-xs); color: #a89ed8; margin-right: 6px; }
 .org-tree__search {
   border: none; outline: none; background: transparent;
-  font-size: 13px; width: 100%; color: var(--color-primary-800);
+  font-size: var(--font-size-sm); width: 100%; color: var(--color-primary-800);
 }
 .org-tree__list { display: flex; flex-direction: column; gap: 6px; }
-.org-tree__empty { font-size: 12px; color: #a89ed8; text-align: center; padding: 16px 0; }
+.org-tree__empty { font-size: var(--font-size-xs); color: #a89ed8; text-align: center; padding: 16px 0; }
 
 /* 그룹 노드 */
 .group-node { display: flex; flex-direction: column; gap: 3px; }
@@ -333,19 +333,19 @@ function removeMember(team, emp) {
   width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0;
 }
 .group-node__name {
-  flex: 1; font-size: 14px; font-weight: 700; color: var(--color-primary-800);
+  flex: 1; font-size: var(--font-size-base); font-weight: var(--font-weight-bold); color: var(--color-primary-800);
 }
 .group-node__team-btn {
   height: 22px; padding: 0 8px;
   background: var(--color-primary-100); color: var(--color-primary-600);
   border: 1px solid var(--color-primary-200);
-  border-radius: 6px; font-size: 10px; font-weight: 700;
+  border-radius: 6px; font-size: var(--font-size-2xs); font-weight: var(--font-weight-bold);
   cursor: pointer;
 }
 .group-node__count {
   min-width: 20px; height: 20px; padding: 0 6px;
   background: var(--color-primary-100); color: var(--color-primary-600);
-  border-radius: 10px; font-size: 11px; font-weight: 700;
+  border-radius: 10px; font-size: var(--font-size-xs); font-weight: var(--font-weight-bold);
   display: flex; align-items: center; justify-content: center;
 }
 
@@ -358,9 +358,9 @@ function removeMember(team, emp) {
 }
 .team-node:hover { background: var(--color-primary-100); }
 .team-node--active { background: var(--color-primary-100); }
-.team-node__icon { font-size: 13px; }
-.team-node__name { flex: 1; font-size: 13px; font-weight: 600; color: var(--color-primary-700); }
-.team-node__count { font-size: 11px; color: #a89ed8; }
+.team-node__icon { font-size: var(--font-size-sm); }
+.team-node__name { flex: 1; font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--color-primary-700); }
+.team-node__count { font-size: var(--font-size-xs); color: #a89ed8; }
 
 /* ── 팀 상세 ── */
 .team-detail {
@@ -372,7 +372,7 @@ function removeMember(team, emp) {
 }
 .team-detail--empty {
   align-items: center; justify-content: center;
-  color: #a89ed8; font-size: 14px;
+  color: #a89ed8; font-size: var(--font-size-base);
 }
 
 .team-detail__header {
@@ -384,34 +384,34 @@ function removeMember(team, emp) {
 .team-detail__dot {
   width: 10px; height: 10px; border-radius: 50;
 }
-.team-detail__group { font-size: 14px; color: var(--color-primary-600); font-weight: 600; }
-.team-detail__arrow { font-size: 13px; color: #a89ed8; }
-.team-detail__team-name { font-size: 15px; font-weight: 800; color: var(--color-primary-800); }
+.team-detail__group { font-size: var(--font-size-base); color: var(--color-primary-600); font-weight: var(--font-weight-semibold); }
+.team-detail__arrow { font-size: var(--font-size-sm); color: #a89ed8; }
+.team-detail__team-name { font-size: var(--font-size-base); font-weight: var(--font-weight-extrabold); color: var(--color-primary-800); }
 .team-detail__badge {
   padding: 2px 8px; background: var(--color-primary-100);
   color: var(--color-primary-600); border-radius: 6px;
-  font-size: 11px; font-weight: 700;
+  font-size: var(--font-size-xs); font-weight: var(--font-weight-bold);
 }
 .team-detail__edit-btn {
   height: 32px; padding: 0 16px;
   background: var(--color-bg-app);
   border: 1.5px solid var(--color-border-default);
-  border-radius: 8px; font-size: 13px; font-weight: 700;
+  border-radius: 8px; font-size: var(--font-size-sm); font-weight: var(--font-weight-bold);
   color: var(--color-primary-600); cursor: pointer;
 }
-.team-detail__desc { font-size: 13px; color: #7a6fa8; }
+.team-detail__desc { font-size: var(--font-size-sm); color: #7a6fa8; }
 
 .team-detail__member-header {
   display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 8px;
 }
 .team-detail__member-title {
-  font-size: 13px; font-weight: 700; color: var(--color-primary-800);
+  font-size: var(--font-size-sm); font-weight: var(--font-weight-bold); color: var(--color-primary-800);
 }
 .team-detail__filters { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
 .team-detail__select {
   height: 32px; padding: 0 10px;
   border: 1.5px solid var(--color-border-default);
-  border-radius: 8px; font-size: 12px;
+  border-radius: 8px; font-size: var(--font-size-xs);
   color: var(--color-primary-600); background: var(--color-bg-app); cursor: pointer;
 }
 .team-detail__search-wrap {
@@ -420,10 +420,10 @@ function removeMember(team, emp) {
   border-radius: 8px; padding: 0 10px; height: 32px;
   background: var(--color-bg-app);
 }
-.team-detail__search-icon { font-size: 12px; color: #a89ed8; margin-right: 4px; }
+.team-detail__search-icon { font-size: var(--font-size-xs); color: #a89ed8; margin-right: 4px; }
 .team-detail__search {
   border: none; outline: none; background: transparent;
-  font-size: 12px; color: var(--color-primary-800); width: 130px;
+  font-size: var(--font-size-xs); color: var(--color-primary-800); width: 130px;
 }
 
 /* 멤버 카드 */
@@ -431,7 +431,7 @@ function removeMember(team, emp) {
   display: flex; flex-direction: column; gap: 8px;
 }
 .member-list__empty {
-  font-size: 13px; color: #a89ed8; text-align: center; padding: 24px 0;
+  font-size: var(--font-size-sm); color: #a89ed8; text-align: center; padding: 24px 0;
 }
 .member-card {
   display: flex; align-items: center; gap: 12px;
@@ -443,35 +443,35 @@ function removeMember(team, emp) {
 .member-card__avatar {
   width: 38px; height: 38px; border-radius: 50%;
   display: flex; align-items: center; justify-content: center;
-  font-size: 14px; font-weight: 800; color: var(--color-white);
+  font-size: var(--font-size-base); font-weight: var(--font-weight-extrabold); color: var(--color-white);
   flex-shrink: 0;
 }
 .member-card__info { flex: 1; }
 .member-card__row1 { display: flex; align-items: center; gap: 6px; }
-.member-card__name { font-size: 14px; font-weight: 700; color: var(--color-primary-800); }
+.member-card__name { font-size: var(--font-size-base); font-weight: var(--font-weight-bold); color: var(--color-primary-800); }
 .member-card__tier {
   display: inline-flex; align-items: center; justify-content: center;
   width: 18px; height: 18px; border-radius: 50%;
-  font-size: 10px; font-weight: 800;
+  font-size: var(--font-size-2xs); font-weight: var(--font-weight-extrabold);
 }
 .member-card__leader-badge {
   padding: 2px 6px;
   background: var(--color-primary-600); color: var(--color-white);
-  border-radius: 4px; font-size: 10px; font-weight: 700;
+  border-radius: 4px; font-size: var(--font-size-2xs); font-weight: var(--font-weight-bold);
 }
-.member-card__sub { font-size: 12px; color: #7a6fa8; margin-top: 2px; }
+.member-card__sub { font-size: var(--font-size-xs); color: #7a6fa8; margin-top: 2px; }
 .member-card__actions { display: flex; gap: 8px; align-items: center; flex-shrink: 0; }
 .member-card__assign-btn {
   height: 32px; padding: 0 14px;
   background: var(--color-bg-surface);
   border: 1.5px solid var(--color-border-default);
-  border-radius: 8px; font-size: 12px; font-weight: 700;
+  border-radius: 8px; font-size: var(--font-size-xs); font-weight: var(--font-weight-bold);
   color: var(--color-primary-600); cursor: pointer;
 }
 .member-card__remove-btn {
   height: 32px; padding: 0 14px;
   background: var(--color-danger); color: var(--color-white);
-  border: none; border-radius: 8px; font-size: 12px; font-weight: 700;
+  border: none; border-radius: 8px; font-size: var(--font-size-xs); font-weight: var(--font-weight-bold);
   cursor: pointer;
 }
 </style>

--- a/src/views/hrmanager/HRMPromotionReviewView.vue
+++ b/src/views/hrmanager/HRMPromotionReviewView.vue
@@ -127,7 +127,7 @@ function handleConfirm(id) {
   padding: 60px;
   text-align: center;
   color: var(--color-text-muted);
-  font-size: 15px;
+  font-size: var(--font-size-base);
 }
 .promo-view__metrics {
   display: grid;


### PR DESCRIPTION
## 작업 내용                                                                                                                                                                                                             
  - variables.css에 font-size, font-weight CSS 변수 추가    
  - HRM 컴포넌트 28개 하드코딩 폰트값 → 변수로 전환                                                                                                                                                                        
  - 평가승인, 승급심사 폰트 크기 가독성 개선       
  - 내용 적을 때 사이드바/배경 잘리는 레이아웃 버그 수정