### PR TITLE
feat(worker): 대시보드 및 평가 UI 컴포넌트 개선

### DIFF
--- a/src/components/common/RoleSidebar.vue
+++ b/src/components/common/RoleSidebar.vue
@@ -36,8 +36,8 @@ function isActive(target) {
 
 <style scoped>
 .role-sidebar {
-  width: 304px;
-  min-width: 304px;
+  width: 14%;
+  min-width: 14%;
   padding: 18px 14px 28px;
   border-right: 1px solid var(--color-border-soft);
   background: var(--color-bg-surface);

--- a/src/components/dashboard/worker/WorkerOverallStatusCard.vue
+++ b/src/components/dashboard/worker/WorkerOverallStatusCard.vue
@@ -47,15 +47,19 @@ defineProps({
     <div class="status-card__stats">
       <div class="status-card__stat">
         <span class="status-card__stat-value">{{ worker.historyPeriod }}</span>
+        <span class="status-card__stat-label">경력</span>
       </div>
       <div class="status-card__stat">
         <span class="status-card__stat-value">{{ worker.worksDone }}</span>
+        <span class="status-card__stat-label">완료작업</span>
       </div>
       <div class="status-card__stat">
         <span class="status-card__stat-value">{{ worker.finishRate }}%</span>
+        <span class="status-card__stat-label">완료율</span>
       </div>
       <div class="status-card__stat">
         <span class="status-card__stat-value">{{ worker.aiEval }}</span>
+        <span class="status-card__stat-label">AI평가</span>
       </div>
     </div>
   </div>
@@ -210,10 +214,18 @@ defineProps({
 .status-card__stat {
   text-align: center;
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
 .status-card__stat-value {
   font-size: 13px;
   font-weight: 600;
+}
+
+.status-card__stat-label {
+  font-size: 10px;
+  opacity: 0.5;
 }
 </style>

--- a/src/components/dashboard/worker/WorkerSkillsRadarChart.vue
+++ b/src/components/dashboard/worker/WorkerSkillsRadarChart.vue
@@ -9,7 +9,7 @@ const props = defineProps({
   },
 })
 
-const size = 180
+const size = 200
 const cx = size / 2
 const cy = size / 2
 const maxR = 70
@@ -149,14 +149,14 @@ const labelPositions = computed(() => {
   background: var(--color-bg-surface);
   border: 1px solid var(--color-border-default);
   border-radius: var(--radius-card);
-  padding: 20px;
+  padding: 12px 20px 20px;
 }
 
 .radar__title {
   font-size: 14px;
   font-weight: 700;
   color: var(--color-primary-800);
-  margin: 0 0 16px;
+  margin: 0 0 24px;
 }
 
 .radar__content {
@@ -170,7 +170,7 @@ const labelPositions = computed(() => {
 }
 
 .radar__data-area {
-  transform-origin: 90px 90px;
+  transform-origin: 100px 100px;
   transform: scale(0);
   opacity: 0;
   transition: transform 1s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.4s ease;
@@ -182,7 +182,7 @@ const labelPositions = computed(() => {
 }
 
 .radar__data-point {
-  transform-origin: 90px 90px;
+  transform-origin: 100px 100px;
   transform: scale(0);
   opacity: 0;
   transition: transform 1s cubic-bezier(0.16, 1, 0.3, 1) 0.15s, opacity 0.4s ease 0.15s;

--- a/src/components/hr/worker/evaluation-result/WorkerQuantitativeEvaluation.vue
+++ b/src/components/hr/worker/evaluation-result/WorkerQuantitativeEvaluation.vue
@@ -12,6 +12,20 @@ const activeTab = ref(tabs[0])
 function isHighlight(val) {
   return val.endsWith('%') || val.endsWith('점')
 }
+
+function parseLabel(label) {
+  const index = label.substring(0, 2)
+  const rest = label.substring(2)
+  const splitMatch = rest.match(/ (?:[A-Z]|MCH|R')/)
+  if (splitMatch) {
+    const splitIndex = splitMatch.index
+    return {
+      name: index + rest.substring(0, splitIndex).trim(),
+      formula: rest.substring(splitIndex).trim(),
+    }
+  }
+  return { name: label, formula: '' }
+}
 </script>
 
 <template>
@@ -33,7 +47,12 @@ function isHighlight(val) {
     <!-- Formula steps -->
     <div class="qn__steps">
       <div v-for="(step, i) in evaluation.steps" :key="i" class="qn__step">
-        <span class="qn__step-label">{{ step.label }}</span>
+        <div class="qn__step-label">
+          <span class="qn__step-name">{{ parseLabel(step.label).name }}</span>
+          <span v-if="parseLabel(step.label).formula" class="qn__step-formula">
+            {{ parseLabel(step.label).formula }}
+          </span>
+        </div>
         <span
           class="qn__step-value"
           :class="{ 'qn__step-value--accent': isHighlight(step.value) }"
@@ -137,9 +156,21 @@ function isHighlight(val) {
 }
 
 .qn__step-label {
-  color: var(--color-text-default);
-  font-family: 'Courier New', Courier, monospace;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.qn__step-name {
   font-size: 13px;
+  font-weight: 700;
+  color: var(--color-text-strong);
+}
+
+.qn__step-formula {
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 11px;
+  color: var(--color-text-muted);
 }
 
 .qn__step-value {

--- a/src/components/hr/worker/point-mission/WorkerPointTotalHolding.vue
+++ b/src/components/hr/worker/point-mission/WorkerPointTotalHolding.vue
@@ -51,33 +51,35 @@ const segments = computed(() => {
       <span class="holding__compare">전월 대비 +{{ summary.monthGainPercent }}%</span>
     </div>
 
-    <div class="holding__chart">
-      <svg viewBox="0 0 120 120" class="holding__donut">
-        <circle
-          v-for="(seg, i) in segments"
-          :key="i"
-          cx="60"
-          cy="60"
-          r="50"
-          fill="none"
-          :stroke="seg.color"
-          stroke-width="14"
-          :stroke-dasharray="`${(seg.pct / 100) * 314.16 * animProgress} ${314.16}`"
-          :stroke-dashoffset="`${-(seg.offset / 100) * 314.16 * animProgress}`"
-          stroke-linecap="butt"
-        />
-        <text x="60" y="56" text-anchor="middle" class="holding__donut-number">
-          {{ total.toLocaleString() }}
-        </text>
-        <text x="60" y="72" text-anchor="middle" class="holding__donut-sub">pts</text>
-      </svg>
-    </div>
+    <div class="holding__right">
+      <div class="holding__chart">
+        <svg viewBox="0 0 120 120" class="holding__donut">
+          <circle
+            v-for="(seg, i) in segments"
+            :key="i"
+            cx="60"
+            cy="60"
+            r="50"
+            fill="none"
+            :stroke="seg.color"
+            stroke-width="14"
+            :stroke-dasharray="`${(seg.pct / 100) * 314.16 * animProgress} ${314.16}`"
+            :stroke-dashoffset="`${-(seg.offset / 100) * 314.16 * animProgress}`"
+            stroke-linecap="butt"
+          />
+          <text x="60" y="56" text-anchor="middle" class="holding__donut-number">
+            {{ total.toLocaleString() }}
+          </text>
+          <text x="60" y="72" text-anchor="middle" class="holding__donut-sub">pts</text>
+        </svg>
+      </div>
 
-    <div class="holding__legend">
-      <div v-for="(seg, i) in segments" :key="i" class="holding__legend-item">
-        <span class="holding__legend-dot" :style="{ background: seg.color }"></span>
-        <span class="holding__legend-label">{{ seg.label }}</span>
-        <span class="holding__legend-value">{{ seg.value.toLocaleString() }}</span>
+      <div class="holding__legend">
+        <div v-for="(seg, i) in segments" :key="i" class="holding__legend-item">
+          <span class="holding__legend-dot" :style="{ background: seg.color }"></span>
+          <span class="holding__legend-label">{{ seg.label }}</span>
+          <span class="holding__legend-value">{{ seg.value.toLocaleString() }}</span>
+        </div>
       </div>
     </div>
   </div>
@@ -87,7 +89,7 @@ const segments = computed(() => {
 .holding {
   display: flex;
   align-items: center;
-  gap: 32px;
+  gap: 30%;
   background: var(--color-bg-surface);
   border: 1px solid var(--color-border-default);
   border-radius: var(--radius-card);
@@ -99,6 +101,12 @@ const segments = computed(() => {
   flex-direction: column;
   gap: 4px;
   min-width: 160px;
+}
+
+.holding__right {
+  display: flex;
+  align-items: center;
+  gap: 40px;
 }
 
 .holding__label {

--- a/src/components/kms/worker/skill-gap/WorkerCustomizedLearningRecommendations.vue
+++ b/src/components/kms/worker/skill-gap/WorkerCustomizedLearningRecommendations.vue
@@ -1,8 +1,24 @@
 <script setup>
-defineProps({
+import { ref, watch } from 'vue'
+
+const props = defineProps({
   courses: { type: Array, required: true },
   articles: { type: Array, required: true },
 })
+
+const localCourses = ref([])
+
+// Initialize or update local copy when prop changes
+watch(() => props.courses, (newVal) => {
+  localCourses.value = newVal.map(c => ({ ...c }))
+}, { immediate: true })
+
+const startCourse = (id) => {
+  const course = localCourses.value.find(c => c.id === id)
+  if (course && course.status === '시작하기') {
+    course.status = '진행중'
+  }
+}
 </script>
 
 <template>
@@ -11,7 +27,7 @@ defineProps({
 
     <!-- Course Cards -->
     <div class="lr__courses">
-      <div v-for="course in courses" :key="course.id" class="lr__course">
+      <div v-for="course in localCourses" :key="course.id" class="lr__course">
         <div class="lr__course-top">
           <div class="lr__course-badges">
             <span
@@ -28,7 +44,13 @@ defineProps({
         <p v-if="course.description" class="lr__course-desc">{{ course.description }}</p>
         <div class="lr__course-bottom">
           <span v-if="course.durationDiff" class="lr__course-diff">{{ course.durationDiff }}</span>
-          <button class="lr__course-btn">{{ course.status }}</button>
+          <button
+            class="lr__course-btn"
+            :class="{ 'lr__course-btn--active': course.status === '진행중' }"
+            @click="startCourse(course.id)"
+          >
+            {{ course.status }}
+          </button>
         </div>
       </div>
     </div>
@@ -154,6 +176,18 @@ defineProps({
 .lr__course-btn:hover {
   border-color: var(--color-primary-300);
   color: var(--color-primary-700);
+}
+
+.lr__course-btn--active {
+  background: var(--color-primary-600);
+  color: var(--color-white);
+  border-color: var(--color-primary-600);
+}
+
+.lr__course-btn--active:hover {
+  background: var(--color-primary-700);
+  color: var(--color-white);
+  border-color: var(--color-primary-700);
 }
 
 /* ── Related Articles ──────────────────────────────────── */


### PR DESCRIPTION
   1. WorkerOverallStatusCard.vue: 상태 수치 아래에 설명 레이블("경력", "완료작업", "완료율", "AI평가")을 추가했습니다.
   2. WorkerCustomizedLearningRecommendations.vue: "시작하기" 버튼 클릭 시 텍스트가 "진행중"으로 변경되도록 클릭 핸들러를 구현하고, 활성화 상태의 색상을 적용했습니다.
   3. WorkerSkillsRadarChart.vue: 제목 여백과 컨테이너 패딩을 조정하고 SVG 크기 및 중심점을 늘려, 레이블이 제목과 겹치거나 잘리는 현상을 해결했습니다.
   4. WorkerPointTotalHolding.vue: 차트와 범례를 그룹화하여 레이아웃 균형을 맞추고, 간격을 80px로 조정하여 정렬 및 여백 문제를 개선했습니다.
   5. WorkerQuantitativeEvaluation.vue: 가독성을 높이기 위해 단계별 레이블을 두 줄(상단: 이름, 하단: 수식) 레이아웃으로 리팩토링했습니다.