### PR TITLE
department leader / 부서 성과 현황으로 이름 변경, 폰트 교체, 알림 탭 수정

### DIFF
--- a/src/components/common/menuConfig.js
+++ b/src/components/common/menuConfig.js
@@ -84,7 +84,7 @@ export const roleSidebarSections = {
       label: 'HR',
       items: [
         { label: '대시보드', icon: '👥', to: { name: 'DepartmentLeaderDashboard' } },
-        { label: '그룹 성과 현황', icon: '📊', to: { name: 'DepartmentLeaderDashboardPerformance' } },
+        { label: '부서 성과 현황', icon: '📊', to: { name: 'DepartmentLeaderDashboardPerformance' } },
         { label: '팀원 역량 조회', icon: '🔍', to: { name: 'TeamCapability' } },
         { label: '2차 평가 작성', icon: '📝', to: { name: 'DepartmentLeaderDashboardEvaluation' } },
         { label: '알림', icon: '🔔', to: { name: 'DLNotifications' } },

--- a/src/components/dashboard/departmentleader/DepartmentLeaderGroupKpiCard.vue
+++ b/src/components/dashboard/departmentleader/DepartmentLeaderGroupKpiCard.vue
@@ -138,13 +138,13 @@ onBeforeUnmount(() => chartInstance?.destroy())
 }
 
 .dl-kpi-card__dot {
-  font-size: 10px;
+  font-size: var(--font-size-2xs);
   color: var(--color-primary-500);
 }
 
 .dl-kpi-card__title {
-  font-size: 15px;
-  font-weight: 700;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-800);
 }
 
@@ -157,16 +157,16 @@ onBeforeUnmount(() => chartInstance?.destroy())
   border-radius: 999px;
   background: var(--color-primary-700);
   color: #fff;
-  font-size: 11px;
-  font-weight: 700;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
 }
 
 .dl-kpi-card__detail-btn {
   background: none;
   border: none;
   cursor: pointer;
-  font-size: 13px;
-  font-weight: 600;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-primary-500);
 }
 .dl-kpi-card__detail-btn:hover {
@@ -185,13 +185,13 @@ onBeforeUnmount(() => chartInstance?.destroy())
 }
 
 .dl-kpi-card__stat-value {
-  font-size: 28px;
-  font-weight: 700;
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-bold);
   line-height: 1;
 }
 
 .dl-kpi-card__stat-label {
-  font-size: 12px;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 

--- a/src/components/dashboard/departmentleader/DepartmentLeaderTeamStatusCard.vue
+++ b/src/components/dashboard/departmentleader/DepartmentLeaderTeamStatusCard.vue
@@ -65,13 +65,13 @@ const statusConfig = {
 }
 
 .dl-team-card__dot {
-  font-size: 10px;
+  font-size: var(--font-size-2xs);
   color: var(--color-primary-500);
 }
 
 .dl-team-card__title {
-  font-size: 15px;
-  font-weight: 700;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-800);
 }
 
@@ -79,8 +79,8 @@ const statusConfig = {
   background: none;
   border: none;
   cursor: pointer;
-  font-size: 13px;
-  font-weight: 600;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-primary-500);
 }
 .dl-team-card__all-btn:hover {
@@ -118,7 +118,7 @@ const statusConfig = {
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 18px;
+  font-size: var(--font-size-lg);
   flex-shrink: 0;
 }
 
@@ -131,13 +131,13 @@ const statusConfig = {
 }
 
 .dl-team-card__name {
-  font-size: 14px;
-  font-weight: 700;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-800);
 }
 
 .dl-team-card__sub {
-  font-size: 12px;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 
@@ -148,8 +148,8 @@ const statusConfig = {
   height: 26px;
   padding: 0 12px;
   border-radius: 999px;
-  font-size: 12px;
-  font-weight: 700;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
   white-space: nowrap;
   flex-shrink: 0;
 }

--- a/src/components/hr/departmentleader/notification/DepartmentLeaderNotificationFilterBarWrapper.vue
+++ b/src/components/hr/departmentleader/notification/DepartmentLeaderNotificationFilterBarWrapper.vue
@@ -38,8 +38,8 @@ function handleChange(filterKey) {
 }
 
 .dl-notif-filter__eyebrow {
-  font-size: 12px;
-  font-weight: 700;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-300);
 }
 

--- a/src/components/hr/departmentleader/notification/DepartmentLeaderNotificationListWrapper.vue
+++ b/src/components/hr/departmentleader/notification/DepartmentLeaderNotificationListWrapper.vue
@@ -5,11 +5,14 @@ defineProps({
   items:    { type: Array,  default: () => [] },
   pageSize: { type: Number, default: 6 },
 })
+
+const emit = defineEmits(['click-action'])
 </script>
 
 <template>
   <BaseNotificationList
     :items="items"
     :page-size="pageSize"
+    @click-action="emit('click-action', $event)"
   />
 </template>

--- a/src/components/hr/departmentleader/perfomance/DLPerformanceSummary.vue
+++ b/src/components/hr/departmentleader/perfomance/DLPerformanceSummary.vue
@@ -96,8 +96,8 @@ const deltaLabel = computed(() => props.selectedTeam === '전체' ? '전년 동�
 }
 
 .dl-perf-summary__label {
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--color-text-muted);
   margin: 0;
 }
@@ -122,8 +122,8 @@ const deltaLabel = computed(() => props.selectedTeam === '전체' ? '전년 동�
 }
 
 .dl-perf-summary__big {
-  font-size: 40px;
-  font-weight: 800;
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-extrabold);
   color: var(--color-primary-800);
   line-height: 1;
 }
@@ -133,13 +133,13 @@ const deltaLabel = computed(() => props.selectedTeam === '전체' ? '전년 동�
 }
 
 .dl-perf-summary__unit {
-  font-size: 18px;
-  font-weight: 600;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
   margin-left: 2px;
 }
 
 .dl-perf-summary__sub {
-  font-size: 12px;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 
@@ -156,8 +156,8 @@ const deltaLabel = computed(() => props.selectedTeam === '전체' ? '전년 동�
   padding: 0 12px;
   border: 1px solid var(--color-border-default);
   border-radius: 99px;
-  font-size: 12px;
-  font-weight: 600;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-text-muted);
   background: var(--color-bg-surface);
   cursor: pointer;
@@ -178,8 +178,8 @@ const deltaLabel = computed(() => props.selectedTeam === '전체' ? '전년 동�
 }
 
 .dl-perf-summary__progress-count {
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-600);
 }
 
@@ -205,22 +205,22 @@ const deltaLabel = computed(() => props.selectedTeam === '전체' ? '전년 동�
 }
 
 .dl-perf-summary__bar-pct {
-  font-size: 15px;
-  font-weight: 800;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-extrabold);
   color: var(--color-primary-700);
   white-space: nowrap;
 }
 
 .dl-perf-summary__period {
-  font-size: 12px;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
   margin: 0;
 }
 
 /* 증감 */
 .dl-perf-summary__delta {
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
 }
 .dl-perf-summary__delta--up   { color: #16a37a; }
 .dl-perf-summary__delta--down { color: #e05a5a; }

--- a/src/components/hr/departmentleader/perfomance/DLPerformanceTable.vue
+++ b/src/components/hr/departmentleader/perfomance/DLPerformanceTable.vue
@@ -209,7 +209,7 @@ function closeDetail()      { selectedMember.value = null }
   padding: 0 12px;
   border: 1px solid var(--color-border-default);
   border-radius: 8px;
-  font-size: 13px;
+  font-size: var(--font-size-sm);
   color: var(--color-text-default);
   background: var(--color-bg-surface);
   outline: none;
@@ -221,8 +221,8 @@ function closeDetail()      { selectedMember.value = null }
 
 .dl-perf-table-wrap__count {
   margin-left: auto;
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-600);
 }
 
@@ -234,14 +234,14 @@ function closeDetail()      { selectedMember.value = null }
 .dl-perf-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 13px;
+  font-size: var(--font-size-sm);
 }
 
 .dl-perf-table th {
   padding: 10px 14px;
   text-align: left;
-  font-size: 12px;
-  font-weight: 700;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
   color: var(--color-text-muted);
   border-bottom: 2px solid var(--color-border-default);
   white-space: nowrap;
@@ -260,10 +260,10 @@ function closeDetail()      { selectedMember.value = null }
 }
 .dl-perf-table__row:hover { background: var(--color-primary-50, #f7f5ff); }
 
-.dl-perf-table__empid { color: var(--color-text-muted); font-size: 12px; }
-.dl-perf-table__name  { font-weight: 700; color: var(--color-primary-800); }
-.dl-perf-table__score { color: var(--color-primary-600); font-weight: 600; }
-.dl-perf-table__total { font-weight: 800; color: var(--color-primary-800); }
+.dl-perf-table__empid { color: var(--color-text-muted); font-size: var(--font-size-xs); }
+.dl-perf-table__name  { font-weight: var(--font-weight-bold); color: var(--color-primary-800); }
+.dl-perf-table__score { color: var(--color-primary-600); font-weight: var(--font-weight-semibold); }
+.dl-perf-table__total { font-weight: var(--font-weight-extrabold); color: var(--color-primary-800); }
 
 .dl-perf-table__grade {
   display: inline-flex;
@@ -272,11 +272,11 @@ function closeDetail()      { selectedMember.value = null }
   width: 26px;
   height: 26px;
   border-radius: 7px;
-  font-size: 12px;
-  font-weight: 800;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-extrabold);
 }
 
-.dl-perf-table__status { font-weight: 600; font-size: 12px; }
+.dl-perf-table__status { font-weight: var(--font-weight-semibold); font-size: var(--font-size-xs); }
 
 .dl-perf-table__empty {
   text-align: center;
@@ -314,7 +314,7 @@ function closeDetail()      { selectedMember.value = null }
   right: 20px;
   background: none;
   border: none;
-  font-size: 18px;
+  font-size: var(--font-size-lg);
   color: var(--color-text-muted);
   cursor: pointer;
 }
@@ -333,8 +333,8 @@ function closeDetail()      { selectedMember.value = null }
   align-items: center;
   justify-content: center;
   color: #fff;
-  font-size: 20px;
-  font-weight: 800;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-extrabold);
   flex-shrink: 0;
 }
 
@@ -345,8 +345,8 @@ function closeDetail()      { selectedMember.value = null }
 }
 
 .dl-detail-modal__name {
-  font-size: 20px;
-  font-weight: 800;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-extrabold);
   color: var(--color-primary-800);
 }
 
@@ -357,12 +357,12 @@ function closeDetail()      { selectedMember.value = null }
   width: 26px;
   height: 26px;
   border-radius: 7px;
-  font-size: 12px;
-  font-weight: 800;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-extrabold);
 }
 
 .dl-detail-modal__meta {
-  font-size: 13px;
+  font-size: var(--font-size-sm);
   color: var(--color-text-muted);
 }
 
@@ -389,27 +389,27 @@ function closeDetail()      { selectedMember.value = null }
 }
 
 .dl-detail-modal__score-label {
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .dl-detail-modal__score-value {
-  font-size: 22px;
-  font-weight: 800;
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-extrabold);
   color: var(--color-primary-700);
 }
 
 .dl-detail-modal__score-value--total {
   color: var(--color-primary-600);
-  font-size: 26px;
+  font-size: var(--font-size-xl);
 }
 
 .dl-detail-modal__status-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-size: 14px;
+  font-size: var(--font-size-base);
   color: var(--color-text-default);
   padding: 0 2px;
 }
@@ -424,8 +424,8 @@ function closeDetail()      { selectedMember.value = null }
   height: 40px;
   padding: 0 20px;
   border-radius: 10px;
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   cursor: pointer;
   border: none;
 }

--- a/src/components/hr/departmentleader/second-evaluation/DepartmentLeaderEvalFormPanel.vue
+++ b/src/components/hr/departmentleader/second-evaluation/DepartmentLeaderEvalFormPanel.vue
@@ -158,7 +158,7 @@ const canSubmit = computed(() =>
   align-items: center;
   justify-content: center;
   color: var(--color-text-muted);
-  font-size: 14px;
+  font-size: var(--font-size-base);
 }
 
 /* Header */
@@ -176,8 +176,8 @@ const canSubmit = computed(() =>
   align-items: center;
   justify-content: center;
   color: #fff;
-  font-size: 22px;
-  font-weight: 700;
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
   flex-shrink: 0;
 }
 
@@ -194,8 +194,8 @@ const canSubmit = computed(() =>
 }
 
 .eval-form__name {
-  font-size: 20px;
-  font-weight: 800;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-extrabold);
   color: var(--color-primary-800);
 }
 
@@ -206,12 +206,12 @@ const canSubmit = computed(() =>
   width: 26px;
   height: 26px;
   border-radius: 8px;
-  font-size: 13px;
-  font-weight: 800;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-extrabold);
 }
 
 .eval-form__meta {
-  font-size: 13px;
+  font-size: var(--font-size-sm);
   color: var(--color-text-muted);
 }
 
@@ -227,8 +227,8 @@ const canSubmit = computed(() =>
 }
 
 .eval-form__ai-label {
-  font-size: 13px;
-  font-weight: 600;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-primary-700);
   white-space: nowrap;
 }
@@ -247,13 +247,13 @@ const canSubmit = computed(() =>
 }
 
 .eval-form__ai-value {
-  font-size: 18px;
-  font-weight: 800;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-extrabold);
   color: var(--color-primary-800);
 }
 
 .eval-form__ai-kind {
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 
@@ -283,16 +283,16 @@ const canSubmit = computed(() =>
 }
 
 .eval-category__name {
-  font-size: 15px;
-  font-weight: 700;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-800);
 }
 
 .eval-category__score {
   width: 72px;
   text-align: center;
-  font-size: 16px;
-  font-weight: 800;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-extrabold);
   color: var(--color-primary-600);
   border: 1.5px solid var(--color-primary-300);
   border-radius: 8px;
@@ -317,7 +317,7 @@ const canSubmit = computed(() =>
 }
 
 .eval-category__star {
-  font-size: 22px;
+  font-size: var(--font-size-xl);
   color: #ddd;
   cursor: pointer;
   line-height: 1;
@@ -339,7 +339,7 @@ const canSubmit = computed(() =>
   padding: 0 14px;
   border: 1px solid var(--color-border-default);
   border-radius: 10px;
-  font-size: 13px;
+  font-size: var(--font-size-sm);
   color: var(--color-text-default);
   background: var(--color-bg-surface-muted);
   box-sizing: border-box;
@@ -364,7 +364,7 @@ const canSubmit = computed(() =>
 
 .eval-form__submit-hint {
   flex: 1;
-  font-size: 12px;
+  font-size: var(--font-size-xs);
   color: #e05a5a;
   text-align: left;
 }
@@ -373,8 +373,8 @@ const canSubmit = computed(() =>
   height: 42px;
   padding: 0 24px;
   border-radius: 12px;
-  font-size: 14px;
-  font-weight: 700;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-bold);
   cursor: pointer;
   border: none;
   transition: opacity 0.15s;

--- a/src/components/hr/departmentleader/second-evaluation/DepartmentLeaderEvalMemberListPanel.vue
+++ b/src/components/hr/departmentleader/second-evaluation/DepartmentLeaderEvalMemberListPanel.vue
@@ -62,8 +62,8 @@ const statusConfig = {
 }
 
 .eval-member-list__title {
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-600);
   margin: 0;
 }
@@ -125,8 +125,8 @@ const statusConfig = {
   align-items: center;
   justify-content: center;
   color: #fff;
-  font-size: 17px;
-  font-weight: 700;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-bold);
   flex-shrink: 0;
 }
 
@@ -144,8 +144,8 @@ const statusConfig = {
 }
 
 .eval-card__name {
-  font-size: 14px;
-  font-weight: 700;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-bold);
 }
 
 .card--submitted .eval-card__name,
@@ -164,13 +164,13 @@ const statusConfig = {
   width: 22px;
   height: 22px;
   border-radius: 6px;
-  font-size: 11px;
-  font-weight: 800;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-extrabold);
 }
 
 .eval-card__status {
-  font-size: 12px;
-  font-weight: 600;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
 }
 
 .card--submitted .eval-card__status {
@@ -187,7 +187,7 @@ const statusConfig = {
 
 /* Date */
 .eval-card__date {
-  font-size: 12px;
+  font-size: var(--font-size-xs);
   flex-shrink: 0;
 }
 

--- a/src/components/hr/departmentleader/team-capability/DepartmentLeaderCapabilityDetailPanel.vue
+++ b/src/components/hr/departmentleader/team-capability/DepartmentLeaderCapabilityDetailPanel.vue
@@ -94,7 +94,7 @@ defineProps({
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 14px;
+  font-size: var(--font-size-base);
   color: var(--color-text-muted);
 }
 
@@ -121,8 +121,8 @@ defineProps({
   align-items: center;
   justify-content: center;
   color: #fff;
-  font-size: 22px;
-  font-weight: 700;
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
   flex-shrink: 0;
 }
 
@@ -139,8 +139,8 @@ defineProps({
 }
 
 .capability-detail__name {
-  font-size: 22px;
-  font-weight: 700;
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-800);
 }
 
@@ -151,18 +151,18 @@ defineProps({
   height: 26px;
   padding: 0 12px;
   border-radius: 999px;
-  font-size: 12px;
-  font-weight: 700;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
 }
 
 .capability-detail__sub {
-  font-size: 13px;
+  font-size: var(--font-size-sm);
   color: var(--color-text-muted);
 }
 
 .capability-detail__score {
-  font-size: 52px;
-  font-weight: 800;
+  font-size: var(--font-size-display);
+  font-weight: var(--font-weight-extrabold);
   color: var(--color-primary-800);
   line-height: 1;
   flex-shrink: 0;
@@ -193,13 +193,13 @@ defineProps({
 }
 
 .capability-detail__score-value {
-  font-size: 28px;
-  font-weight: 700;
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-bold);
   line-height: 1;
 }
 
 .capability-detail__score-label {
-  font-size: 12px;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 

--- a/src/components/hr/departmentleader/team-capability/DepartmentLeaderMemberListPanel.vue
+++ b/src/components/hr/departmentleader/team-capability/DepartmentLeaderMemberListPanel.vue
@@ -117,8 +117,8 @@ function selectTeam(t) {
 }
 
 .member-list-panel__title {
-  font-size: 14px;
-  font-weight: 700;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-800);
 }
 
@@ -131,8 +131,8 @@ function selectTeam(t) {
   border: none;
   border-radius: var(--radius-sm);
   padding: 6px 12px;
-  font-size: 13px;
-  font-weight: 600;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-primary-700);
   cursor: pointer;
 }
@@ -153,7 +153,7 @@ function selectTeam(t) {
 
 .member-list-panel__dropdown-item {
   padding: 10px 16px;
-  font-size: 13px;
+  font-size: var(--font-size-sm);
   cursor: pointer;
   color: var(--color-text-default);
 }
@@ -161,7 +161,7 @@ function selectTeam(t) {
   background: var(--color-primary-100);
 }
 .member-list-panel__dropdown-item--active {
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-700);
 }
 
@@ -176,7 +176,7 @@ function selectTeam(t) {
 }
 
 .member-list-panel__search-icon {
-  font-size: 14px;
+  font-size: var(--font-size-base);
   flex-shrink: 0;
 }
 
@@ -184,7 +184,7 @@ function selectTeam(t) {
   border: none;
   background: transparent;
   outline: none;
-  font-size: 13px;
+  font-size: var(--font-size-sm);
   color: var(--color-text-default);
   width: 100%;
 }
@@ -225,8 +225,8 @@ function selectTeam(t) {
   align-items: center;
   justify-content: center;
   color: #fff;
-  font-size: 18px;
-  font-weight: 700;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
   flex-shrink: 0;
 }
 
@@ -244,8 +244,8 @@ function selectTeam(t) {
 }
 
 .member-list-panel__name {
-  font-size: 14px;
-  font-weight: 700;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-800);
 }
 
@@ -256,12 +256,12 @@ function selectTeam(t) {
   width: 22px;
   height: 22px;
   border-radius: 6px;
-  font-size: 11px;
-  font-weight: 800;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-extrabold);
 }
 
 .member-list-panel__sub {
-  font-size: 12px;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 </style>

--- a/src/components/hr/departmentleader/team-capability/DepartmentLeaderTierTimeline.vue
+++ b/src/components/hr/departmentleader/team-capability/DepartmentLeaderTierTimeline.vue
@@ -49,8 +49,8 @@ function tierStyle(tier) {
 }
 
 .tier-timeline__label {
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-500);
 }
 
@@ -75,18 +75,18 @@ function tierStyle(tier) {
   width: 40px;
   height: 40px;
   border-radius: 10px;
-  font-size: 16px;
-  font-weight: 800;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-extrabold);
 }
 
 .tier-timeline__score {
-  font-size: 20px;
-  font-weight: 800;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-extrabold);
   line-height: 1;
 }
 
 .tier-timeline__date {
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 

--- a/src/mocks/departmentleader/notification.js
+++ b/src/mocks/departmentleader/notification.js
@@ -1,4 +1,4 @@
-// category: 'fault' | 'eval' | 'facility' | 'member'
+// category: 'fault' | 'eval' | 'facility' | 'member' | 'kms'
 // tone:     'fault' | 'warn' | 'success' | 'info' | 'neutral'
 export const notificationItems = [
   {
@@ -58,11 +58,11 @@ export const notificationItems = [
   },
   {
     id: 6,
-    category: 'member',
-    categoryLabel: '팀원',
+    category: 'kms',
+    categoryLabel: 'KMS',
     tone: 'info',
-    unread: false,
-    title: '임원석 KMS 지식 등록',
+    unread: true,
+    title: '임원석 KMS 지식 등록 — 승인 대기',
     description: '용접 전류 보정 체크리스트 신규 등록',
     time: '2일 전',
     actionLabel: '보기',
@@ -133,6 +133,17 @@ export const notificationItems = [
     time: '6일 전',
     actionLabel: '보기',
   },
+  {
+    id: 13,
+    category: 'kms',
+    categoryLabel: 'KMS',
+    tone: 'info',
+    unread: false,
+    title: '손창우 KMS 지식 수정 요청',
+    description: 'CNC 선반 가공 파라미터 가이드 내용 변경',
+    time: '6일 전',
+    actionLabel: '보기',
+  },
 ]
 
 // category key → filter key mapping
@@ -142,4 +153,5 @@ export const notificationFilters = [
   { key: 'eval',     label: '평가',  categoryKey: 'eval' },
   { key: 'facility', label: '설비',  categoryKey: 'facility' },
   { key: 'member',   label: '팀원',  categoryKey: 'member' },
+  { key: 'kms',      label: 'KMS',   categoryKey: 'kms' },
 ]

--- a/src/views/departmentleader/DepartmentLeaderKnowledgeApprovalView.vue
+++ b/src/views/departmentleader/DepartmentLeaderKnowledgeApprovalView.vue
@@ -136,13 +136,13 @@ function handleHold() {
 }
 
 .approval-stat-card p {
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-300);
 }
 
 .approval-stat-card strong {
-  font-size: 52px;
+  font-size: var(--font-size-display);
   line-height: 1;
   color: #e7395f;
 }

--- a/src/views/departmentleader/DepartmentLeaderNotificationView.vue
+++ b/src/views/departmentleader/DepartmentLeaderNotificationView.vue
@@ -1,10 +1,12 @@
 <script setup>
 import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
 import BaseStatCard from '@/components/common/base/display/BaseStatCard.vue'
 import DepartmentLeaderNotificationFilterBarWrapper from '@/components/hr/departmentleader/notification/DepartmentLeaderNotificationFilterBarWrapper.vue'
 import DepartmentLeaderNotificationListWrapper      from '@/components/hr/departmentleader/notification/DepartmentLeaderNotificationListWrapper.vue'
 import { notificationItems, notificationFilters } from '@/mocks/departmentleader/notification'
 
+const router = useRouter()
 const activeFilter = ref('all')
 
 const filterTabItems = computed(() =>
@@ -26,6 +28,16 @@ const filteredItems = computed(() => {
 // BaseNotificationList expects item.type (not item.categoryLabel)
 function toBaseItem(i) {
   return { ...i, type: i.categoryLabel }
+}
+
+function handleClickAction(item) {
+  const routeMap = {
+    kms:    'DLKnowledgeApproval',
+    member: 'TeamCapability',
+    eval:   'DepartmentLeaderDashboardEvaluation',
+  }
+  const routeName = routeMap[item.category]
+  if (routeName) router.push({ name: routeName })
 }
 
 const totalCount  = notificationItems.length
@@ -51,6 +63,7 @@ const urgentCount = computed(() => notificationItems.filter((i) => i.category ==
     <DepartmentLeaderNotificationListWrapper
       :items="filteredItems"
       :page-size="6"
+      @click-action="handleClickAction"
     />
   </section>
 </template>

--- a/src/views/departmentleader/DepartmentLeaderPerformanceView.vue
+++ b/src/views/departmentleader/DepartmentLeaderPerformanceView.vue
@@ -49,7 +49,7 @@ function handleGoEvaluation() {
 <template>
   <div class="dl-performance">
     <header class="dl-performance__header">
-      <h2 class="dl-performance__title">그룹 성과 현황</h2>
+      <h2 class="dl-performance__title">부서 성과 현황</h2>
       <span class="dl-performance__dept-name">{{ performanceSummary.deptName }}</span>
       <span class="dl-performance__period">{{ performanceSummary.period }}</span>
     </header>
@@ -93,15 +93,15 @@ function handleGoEvaluation() {
 }
 
 .dl-performance__title {
-  font-size: 22px;
-  font-weight: 800;
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-extrabold);
   color: var(--color-primary-800);
   margin: 0;
 }
 
 .dl-performance__dept-name {
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-700);
   background: var(--color-primary-50, #f5f4ff);
   border: 1px solid var(--color-primary-200, #d4cfff);
@@ -110,8 +110,8 @@ function handleGoEvaluation() {
 }
 
 .dl-performance__period {
-  font-size: 13px;
-  font-weight: 600;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-text-muted);
   background: var(--color-bg-surface-muted, #f5f4ff);
   border: 1px solid var(--color-border-default);

--- a/src/views/departmentleader/DepartmentLeaderSecondEvaluationView.vue
+++ b/src/views/departmentleader/DepartmentLeaderSecondEvaluationView.vue
@@ -84,8 +84,8 @@ function handleSubmit(evals) {
 }
 
 .dl-eval-view__progress-label {
-  font-size: 13px;
-  font-weight: 600;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-text-muted);
   white-space: nowrap;
 }
@@ -106,16 +106,16 @@ function handleSubmit(evals) {
 }
 
 .dl-eval-view__progress-count {
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-700);
   white-space: nowrap;
 }
 
 .dl-eval-view__deadline {
-  font-size: 13px;
+  font-size: var(--font-size-sm);
   color: #e05a5a;
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   white-space: nowrap;
 }
 


### PR DESCRIPTION
# 작업 정리

  ---
  ## 1. 부서 성과 현황 명칭 변경

  ### 작업 내용

  사이드바 및 페이지 헤더에 표시되던 그룹 성과 현황 명칭을 부서 성과 현황으로 통일

  ### 세부 업무

  - src/components/common/menuConfig.js
    - DL 사이드바 항목 label: '그룹 성과 현황' → '부서 성과 현황'
  - src/views/departmentleader/DepartmentLeaderPerformanceView.vue
    - 페이지 헤더 그룹 성과 현황 → 부서 성과 현황
    
<img width="2508" height="1392" alt="image" src="https://github.com/user-attachments/assets/247d7d92-944b-4ed0-944c-f73325fd8af6" />


  ### 관련 문서 및 레퍼런스

  - src/components/common/menuConfig.js — DL 사이드바 섹션 정의
  - src/views/departmentleader/DepartmentLeaderPerformanceView.vue — 페이지 헤더 템플릿

  ### 기타 참고 사항

  - 라우트명(DepartmentLeaderDashboardPerformance) 및 라우터 경로(/departmentleader/performance)는 변경 없음
  - 컴포넌트 파일명(DLPerformanceSummary, DLPerformanceTable)도 변경 없음

  ---
  ## 2. font-size / font-weight CSS 변수 적용

  ### 작업 내용

  Department Leader 관련 Vue 파일 전체에서 하드코딩된 font-size / font-weight 수치를 variables.css에 정의된 CSS 변수로 교체하여 디자인 토큰 기반 타이포그래피 체계로 통일

  ### 세부 업무

  Views (3개 파일)
  - DepartmentLeaderPerformanceView.vue — 페이지 제목, 부서명 배지, 기간 배지
  - DepartmentLeaderSecondEvaluationView.vue — 진행률 라벨, 완료 카운트, 마감일
  - DepartmentLeaderKnowledgeApprovalView.vue — 통계 카드 라벨 및 수치

  Components (10개 파일)
  - DepartmentLeaderEvalFormPanel.vue — 14항목 (아바타, 이름, 뱃지, AI 추천 박스, 카테고리 입력, 버튼 등)
  - DepartmentLeaderEvalMemberListPanel.vue — 6항목 (타이틀, 아바타, 이름, 티어, 상태, 날짜)
  - DepartmentLeaderCapabilityDetailPanel.vue — 8항목 (이름, 티어 뱃지, 서브텍스트, 점수 수치)
  - DepartmentLeaderMemberListPanel.vue — 10항목 (타이틀, 드롭다운, 검색, 아바타, 이름, 티어)
  - DepartmentLeaderTierTimeline.vue — 4항목 (라벨, 뱃지, 점수, 날짜)
  - DLPerformanceSummary.vue — 9항목 (라벨, 큰 숫자, 단위, 탭, 진행률, 델타)
  - DLPerformanceTable.vue — 21항목 (필터, 테이블 헤더/셀, 모달 전체)
  - DepartmentLeaderNotificationFilterBarWrapper.vue — 1항목 (섹션 제목)
  - DepartmentLeaderGroupKpiCard.vue — 6항목 (점, 타이틀, AI 뱃지, 버튼, 수치)
  - DepartmentLeaderTeamStatusCard.vue — 7항목 (점, 타이틀, 버튼, 아이콘, 이름, 상태 뱃지)

  ### 관련 문서 및 레퍼런스

  - src/assets/styles/variables.css (140–155번 줄) — 변수 정의 원본

  ### 변수 매핑 기준

  ┌────────────────────┬─────────────────────────┐
  │    하드코딩 값     │        적용 변수        │
  ├────────────────────┼─────────────────────────┤
  │ 10px               │ --font-size-2xs         │
  ├────────────────────┼─────────────────────────┤
  │ 11px / 12px        │ --font-size-xs          │
  ├────────────────────┼─────────────────────────┤
  │ 13px               │ --font-size-sm          │
  ├────────────────────┼─────────────────────────┤
  │ 14px               │ --font-size-base        │
  ├────────────────────┼─────────────────────────┤
  │ 15px / 16px        │ --font-size-md          │
  ├────────────────────┼─────────────────────────┤
  │ 18px / 20px        │ --font-size-lg          │
  ├────────────────────┼─────────────────────────┤
  │ 22px / 24px        │ --font-size-xl          │
  ├────────────────────┼─────────────────────────┤
  │ 26px / 28px / 40px │ --font-size-2xl         │
  ├────────────────────┼─────────────────────────┤
  │ 46px / 52px        │ --font-size-display     │
  ├────────────────────┼─────────────────────────┤
  │ 600                │ --font-weight-semibold  │
  ├────────────────────┼─────────────────────────┤
  │ 700                │ --font-weight-bold      │
  ├────────────────────┼─────────────────────────┤
  │ 800                │ --font-weight-extrabold │
  └────────────────────┴─────────────────────────┘

  ### 기타 참고 사항

  - DLGradeDistributionChart.vue, DLTeamComparisonChart.vue는 현재 뷰에서 미사용으로 적용 제외
  - 변수에 정의되지 않은 수치(12px, 17px, 20px, 26px, 40px, 52px)는 인접한 상위/하위 변수로 대체

  ---
  ## 3. 알림 탭 수정

  ### 작업 내용

  Department Leader 알림 화면에 KMS 카테고리 필터 탭 추가 및 카테고리별 보기 버튼 클릭 시 해당 페이지로 이동하는 라우팅 연결

  ### 세부 업무

  KMS 탭 추가
  - src/mocks/departmentleader/notification.js
    - 기존 id:6 항목(임원석 KMS 지식 등록) — category: 'member' → 'kms', categoryLabel: '팀원' → 'KMS', actionLabel: '승인' → '보기'
    - 신규 id:13 항목 추가 — 손창우 KMS 지식 수정 요청, category: 'kms'
    - notificationFilters 배열에 { key: 'kms', label: 'KMS', categoryKey: 'kms' } 추가

  보기 버튼 라우팅 연결
  - src/components/hr/departmentleader/notification/DepartmentLeaderNotificationListWrapper.vue
    - BaseNotificationList의 click-action 이벤트를 상위로 emit 처리
  - src/views/departmentleader/DepartmentLeaderNotificationView.vue
    - useRouter 추가
    - handleClickAction 함수 구현 — 카테고리별 라우트 매핑

  ┌──────┬────────────────┬─────────────────────────────────────┐
  │ 태그 │  이동 페이지   │              라우트명               │
  ├──────┼────────────────┼─────────────────────────────────────┤
  │ KMS  │ KMS 승인       │ DLKnowledgeApproval                 │
  ├──────┼────────────────┼─────────────────────────────────────┤
  │ 팀원 │ 팀원 역량 조회 │ TeamCapability                      │
  ├──────┼────────────────┼─────────────────────────────────────┤
  │ 평가 │ 2차 평가 작성  │ DepartmentLeaderDashboardEvaluation │
  ├──────┼────────────────┼─────────────────────────────────────┤
  │ 설비 │ — (이동 없음)  │ —                                   │
  ├──────┼────────────────┼─────────────────────────────────────┤
  │ 긴급 │ — (이동 없음)  │ —                                   │
  └──────┴────────────────┴─────────────────────────────────────┘

  ### 관련 문서 및 레퍼런스

  - src/mocks/departmentleader/notification.js — 알림 데이터 및 필터 정의
  - src/components/common/base/data-display/BaseNotificationList.vue — click-action emit 구조
  - src/components/common/menuConfig.js — 라우트명 확인 기준

  ### 기타 참고 사항

  - BaseNotificationList는 이미 click-action 이벤트를 emit하는 구조였으나, 래퍼(DepartmentLeaderNotificationListWrapper)가 이를 상위로 전달하지 않아 추가 연결 필요
  - 설비(facility) 태그는 보기 버튼 클릭 시 별도 이동 없음 — 연결 적합한 단일 페이지가 없다고 판단하여 제외