### PR TITLE
worker 컴포넌트 기능 추가 및 수정

### DIFF
--- a/src/components/hr/worker/appeal-request/WorkerAppealForm.vue
+++ b/src/components/hr/worker/appeal-request/WorkerAppealForm.vue
@@ -3,7 +3,10 @@ import { ref, computed, watch } from 'vue'
 
 const props = defineProps({
   appealData: { type: Object, required: true },
+  statusBadge: { type: String, default: null },
 })
+
+const isConfirmed = computed(() => props.statusBadge === '확정')
 
 const emit = defineEmits(['cancel', 'submit'])
 
@@ -56,9 +59,24 @@ const processSteps = computed(() => {
   ]
 })
 
+const showToast = ref(false)
+
 const submitLabel = computed(() => {
   return props.appealData.processStatus >= 1 ? '수정 제출' : '제출'
 })
+
+function handleSubmit() {
+  const payload = {
+    categories: [...checkedCategories.value],
+    content: appealContent.value,
+    attachments: [...attachments.value],
+  }
+  emit('submit', payload)
+  if (props.appealData.processStatus >= 1) {
+    showToast.value = true
+    setTimeout(() => { showToast.value = false }, 2500)
+  }
+}
 </script>
 
 <template>
@@ -103,6 +121,7 @@ const submitLabel = computed(() => {
           <input
             type="checkbox"
             :checked="checkedCategories.includes(cat)"
+            :disabled="isConfirmed"
             @change="toggleCategory(cat)"
           />
           <span>{{ cat }}</span>
@@ -118,6 +137,7 @@ const submitLabel = computed(() => {
         class="af__textarea"
         rows="4"
         placeholder="이의 제기 내용을 입력해주세요."
+        :disabled="isConfirmed"
       ></textarea>
     </div>
 
@@ -128,9 +148,9 @@ const submitLabel = computed(() => {
         <div v-for="(file, i) in attachments" :key="i" class="af__file">
           <span class="af__file-icon">📎</span>
           <span class="af__file-name">{{ file }}</span>
-          <button class="af__file-remove" @click="removeFile(i)">X</button>
+          <button v-if="!isConfirmed" class="af__file-remove" @click="removeFile(i)">X</button>
         </div>
-        <button class="af__file-add" @click="addFile">+ 파일 추가</button>
+        <button v-if="!isConfirmed" class="af__file-add" @click="addFile">+ 파일 추가</button>
       </div>
     </div>
 
@@ -159,16 +179,16 @@ const submitLabel = computed(() => {
     </div>
 
     <!-- Actions -->
-    <div class="af__actions">
+    <div v-if="!isConfirmed" class="af__actions">
       <button class="af__btn af__btn--cancel" @click="emit('cancel')">취소</button>
-      <button class="af__btn af__btn--submit" @click="emit('submit', {
-        categories: checkedCategories,
-        content: appealContent,
-        attachments,
-      })">
+      <button class="af__btn af__btn--submit" @click="handleSubmit">
         {{ submitLabel }}
       </button>
     </div>
+
+    <Transition name="af__toast-fade">
+      <div v-if="showToast" class="af__toast">수정되었습니다</div>
+    </Transition>
   </div>
 </template>
 
@@ -445,5 +465,31 @@ const submitLabel = computed(() => {
 
 .af__btn--submit:hover {
   background: var(--color-primary-700);
+}
+
+.af__toast {
+  position: fixed;
+  bottom: 40px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--color-primary-800);
+  color: var(--color-white);
+  padding: 12px 28px;
+  border-radius: var(--radius-sm);
+  font-size: 14px;
+  font-weight: 600;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  z-index: 9999;
+}
+
+.af__toast-fade-enter-active,
+.af__toast-fade-leave-active {
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.af__toast-fade-enter-from,
+.af__toast-fade-leave-to {
+  opacity: 0;
+  transform: translateX(-50%) translateY(10px);
 }
 </style>

--- a/src/components/hr/worker/evaluation-result/WorkerGrowthFeedback.vue
+++ b/src/components/hr/worker/evaluation-result/WorkerGrowthFeedback.vue
@@ -102,7 +102,7 @@ const chartPoints = computed(() => {
           <div class="gf__goal-values">
             <span class="gf__goal-current">{{ goal.current }}</span>
             <span class="gf__goal-arrow">→</span>
-            <span class="gf__goal-target">{{ goal.target }}</span>
+            <span class="gf__goal-target">{{ String(goal.target).replace('건', '') }}</span>
           </div>
         </div>
       </div>

--- a/src/components/hr/worker/evaluation-result/WorkerQuantitativeEvaluation.vue
+++ b/src/components/hr/worker/evaluation-result/WorkerQuantitativeEvaluation.vue
@@ -1,13 +1,11 @@
 <script setup>
 import { ref } from 'vue'
-import { BaseFilterTabs } from '@/components/common/base'
 
 const props = defineProps({
   evaluation: { type: Object, required: true },
 })
 
-const tabs = ['정량 세부 산식', 'AI 평가 근거 보기']
-const activeTab = ref(tabs[0])
+const showFormula = ref(false)
 
 function isHighlight(val) {
   return val.endsWith('%') || val.endsWith('점')
@@ -36,12 +34,13 @@ function parseLabel(label) {
         <h3 class="qn__title">정량 평가 산출 내역</h3>
         <span class="qn__sub">설비 E_idx 보정 적용 기준</span>
       </div>
-      <BaseFilterTabs
-        v-model="activeTab"
-        :items="tabs"
-        variant="chip"
-        class="qn__tabs"
-      />
+      <button
+        class="qn__toggle"
+        :class="{ 'qn__toggle--active': showFormula }"
+        @click="showFormula = !showFormula"
+      >
+        정량 세부 산식
+      </button>
     </div>
 
     <!-- Formula steps -->
@@ -49,7 +48,7 @@ function parseLabel(label) {
       <div v-for="(step, i) in evaluation.steps" :key="i" class="qn__step">
         <div class="qn__step-label">
           <span class="qn__step-name">{{ parseLabel(step.label).name }}</span>
-          <span v-if="parseLabel(step.label).formula" class="qn__step-formula">
+          <span v-if="showFormula && parseLabel(step.label).formula" class="qn__step-formula">
             {{ parseLabel(step.label).formula }}
           </span>
         </div>
@@ -133,7 +132,19 @@ function parseLabel(label) {
   color: var(--color-text-muted);
 }
 
-.qn__tabs :deep(.base-filter-tabs__item--active) {
+.qn__toggle {
+  padding: 8px 18px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-surface);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text-default);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.qn__toggle--active {
   background: var(--color-primary-800);
   color: var(--color-white);
   border-color: var(--color-primary-800);

--- a/src/mocks/worker/workerKnowledgeHubData.js
+++ b/src/mocks/worker/workerKnowledgeHubData.js
@@ -11,6 +11,16 @@ export const knowledgeStats = {
   myArticlesDiff: 3.1,
 }
 
+export const knowledgeCategories = [
+  { key: 'all', label: '전체' },
+  { key: 'popular', label: '인기' },
+  { key: 'latest', label: '최신' },
+  { key: 'subscribed', label: '내 구독' },
+  { key: '정밀가공', label: '정밀가공' },
+  { key: '설비점검', label: '설비점검' },
+  { key: '품질관리', label: '품질관리' },
+]
+
 export const knowledgeArticles = [
   {
     id: 1,

--- a/src/views/worker/WorkerAppealRequestView.vue
+++ b/src/views/worker/WorkerAppealRequestView.vue
@@ -47,6 +47,12 @@ const selectedAppeal = computed(() => {
   return appealForms.value[selectedId.value] ?? null
 })
 
+const selectedStatus = computed(() => {
+  if (!selectedId.value) return null
+  const item = evalHistory.value.find((h) => h.id === selectedId.value)
+  return item?.statusBadge ?? null
+})
+
 function handleSelect(id) {
   selectedId.value = id
 }
@@ -56,7 +62,13 @@ function handleCancel() {
 }
 
 function handleSubmit(payload) {
-  console.log('Appeal submitted:', payload)
+  if (!selectedId.value) return
+  const form = appealForms.value[selectedId.value]
+  if (form) {
+    form.categories = [...payload.categories]
+    form.content = payload.content
+    form.attachments = [...payload.attachments]
+  }
 }
 </script>
 
@@ -77,6 +89,7 @@ function handleSubmit(payload) {
         <WorkerAppealForm
           v-if="selectedAppeal"
           :appeal-data="selectedAppeal"
+          :status-badge="selectedStatus"
           @cancel="handleCancel"
           @submit="handleSubmit"
         />

--- a/src/views/worker/WorkerKnowledgeHubView.vue
+++ b/src/views/worker/WorkerKnowledgeHubView.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref } from 'vue'
 import WorkerKnowledgeHubContentHeader from '@/components/kms/common/knowledge-hub/worker/WorkerKnowledgeHubContentHeader.vue'
-import WorkerKnowledgeHubFeed from '@/components/kms/common/knowledge-hub/worker/WorkerKnowledgeHubFeed.vue'
+import TeamLeaderKnowledgeHubFeed from '@/components/kms/common/knowledge-hub/teamleader/TeamLeaderKnowledgeHubFeed.vue'
 import WorkerKnowledgeHubMonthlyRank from '@/components/kms/common/knowledge-hub/worker/WorkerKnowledgeHubMonthlyRank.vue'
 import WorkerKnowledgeHubMentoringMatchingStatus from '@/components/kms/common/knowledge-hub/worker/WorkerKnowledgeHubMentoringMatchingStatus.vue'
 import WorkerKnowledgeHubAIRecommendation from '@/components/kms/common/knowledge-hub/worker/WorkerKnowledgeHubAIRecommendation.vue'
@@ -11,6 +11,7 @@ import WorkerKnowledgeAddModal from '@/components/kms/worker/my-knowledge-manage
 
 import {
   knowledgeStats,
+  knowledgeCategories,
   knowledgeArticles,
   monthlyRanking,
   ongoingMentoring,
@@ -71,7 +72,11 @@ function closeModal() {
 
     <!-- Main Grid: Feed (left) + Sidebar (right) -->
     <div class="kh-grid">
-      <WorkerKnowledgeHubFeed :articles="knowledgeArticles" @openAddModal="showAddModal = true" />
+      <TeamLeaderKnowledgeHubFeed
+        :categories="knowledgeCategories"
+        :articles="knowledgeArticles"
+        @open-write="showAddModal = true"
+      />
 
       <div class="kh-sidebar">
         <WorkerKnowledgeHubMonthlyRank :ranking="monthlyRanking" />


### PR DESCRIPTION
# WorkerQuantitativeEvaluation
- AI평가근거보기 버튼 삭제
- 정량세부산식 버튼 활성화, 비활성화 상태로 변경
  - 버튼 활성화 시 qn__step-name, qn__step-formula, qn__step-value 표시
  - 버튼 비활성화 시 qn__step-name, qu__step-value 표시

# WorkerGrowthFeedback
- gf__goal-target "건" text 지우기

# WorkerAppealForm
- "수정제출" 버튼 클릭시 "수정되었습니다" 토스트 메세지 화면에 출력.
- 수정한 내역을 저장.
- 이미 "확정" 상태의 평가 이력 선택시 평가 이력과 의의신청 내역을 표시하는 기능만 남기고 버튼은 모두 없애기.

# WorkerKnowledgeHubFeed
- WorkerKnowledgeHubFeed replace to TeamLeaderKnowledgeHubFeed