### PR TITLE
feat: HR매니저 이의신청 승인 페이지 구현 (#141)

### DIFF
--- a/db.json
+++ b/db.json
@@ -424,6 +424,38 @@
         { "label": "KMS 기여", "score": 72, "tags": ["등록필요"], "barColor": "#FFD166" }
       ],
       "aiAnalysis": "이번 분기 작업 태도와 기술 역량은 전반적으로 우수합니다. 협업 측면에서 동료 피드백 기반 개선 여지가 있으며, KMS 기여 활동 독려가 필요합니다."
+    },
+    {
+      "id": 2,
+      "employee_id": 3,
+      "evaluator": "이팀장",
+      "evaluatorRole": "Team Leader",
+      "nlpConfidence": 0.91,
+      "categories": [
+        { "label": "작업 태도", "score": 86, "tags": ["성실함", "리더십"], "barColor": "#2D1F6E" },
+        { "label": "기술 역량", "score": 88, "tags": ["정밀도↑", "전문성"], "barColor": "#2D1F6E" },
+        { "label": "협업 능력", "score": 85, "tags": ["소통원활"], "barColor": "#2D1F6E" },
+        { "label": "안전 준수", "score": 87, "tags": ["규정준수", "모범적"], "barColor": "#2D1F6E" },
+        { "label": "문제 해결", "score": 84, "tags": ["분석적", "자발적"], "barColor": "#2D1F6E" },
+        { "label": "KMS 기여", "score": 79, "tags": ["문서화필요"], "barColor": "#FFD166" }
+      ],
+      "aiAnalysis": "전반적으로 우수한 성과를 보이고 있습니다. 기술 역량과 안전 준수 면에서 팀 내 상위권을 유지하고 있으며, KMS 기여 활동 보강이 필요합니다."
+    },
+    {
+      "id": 3,
+      "employee_id": 4,
+      "evaluator": "이팀장",
+      "evaluatorRole": "Team Leader",
+      "nlpConfidence": 0.88,
+      "categories": [
+        { "label": "작업 태도", "score": 80, "tags": ["성실함"], "barColor": "#2D1F6E" },
+        { "label": "기술 역량", "score": 79, "tags": ["숙련됨", "개선중"], "barColor": "#FFD166" },
+        { "label": "협업 능력", "score": 83, "tags": ["팀워크"], "barColor": "#2D1F6E" },
+        { "label": "안전 준수", "score": 82, "tags": ["규정준수"], "barColor": "#2D1F6E" },
+        { "label": "문제 해결", "score": 78, "tags": ["개선여지"], "barColor": "#FFD166" },
+        { "label": "KMS 기여", "score": 75, "tags": ["등록필요"], "barColor": "#FFD166" }
+      ],
+      "aiAnalysis": "협업 능력과 안전 준수 측면에서 안정적인 성과를 보이고 있습니다. 기술 역량 향상을 위한 추가 교육 및 KMS 기여 활동 독려가 권장됩니다."
     }
   ],
   "evalHistory": [
@@ -484,6 +516,32 @@
       "attachments": [],
       "processStatus": 0,
       "submittedDate": ""
+    },
+    {
+      "id": 5,
+      "employee_id": 3,
+      "evalHistoryId": null,
+      "quarter": "2026년 1분기",
+      "scores": { "quantitative": 86.2, "qualitative": 84.8, "composite": 85.7, "quantFlagDown": false },
+      "reason": "정성 평가 항목 누락",
+      "categories": ["정성 평가 오류"],
+      "content": "2월 품질 개선 활동(KMS 등록 2건) 내용이 정성 평가에 반영되지 않은 것으로 확인됩니다. 해당 활동 기록을 첨부합니다.",
+      "attachments": ["KMS_Feb_Records.pdf"],
+      "processStatus": 2,
+      "submittedDate": "2026.03.11"
+    },
+    {
+      "id": 6,
+      "employee_id": 4,
+      "evalHistoryId": null,
+      "quarter": "2026년 1분기",
+      "scores": { "quantitative": 80.1, "qualitative": 78.4, "composite": 79.4, "quantFlagDown": true },
+      "reason": "설비 보정 계수 미적용",
+      "categories": ["정량 평가 점수 오류"],
+      "content": "3월 초 MCH-02 설비 점검 기간(3/2~3/5) 동안의 생산량이 보정 없이 그대로 반영되었습니다. 해당 기간 설비 이력 확인을 요청드립니다.",
+      "attachments": ["MCH02_Mar_Maintenance.xlsx"],
+      "processStatus": 2,
+      "submittedDate": "2026.03.13"
     }
   ],
   "growthFeedback": [

--- a/src/components/hr/hrmanager/evaluation-approval/HRMApprovalBanner.vue
+++ b/src/components/hr/hrmanager/evaluation-approval/HRMApprovalBanner.vue
@@ -9,7 +9,7 @@ defineEmits(['bulk-review'])
 <template>
   <div class="hrm-banner">
     <p class="hrm-banner__text">
-      ⏰ 승인 대기 중인 평가가 {{ count }}건 있습니다 — 월말 고과 확정까지 D-{{ daysLeft }}
+      ⏰ 검토 대기 중인 이의신청이 {{ count }}건 있습니다 — 월말 고과 확정까지 D-{{ daysLeft }}
     </p>
     <button class="hrm-banner__btn" @click="$emit('bulk-review')">일괄 검토</button>
   </div>

--- a/src/components/hr/hrmanager/evaluation-approval/HRMApprovalDetail.vue
+++ b/src/components/hr/hrmanager/evaluation-approval/HRMApprovalDetail.vue
@@ -1,6 +1,8 @@
 <script setup>
 defineProps({
-  item: { type: Object, required: true },
+  item:     { type: Object,  required: true },
+  readonly: { type: Boolean, default: false },
+  held:     { type: Boolean, default: false },
 })
 defineEmits(['approve', 'reject', 'hold'])
 </script>
@@ -48,27 +50,41 @@ defineEmits(['approve', 'reject', 'hold'])
       <p class="hrm-ai-box__trust">데이터 신뢰도 {{ item.detail.dataTrust }}</p>
     </div>
 
-    <!-- 라인장 코멘트 -->
-    <div class="hrm-comment-box">
-      <div class="hrm-comment-box__header">
-        <div class="hrm-comment-box__avatar">{{ item.detail.avatar }}</div>
-        <span class="hrm-comment-box__role">라인장 코멘트</span>
-        <span class="hrm-comment-box__date">· {{ item.detail.commentDate }}</span>
+    <!-- 이의신청 내용 -->
+    <div class="hrm-appeal-box">
+      <div class="hrm-appeal-box__row">
+        <span class="hrm-appeal-box__label">대상 분기</span>
+        <span class="hrm-appeal-box__value">{{ item.detail.quarter }}</span>
       </div>
-      <p class="hrm-comment-box__text">"{{ item.detail.comment }}"</p>
-    </div>
-
-    <!-- 이의신청 여부 -->
-    <div class="hrm-objection">
-      <p v-if="!item.detail.objection" class="hrm-objection__none">이의신청 내역 없음</p>
-      <p v-else class="hrm-objection__exists">이의신청 접수됨</p>
+      <div class="hrm-appeal-box__row">
+        <span class="hrm-appeal-box__label">신청 사유</span>
+        <span class="hrm-appeal-box__value hrm-appeal-box__value--reason">{{ item.detail.reason }}</span>
+      </div>
+      <p class="hrm-appeal-box__content">{{ item.detail.content }}</p>
+      <div v-if="item.detail.attachments?.length" class="hrm-appeal-box__attachments">
+        <span v-for="f in item.detail.attachments" :key="f" class="hrm-appeal-attachment">📎 {{ f }}</span>
+      </div>
     </div>
 
     <!-- 액션 버튼 -->
-    <div class="hrm-actions">
+    <div v-if="!readonly && !held" class="hrm-actions">
       <button class="hrm-btn hrm-btn--reject"  @click="$emit('reject')">반려</button>
       <button class="hrm-btn hrm-btn--hold"    @click="$emit('hold')">보류</button>
       <button class="hrm-btn hrm-btn--approve" @click="$emit('approve')">최종 승인</button>
+    </div>
+    <div v-else-if="held" class="hrm-held-actions">
+      <div class="hrm-processed-result" :style="{ background: item.processedBg, color: item.processedColor }">
+        <span class="hrm-processed-result__label">보류 처리됨</span>
+        <span v-if="item.processedReason" class="hrm-processed-result__reason">사유: {{ item.processedReason }}</span>
+      </div>
+      <div class="hrm-actions">
+        <button class="hrm-btn hrm-btn--reject"  @click="$emit('reject')">반려</button>
+        <button class="hrm-btn hrm-btn--approve" @click="$emit('approve')">최종 승인</button>
+      </div>
+    </div>
+    <div v-else class="hrm-processed-result" :style="{ background: item.processedBg, color: item.processedColor }">
+      <span class="hrm-processed-result__label">{{ item.processedLabel }} 처리 완료</span>
+      <span v-if="item.processedReason" class="hrm-processed-result__reason">사유: {{ item.processedReason }}</span>
     </div>
   </article>
 </template>
@@ -123,26 +139,51 @@ defineEmits(['approve', 'reject', 'hold'])
 }
 .hrm-ai-box__trust { font-size: var(--font-size-xs); color: #7a6fa8; }
 
-.hrm-comment-box {
-  padding: 15px; background: var(--color-bg-surface);
-  border: 1.5px solid var(--color-primary-600);
-  border-radius: 4px; display: flex; flex-direction: column; gap: 6px;
+.hrm-appeal-box {
+  padding: 14px 16px;
+  background: #fff8f9;
+  border: 1.5px solid #f5c0cc;
+  border-radius: 8px;
+  display: flex; flex-direction: column; gap: 8px;
 }
-.hrm-comment-box__header { display: flex; align-items: center; gap: 6px; }
-.hrm-comment-box__avatar {
-  width: 24px; height: 24px; background: #1a8060; border-radius: 50%;
-  display: flex; align-items: center; justify-content: center;
-  font-size: var(--font-size-xs); font-weight: var(--font-weight-bold); color: var(--color-white); flex-shrink: 0;
+.hrm-appeal-box__row { display: flex; align-items: baseline; gap: 10px; }
+.hrm-appeal-box__label {
+  font-size: var(--font-size-xs); color: #a89ed8;
+  white-space: nowrap; flex-shrink: 0; min-width: 60px;
 }
-.hrm-comment-box__role,
-.hrm-comment-box__date { font-size: var(--font-size-2xs); color: #a89ed8; }
-.hrm-comment-box__text { font-size: var(--font-size-sm); color: #7a6fa8; line-height: 1.5; }
-
-.hrm-objection { text-align: center; padding: 8px 0; }
-.hrm-objection__none   { font-size: var(--font-size-xs); color: #a89ed8; }
-.hrm-objection__exists { font-size: var(--font-size-xs); color: #c0103e; font-weight: var(--font-weight-bold); }
+.hrm-appeal-box__value { font-size: var(--font-size-sm); color: var(--color-primary-800); }
+.hrm-appeal-box__value--reason { font-weight: var(--font-weight-bold); color: #c0103e; }
+.hrm-appeal-box__content {
+  font-size: var(--font-size-sm); color: #7a6fa8;
+  line-height: 1.6; padding-top: 4px;
+  border-top: 1px solid #f5c0cc;
+}
+.hrm-appeal-box__attachments { display: flex; flex-wrap: wrap; gap: 6px; }
+.hrm-appeal-attachment {
+  display: inline-block; padding: 2px 8px; height: 20px;
+  background: #fee2e2; color: #991b1b;
+  font-size: var(--font-size-2xs); font-weight: var(--font-weight-bold);
+  border-radius: 3px; line-height: 16px;
+}
 
 .hrm-actions { display: flex; justify-content: flex-end; gap: 8px; }
+
+.hrm-held-actions { display: flex; flex-direction: column; gap: 10px; }
+.hrm-processed-result {
+  padding: 12px 16px;
+  border-radius: 8px;
+  display: flex; flex-direction: column; gap: 4px;
+}
+.hrm-processed-result__label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+  text-align: center;
+}
+.hrm-processed-result__reason {
+  font-size: var(--font-size-xs);
+  opacity: 0.8;
+  text-align: center;
+}
 .hrm-btn {
   height: 40px; padding: 0 16px; border-radius: 4px;
   font-size: var(--font-size-sm); font-weight: var(--font-weight-bold); cursor: pointer; border: 1.5px solid transparent;

--- a/src/components/hr/hrmanager/evaluation-approval/HRMApprovalList.vue
+++ b/src/components/hr/hrmanager/evaluation-approval/HRMApprovalList.vue
@@ -2,18 +2,24 @@
 import BaseFilterTabs from '@/components/common/base/navigation/BaseFilterTabs.vue'
 
 defineProps({
-  list: { type: Array, required: true },
-  total: { type: Number, required: true },
-  tabs: { type: Array, required: true },
-  activeTab: { type: String, required: true },
-  selectedId: { default: null },
+  list:           { type: Array,  required: true },
+  pendingCount:   { type: Number, required: true },
+  heldCount:      { type: Number, default: 0 },
+  processedCount: { type: Number, default: 0 },
+  tabs:           { type: Array,  required: true },
+  activeTab:      { type: String, required: true },
+  selectedId:     { default: null },
 })
 defineEmits(['tab-change', 'select'])
 </script>
 
 <template>
   <article class="hrm-panel">
-    <p class="hrm-panel__header">📋 승인 대기 ({{ total }}건)</p>
+    <p class="hrm-panel__header">
+      <template v-if="activeTab === '처리 완료'">✅ 처리 완료 ({{ processedCount }}건)</template>
+      <template v-else-if="activeTab === '보류'">⏳ 보류 ({{ heldCount }}건)</template>
+      <template v-else>📋 이의신청 검토 대기 ({{ pendingCount }}건)</template>
+    </p>
 
     <BaseFilterTabs
       :items="tabs"
@@ -38,6 +44,7 @@ defineEmits(['tab-change', 'select'])
             <span class="hrm-badge" :style="{ background: item.typeBg, color: item.typeColor }">{{ item.type }}</span>
             <span class="hrm-list-item__name">{{ item.name }}</span>
             <span class="hrm-grade" :style="{ background: item.gradeBg, color: item.gradeColor }">{{ item.grade }}</span>
+            <span v-if="item.processedLabel" class="hrm-processed-badge" :style="{ background: item.processedBg, color: item.processedColor }">{{ item.processedLabel }}</span>
           </div>
           <p class="hrm-list-item__desc">{{ item.desc }}</p>
           <p class="hrm-list-item__date">{{ item.date }}</p>
@@ -95,4 +102,9 @@ defineEmits(['tab-change', 'select'])
   border-radius: 7px; flex-shrink: 0;
 }
 .hrm-list-item__check--filled { background: var(--color-primary-600); border-color: var(--color-primary-600); }
+
+.hrm-processed-badge {
+  display: inline-flex; align-items: center; height: 14px; padding: 0 7px;
+  border-radius: 3px; font-size: var(--font-size-2xs); font-weight: 900;
+}
 </style>

--- a/src/views/hrmanager/HRMApprovalView.vue
+++ b/src/views/hrmanager/HRMApprovalView.vue
@@ -1,9 +1,10 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
-import { API_BASE, SCORE_WEIGHT_QUANT, SCORE_WEIGHT_QUAL, GRADE_THRESHOLDS, AI_TAG_LIMIT, TYPE_STYLE, GRADE_STYLE, EVAL_TYPE_LABEL, scoreToGrade } from '@/constants'
-import HRMApprovalBanner from '@/components/hr/hrmanager/evaluation-approval/HRMApprovalBanner.vue'
-import HRMApprovalList   from '@/components/hr/hrmanager/evaluation-approval/HRMApprovalList.vue'
-import HRMApprovalDetail from '@/components/hr/hrmanager/evaluation-approval/HRMApprovalDetail.vue'
+import { API_BASE, AI_TAG_LIMIT, TYPE_STYLE, GRADE_STYLE, EVAL_TYPE_LABEL, scoreToGrade } from '@/constants'
+import HRMApprovalBanner  from '@/components/hr/hrmanager/evaluation-approval/HRMApprovalBanner.vue'
+import HRMApprovalList    from '@/components/hr/hrmanager/evaluation-approval/HRMApprovalList.vue'
+import HRMApprovalDetail  from '@/components/hr/hrmanager/evaluation-approval/HRMApprovalDetail.vue'
+import BaseConfirmModal   from '@/components/common/base/overlay/BaseConfirmModal.vue'
 
 // ── 유틸 함수 ─────────────────────────────────────────────────────
 function gradeStyle(grade) {
@@ -37,107 +38,37 @@ function extractAiTags(categories) {
 }
 
 // ── 상태 ──────────────────────────────────────────────────────────
-const approvalList = ref([])
-const loading      = ref(true)
-const error        = ref(null)
-const activeTab    = ref('전체')
-const tabs         = ['전체', '승급신청', '정기평가', '이의신청']
-const selectedId   = ref(null)
+const approvalList   = ref([])
+const heldList       = ref([])
+const processedList  = ref([])
+const loading        = ref(true)
+const error          = ref(null)
+const activeTab      = ref('대기중')
+const tabs           = ['대기중', '보류', '처리 완료']
+const selectedId     = ref(null)
+
+const PROCESSED_STATUS_STYLE = {
+  approve: { label: '승인', bg: '#d1fae5', color: '#065f46' },
+  reject:  { label: '반려', bg: '#fee2e2', color: '#991b1b' },
+  hold:    { label: '보류', bg: '#fef3c7', color: '#92400e' },
+}
 
 // ── 데이터 로딩 ───────────────────────────────────────────────────
 onMounted(async () => {
   try {
     const fetchJson = url => fetch(url).then(r => r.json())
-    const [empData, qualData, quantData, teamData, appealData, promotionData] = await Promise.all([
+    const [empData, qualData, teamData, appealData] = await Promise.all([
       fetchJson(`${API_BASE}/employees`),
       fetchJson(`${API_BASE}/qualitativeEval`),
-      fetchJson(`${API_BASE}/quantitativeEval`),
       fetchJson(`${API_BASE}/teamStats`),
       fetchJson(`${API_BASE}/appealForms`),
-      fetchJson(`${API_BASE}/tierPromotions`),
     ])
 
-    const result = []
+    // processStatus === 2 : HRM 검토 대기 중인 이의신청만
+    const pending = appealData.filter(a => a.processStatus === 2)
+    const result  = []
 
-    // 1. 정기평가
-    for (const qual of qualData) {
-      const emp   = empData.find(e => e.employee_id === qual.employee_id)
-      if (!emp) continue
-      const team  = teamData.find(t => t.id === emp.team_id)
-      const quant = quantData.find(q => q.employee_id === emp.employee_id)
-
-      const qualScore  = calcQualScore(qual.categories)
-      const quantScore = quant ? calcQuantScore(quant.steps) : null
-      const totalScore = calcTotalScore(quantScore, qualScore)
-      const grade      = emp.employee_current_tier ?? scoreToGrade(parseFloat(totalScore))
-
-      result.push({
-        id: `qual-${qual.id}`,
-        type: '정기평가',
-        ...TYPE_STYLE['정기평가'],
-        name: emp.employee_name,
-        grade,
-        ...gradeStyle(grade),
-        desc: '2026년 1분기',
-        date: '03.10',
-        detail: {
-          avatar: emp.employee_name[0],
-          dept: team?.team ?? '-',
-          evalType: EVAL_TYPE_LABEL['정기평가'],
-          quantScore: quantScore != null ? quantScore.toFixed(1) : '-',
-          qualScore: qualScore.toFixed(1),
-          totalScore,
-          quantDiff: '', qualDiff: '', totalDiff: '',
-          aiTags: extractAiTags(qual.categories),
-          dataTrust: `${(qual.nlpConfidence * 100).toFixed(0)}%`,
-          comment: qual.aiAnalysis,
-          commentDate: '2026.03.10',
-          objection: appealData.some(a => a.employee_id === emp.employee_id),
-        },
-      })
-    }
-
-    // 2. 승급신청
-    for (const promo of promotionData) {
-      const emp   = empData.find(e => e.employee_id === promo.employee_id)
-      if (!emp) continue
-      const team  = teamData.find(t => t.id === emp.team_id)
-      const qual  = qualData.find(q => q.employee_id === promo.employee_id)
-      const quant = quantData.find(q => q.employee_id === promo.employee_id)
-      const grade = `${promo.current_tier}→${promo.target_tier}`
-
-      const qualScore  = qual  ? calcQualScore(qual.categories)    : null
-      const quantScore = quant ? calcQuantScore(quant.steps)       : null
-      const totalScore = calcTotalScore(quantScore, qualScore)
-
-      result.push({
-        id: `promo-${promo.tier_promotion_id}`,
-        type: '승급신청',
-        ...TYPE_STYLE['승급신청'],
-        name: emp.employee_name,
-        grade,
-        ...gradeStyle(grade),
-        desc: `누적 포인트 ${promo.tier_accumulated_point}점`,
-        date: shortDate(promo.created_at?.slice(0, 10).replace(/-/g, '.')),
-        detail: {
-          avatar: emp.employee_name[0],
-          dept: team?.team ?? '-',
-          evalType: EVAL_TYPE_LABEL['승급신청'],
-          quantScore: quantScore != null ? quantScore.toFixed(1) : '-',
-          qualScore:  qualScore  != null ? qualScore.toFixed(1)  : '-',
-          totalScore,
-          quantDiff: '', qualDiff: '', totalDiff: '',
-          aiTags: qual ? extractAiTags(qual.categories) : [],
-          dataTrust: qual ? `${(qual.nlpConfidence * 100).toFixed(0)}%` : '-',
-          comment: qual?.aiAnalysis ?? '코멘트 없음',
-          commentDate: promo.created_at?.slice(0, 10).replace(/-/g, '.') ?? '-',
-          objection: false,
-        },
-      })
-    }
-
-    // 3. 이의신청
-    for (const appeal of appealData) {
+    for (const appeal of pending) {
       const emp  = empData.find(e => e.employee_id === appeal.employee_id)
       if (!emp) continue
       const team = teamData.find(t => t.id === emp.team_id)
@@ -161,15 +92,16 @@ onMounted(async () => {
           avatar: emp.employee_name[0],
           dept: team?.team ?? '-',
           evalType: EVAL_TYPE_LABEL['이의신청'],
+          quarter: appeal.quarter,
+          reason: appeal.reason || '사유 없음',
+          content: appeal.content || '내용 없음',
+          attachments: appeal.attachments ?? [],
           quantScore: appeal.scores.quantitative.toFixed(1),
           qualScore:  appeal.scores.qualitative.toFixed(1),
           totalScore: appeal.scores.composite.toFixed(1),
-          quantDiff: '', qualDiff: '', totalDiff: '',
           aiTags,
           dataTrust: qual ? `${(qual.nlpConfidence * 100).toFixed(0)}%` : '-',
-          comment: appeal.content || '내용 없음',
-          commentDate: appeal.submittedDate || '-',
-          objection: true,
+          aiAnalysis: qual?.aiAnalysis ?? '',
         },
       })
     }
@@ -186,18 +118,104 @@ onMounted(async () => {
 
 // ── computed ──────────────────────────────────────────────────────
 const filteredList = computed(() => {
-  if (activeTab.value === '전체') return approvalList.value
-  return approvalList.value.filter(item => item.type === activeTab.value)
+  if (activeTab.value === '처리 완료') return processedList.value
+  if (activeTab.value === '보류')      return heldList.value
+  return approvalList.value
 })
 
 const selectedItem = computed(() =>
-  approvalList.value.find(item => item.id === selectedId.value)
+  approvalList.value.find(item => item.id === selectedId.value) ??
+  heldList.value.find(item => item.id === selectedId.value) ??
+  processedList.value.find(item => item.id === selectedId.value)
 )
 
+const isSelectedProcessed = computed(() =>
+  processedList.value.some(item => item.id === selectedId.value)
+)
+
+const isSelectedHeld = computed(() =>
+  heldList.value.some(item => item.id === selectedId.value)
+)
+
+const isConfirmDisabled = computed(() =>
+  confirmModal.value.action !== 'approve' && !confirmReason.value.trim()
+)
+
+// ── 확인 모달 / 토스트 상태 ───────────────────────────────────────
+const confirmModal  = ref({ show: false, action: null, title: '', message: '', confirmText: '' })
+const confirmReason = ref('')
+const toast         = ref({ show: false, message: '' })
+let toastTimer = null
+
+const ACTION_CONFIG = {
+  approve: { title: '최종 승인', message: '해당 평가를 최종 승인하시겠습니까?',  confirmText: '승인', toastMsg: '승인되었습니다.' },
+  reject:  { title: '반려',     message: '해당 평가를 반려 처리하시겠습니까?',  confirmText: '반려', toastMsg: '반려되었습니다.' },
+  hold:    { title: '보류',     message: '해당 평가를 보류 처리하시겠습니까?',  confirmText: '보류', toastMsg: '보류되었습니다.' },
+}
+
 // ── 액션 핸들러 ───────────────────────────────────────────────────
-function handleApprove() { alert(`${selectedItem.value.name} 승인 완료`) }
-function handleReject()  { alert(`${selectedItem.value.name} 반려`) }
-function handleHold()    { alert(`${selectedItem.value.name} 보류`) }
+function handleApprove() { openConfirm('approve') }
+function handleReject()  { openConfirm('reject') }
+function handleHold()    { openConfirm('hold') }
+
+function openConfirm(action) {
+  const cfg = ACTION_CONFIG[action]
+  confirmReason.value = ''
+  confirmModal.value = {
+    show: true, action,
+    title: cfg.title,
+    message: `${selectedItem.value.name}님 — ${cfg.message}`,
+    confirmText: cfg.confirmText,
+  }
+}
+
+function handleConfirm() {
+  const { action } = confirmModal.value
+  const name  = selectedItem.value.name
+  const style = PROCESSED_STATUS_STYLE[action]
+
+  // source 목록을 추가 전에 먼저 확정
+  const sourceList = heldList.value.some(i => i.id === selectedId.value)
+    ? heldList.value
+    : approvalList.value
+
+  if (action === 'hold') {
+    heldList.value.unshift({
+      ...selectedItem.value,
+      processedStatus: 'hold',
+      processedLabel:  style.label,
+      processedBg:     style.bg,
+      processedColor:  style.color,
+      processedReason: confirmReason.value.trim() || null,
+    })
+  } else {
+    processedList.value.unshift({
+      ...selectedItem.value,
+      processedStatus: action,
+      processedLabel:  style.label,
+      processedBg:     style.bg,
+      processedColor:  style.color,
+      processedReason: confirmReason.value.trim() || null,
+    })
+  }
+
+  confirmModal.value.show = false
+  removeAndSelectNext(sourceList)
+  showToast(`${name}님의 평가가 ${ACTION_CONFIG[action].toastMsg}`)
+}
+
+function removeAndSelectNext(sourceList) {
+  const idx  = sourceList.findIndex(i => i.id === selectedId.value)
+  sourceList.splice(idx, 1)
+  const next = sourceList[idx] ?? sourceList[idx - 1]
+  selectedId.value = next?.id ?? null
+}
+
+function showToast(message) {
+  if (toastTimer) clearTimeout(toastTimer)
+  toast.value = { show: true, message }
+  toastTimer = setTimeout(() => { toast.value.show = false }, 2500)
+}
 </script>
 
 <template>
@@ -210,16 +228,20 @@ function handleHold()    { alert(`${selectedItem.value.name} 보류`) }
       <div class="hrm-approval__content">
         <HRMApprovalList
           :list="filteredList"
-          :total="approvalList.length"
+          :pending-count="approvalList.length"
+          :held-count="heldList.length"
+          :processed-count="processedList.length"
           :tabs="tabs"
           :active-tab="activeTab"
           :selected-id="selectedId"
-          @tab-change="activeTab = $event"
+          @tab-change="tab => { activeTab = tab; selectedId = filteredList[0]?.id ?? null }"
           @select="selectedId = $event"
         />
         <HRMApprovalDetail
           v-if="selectedItem"
           :item="selectedItem"
+          :readonly="isSelectedProcessed"
+          :held="isSelectedHeld"
           @approve="handleApprove"
           @reject="handleReject"
           @hold="handleHold"
@@ -227,6 +249,40 @@ function handleHold()    { alert(`${selectedItem.value.name} 보류`) }
       </div>
     </template>
   </div>
+
+  <!-- 확인 모달 -->
+  <BaseConfirmModal
+    v-if="confirmModal.show"
+    :title="confirmModal.title"
+    :confirm-text="confirmModal.confirmText"
+    :confirm-disabled="isConfirmDisabled"
+    cancel-text="취소"
+    width="440px"
+    @cancel="confirmModal.show = false; confirmReason = ''"
+    @close="confirmModal.show = false; confirmReason = ''"
+    @confirm="handleConfirm"
+  >
+    <p class="hrm-confirm-message">{{ confirmModal.message }}</p>
+    <div v-if="confirmModal.action !== 'approve'" class="hrm-confirm-reason">
+      <label class="hrm-confirm-reason__label">
+        처리 사유 <span class="hrm-confirm-reason__required">*필수</span>
+      </label>
+      <textarea
+        v-model="confirmReason"
+        class="hrm-confirm-reason__input"
+        placeholder="사유를 입력해주세요"
+        rows="3"
+      />
+    </div>
+  </BaseConfirmModal>
+
+  <!-- 토스트 -->
+  <Transition name="hrm-toast">
+    <div v-if="toast.show" class="hrm-toast">
+      <span class="hrm-toast__icon">✓</span>
+      {{ toast.message }}
+    </div>
+  </Transition>
 </template>
 
 <style scoped>
@@ -243,4 +299,70 @@ function handleHold()    { alert(`${selectedItem.value.name} 보류`) }
 .hrm-approval__loading { color: #a89ed8; font-size: var(--font-size-base); }
 .hrm-approval__error   { color: var(--color-danger); font-size: var(--font-size-base); }
 .hrm-approval__content { display: flex; gap: 16px; align-items: flex-start; flex: 1; min-height: 0; }
+
+.hrm-confirm-message {
+  font-size: var(--font-size-base);
+  color: var(--color-primary-800);
+  line-height: 1.6;
+  padding: 8px 0;
+}
+
+.hrm-confirm-reason { display: flex; flex-direction: column; gap: 6px; }
+.hrm-confirm-reason__label {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary-800);
+}
+.hrm-confirm-reason__required { color: var(--color-danger); margin-left: 4px; }
+.hrm-confirm-reason__input {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1.5px solid var(--color-border-default);
+  border-radius: 8px;
+  font-size: var(--font-size-sm);
+  color: var(--color-primary-800);
+  background: var(--color-bg-app);
+  resize: none;
+  line-height: 1.5;
+  box-sizing: border-box;
+  font-family: inherit;
+}
+.hrm-confirm-reason__input:focus {
+  outline: none;
+  border-color: var(--color-primary-600);
+}
+
+.hrm-toast {
+  position: fixed;
+  bottom: 32px;
+  right: 32px;
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 20px;
+  background: var(--color-primary-700);
+  color: #fff;
+  border-radius: 10px;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+  box-shadow: 0 8px 24px rgba(20, 15, 60, 0.2);
+  pointer-events: none;
+}
+.hrm-toast__icon {
+  width: 20px;
+  height: 20px;
+  background: rgba(255,255,255,0.25);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+.hrm-toast-enter-active,
+.hrm-toast-leave-active { transition: all 0.25s ease; }
+.hrm-toast-enter-from   { opacity: 0; transform: translateY(12px); }
+.hrm-toast-leave-to     { opacity: 0; transform: translateY(12px); }
 </style>


### PR DESCRIPTION
## 변경 사항
  - 이의신청 전용 페이지로 전환 (승급신청·정기평가 제거)
  - 탭 구조 개편 — `대기중 / 보류 / 처리 완료`
  - 승인·반려·보류 확인 모달 + 토스트 알림
  - 반려·보류 사유 필수 입력 (미입력 시 버튼 비활성화)
  - 보류 탭에서 재처리(승인/반려) 가능
  - 이의신청 상세 UI 개편 (분기·사유·내용·첨부파일)
  - db.json mock 데이터 보강 (기존 데이터 무수정)

  ## 테스트 방법
  1. HR매니저 계정으로 로그인
  2. 이의신청 승인 페이지 진입
  3. 반려·보류 시 사유 입력 모달 확인
  4. 보류 탭에서 재처리 동작 확인
  5. 처리 완료 탭에서 결과 및 사유 확인

  Closes #141