### PR TITLE
[Refactor] HR매니저 - 이의신청 검토 및 승급심사 UI/UX 개선(#145)

### DIFF
--- a/src/components/hr/hrmanager/kpi-report/HRMKpiTeamBarChart.vue
+++ b/src/components/hr/hrmanager/kpi-report/HRMKpiTeamBarChart.vue
@@ -47,7 +47,7 @@ function buildChart() {
         data: props.data.map(d => d.score),
         backgroundColor: props.data.map((_, i) => colors[i] ?? colors[colors.length - 1]),
         borderRadius: 6,
-        barThickness: 28,
+        barThickness: 36,
       }],
     },
     options: {
@@ -60,7 +60,7 @@ function buildChart() {
         tooltip: { callbacks: { label: ctx => ` ${ctx.parsed.x}점` } },
       },
       scales: {
-        x: { display: false, min: 70, max: 100 },
+        x: { display: false, min: 0, max: 100 },
         y: {
           grid: { display: false },
           ticks: { color: '#7c739f', font: { size: 12 } },
@@ -111,7 +111,7 @@ onBeforeUnmount(() => chartInstance?.destroy())
   color: var(--color-primary-500);
 }
 .kpi-bar-card__chart {
-  height: 200px;
+  height: 260px;
   position: relative;
 }
 </style>

--- a/src/components/hr/hrmanager/kpi-report/HRMKpiTierTrendChart.vue
+++ b/src/components/hr/hrmanager/kpi-report/HRMKpiTierTrendChart.vue
@@ -116,7 +116,8 @@ onBeforeUnmount(() => chartInstance?.destroy())
   color: var(--color-primary-500);
 }
 .kpi-trend-card__chart {
-  height: 180px;
+  flex: 1;
+  min-height: 180px;
   position: relative;
 }
 </style>

--- a/src/components/hr/hrmanager/promotion-review/HRMPromotionList.vue
+++ b/src/components/hr/hrmanager/promotion-review/HRMPromotionList.vue
@@ -42,7 +42,7 @@ function resultStyle(result) {
           <th>미달항목</th>
           <th>성장추이</th>
           <th>예상결과</th>
-          <th>액션</th>
+          <th>처리결과</th>
         </tr>
       </thead>
       <tbody>
@@ -85,26 +85,22 @@ function resultStyle(result) {
             </span>
           </td>
           <td>
-            <button
-              v-if="item.result === '승급 확정'"
-              class="promo-table__btn promo-table__btn--confirm"
-              @click.stop="$emit('confirm', item.id)"
-            >확정처리</button>
-            <button
-              v-else
-              class="promo-table__btn promo-table__btn--detail"
-              @click.stop="$emit('select', item.id)"
-            >상세보기</button>
+            <span
+              class="promo-table__process"
+              :class="{
+                'promo-table__process--confirm': item.processedStatus === 'confirm',
+                'promo-table__process--hold':    item.processedStatus === 'hold',
+                'promo-table__process--none':    !item.processedStatus,
+              }"
+            >
+              {{ item.processedStatus === 'confirm' ? '승급확정' : item.processedStatus === 'hold' ? '보류' : '미처리' }}
+            </span>
           </td>
         </tr>
       </tbody>
     </table>
 
     <div class="promo-list__actions">
-      <button class="promo-list__btn promo-list__btn--confirm">
-        승급 확정 ({{ list.filter(i => i.result === '승급 확정').length }}명)
-      </button>
-      <button class="promo-list__btn promo-list__btn--hold">일괄 보류</button>
       <button class="promo-list__btn promo-list__btn--excel">Excel 내보내기</button>
     </div>
   </article>
@@ -210,25 +206,19 @@ function resultStyle(result) {
   font-weight: var(--font-weight-bold);
   white-space: nowrap;
 }
-.promo-table__btn {
-  height: 24px;
+.promo-table__process {
+  display: inline-flex;
+  align-items: center;
+  height: 22px;
   padding: 0 10px;
   border-radius: 6px;
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-xs);
   font-weight: var(--font-weight-bold);
-  cursor: pointer;
-  border: none;
   white-space: nowrap;
 }
-.promo-table__btn--confirm {
-  background: var(--color-mint-500);
-  color: #fff;
-}
-.promo-table__btn--detail {
-  background: var(--color-bg-app);
-  color: var(--color-primary-600);
-  border: 1px solid var(--color-border-default);
-}
+.promo-table__process--none    { background: var(--color-bg-app);  color: #a89ed8; border: 1px solid var(--color-border-default); }
+.promo-table__process--confirm { background: #e3fbef; color: #007a60; border: 1px solid var(--color-mint-500); }
+.promo-table__process--hold    { background: #fef3c7; color: #92400e; border: 1px solid #fbbf24; }
 
 /* 하단 액션 */
 .promo-list__actions {
@@ -245,15 +235,6 @@ function resultStyle(result) {
   font-weight: var(--font-weight-bold);
   cursor: pointer;
   border: none;
-}
-.promo-list__btn--confirm {
-  background: var(--color-mint-500);
-  color: #fff;
-}
-.promo-list__btn--hold {
-  background: var(--color-bg-app);
-  color: var(--color-primary-600);
-  border: 1.5px solid var(--color-border-default);
 }
 .promo-list__btn--excel {
   background: var(--color-bg-app);

--- a/src/views/hrmanager/HRMPromotionReviewView.vue
+++ b/src/views/hrmanager/HRMPromotionReviewView.vue
@@ -1,9 +1,10 @@
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { API_BASE } from '@/constants'
 import BaseStatCard        from '@/components/common/base/display/BaseStatCard.vue'
 import HRMPromotionList    from '@/components/hr/hrmanager/promotion-review/HRMPromotionList.vue'
 import HRMPromotionDetail  from '@/components/hr/hrmanager/promotion-review/HRMPromotionDetail.vue'
+import BaseConfirmModal    from '@/components/common/base/overlay/BaseConfirmModal.vue'
 
 const loading    = ref(true)
 const summary    = ref(null)
@@ -49,13 +50,43 @@ onMounted(async () => {
   }
 })
 
-function handleHold(id) {
-  alert(`${candidates.value.find(c => c.id === id)?.name} 보류 처리`)
+// ── 확인 모달 / 토스트 ────────────────────────────────────────────
+const confirmModal   = ref({ show: false, action: null, targetId: null, title: '', message: '', confirmText: '' })
+const confirmOpinion = ref('')
+const isConfirmDisabled = computed(() => !confirmOpinion.value.trim())
+const toast          = ref({ show: false, message: '' })
+let toastTimer = null
+
+watch(() => confirmModal.value.show, show => { if (!show) confirmOpinion.value = '' })
+
+function openConfirm(action, id) {
+  const candidate = candidates.value.find(c => c.id === id)
+  const { name, currentTier, targetTier } = candidate
+  const config = {
+    hold:    { title: '보류',     message: `${name}님의 승급 심사를 보류하시겠습니까?`,  confirmText: '보류' },
+    confirm: { title: '승급 확정', message: `${name}님을 ${currentTier}-Tier에서 ${targetTier}-Tier로 승급 확정하시겠습니까?`, confirmText: '확정' },
+  }[action]
+  confirmModal.value = { show: true, action, targetId: id, ...config }
 }
 
-function handleConfirm(id) {
-  alert(`${candidates.value.find(c => c.id === id)?.name} 승급 확정`)
+function handleModalConfirm() {
+  const { action, targetId } = confirmModal.value
+  const candidate = candidates.value.find(c => c.id === targetId)
+  const name = candidate?.name
+  if (candidate) candidate.processedStatus = action
+  confirmModal.value.show = false
+  const msg = action === 'confirm' ? `${name}님 승급이 확정되었습니다.` : `${name}님이 보류 처리되었습니다.`
+  showToast(msg)
 }
+
+function showToast(message) {
+  if (toastTimer) clearTimeout(toastTimer)
+  toast.value = { show: true, message }
+  toastTimer = setTimeout(() => { toast.value.show = false }, 2500)
+}
+
+function handleHold(id)    { openConfirm('hold', id) }
+function handleConfirm(id) { openConfirm('confirm', id) }
 </script>
 
 <template>
@@ -110,6 +141,36 @@ function handleConfirm(id) {
       </div>
     </template>
   </section>
+
+  <BaseConfirmModal
+    v-if="confirmModal.show"
+    :title="confirmModal.title"
+    :confirm-text="confirmModal.confirmText"
+    :confirm-disabled="isConfirmDisabled"
+    cancel-text="취소"
+    width="420px"
+    @cancel="confirmModal.show = false"
+    @close="confirmModal.show = false"
+    @confirm="handleModalConfirm"
+  >
+    <p class="promo-confirm-message">{{ confirmModal.message }}</p>
+    <div class="promo-opinion-wrap">
+      <label class="promo-opinion-label">심사의견 <span class="promo-opinion-required">*</span></label>
+      <textarea
+        v-model="confirmOpinion"
+        class="promo-opinion-textarea"
+        placeholder="심사의견을 입력하세요 (필수)"
+        rows="3"
+      />
+    </div>
+  </BaseConfirmModal>
+
+  <Transition name="promo-toast">
+    <div v-if="toast.show" class="promo-toast">
+      <span class="promo-toast__icon">✓</span>
+      {{ toast.message }}
+    </div>
+  </Transition>
 </template>
 
 <style scoped>
@@ -141,4 +202,75 @@ function handleConfirm(id) {
   flex: 1;
   min-height: 0;
 }
+
+.promo-confirm-message {
+  font-size: var(--font-size-base);
+  color: var(--color-primary-800);
+  line-height: 1.6;
+  padding: 8px 0;
+}
+.promo-opinion-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 4px;
+}
+.promo-opinion-label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary-700);
+}
+.promo-opinion-required {
+  color: var(--color-danger);
+}
+.promo-opinion-textarea {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1.5px solid var(--color-border-default);
+  border-radius: 8px;
+  font-size: var(--font-size-sm);
+  color: var(--color-primary-800);
+  background: var(--color-bg-app);
+  resize: none;
+  outline: none;
+  box-sizing: border-box;
+  transition: border-color 0.2s;
+}
+.promo-opinion-textarea:focus {
+  outline: none;
+  border-color: var(--color-border-default);
+}
+
+.promo-toast {
+  position: fixed;
+  bottom: 32px;
+  right: 32px;
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 20px;
+  background: var(--color-mint-500);
+  color: #fff;
+  border-radius: 10px;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+  box-shadow: 0 8px 24px rgba(20, 15, 60, 0.2);
+  pointer-events: none;
+}
+.promo-toast__icon {
+  width: 20px;
+  height: 20px;
+  background: rgba(255,255,255,0.25);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+.promo-toast-enter-active,
+.promo-toast-leave-active { transition: all 0.25s ease; }
+.promo-toast-enter-from   { opacity: 0; transform: translateY(12px); }
+.promo-toast-leave-to     { opacity: 0; transform: translateY(12px); }
 </style>


### PR DESCRIPTION
## 📋 변경 사항                                                                                                                                                                                                          
  - HRMApprovalView 이의신청 전용 리팩토링 (탭: 대기중 / 보류 / 처리 완료)                                                                                                                                                 
  - 반려/보류/승인 처리 시 확인 모달 + 토스트 알림 추가                   
  - 반려/보류 사유 필수 입력, 심사의견 필수 입력 (미입력 시 버튼 비활성화)                                                                                                                                                 
  - 보류 항목 별도 탭 관리 및 재처리 기능                                                                                                                                                                                  
  - 처리결과 컬럼 배지(미처리 / 보류 / 승급확정)로 변경                                                                                                                                                                    
  - 일괄 확정/보류 버튼 및 체크박스 제거                                                                                                                                                                                   
  - KPI 바차트 두께·x축 조정, TIER 분포 차트 높이 자동 조정                                                                                                                                                                
  - db.json 이의신청 mock 데이터 추가 (id: 5, 6)               

Closes #145