### PR TITLE
fix(layout): 헤더·사이드바 고정 및 라우트 이동 시 스크롤 초기화

### DIFF
--- a/src/components/common/AdminSidebar.vue
+++ b/src/components/common/AdminSidebar.vue
@@ -38,10 +38,19 @@ function isActive(target) {
   padding: 18px 14px 28px;
   border-right: 1px solid var(--color-border-soft);
   background: var(--color-bg-surface);
+  position: fixed;
+  left: 0;
+  top: 80px;
+  height: calc(100vh - 80px);
+  overflow-y: auto;
+  z-index: 99;
 }
 
 .admin-sidebar__section {
-  margin-top: 26px;
+  margin-top: 24px;
+}
+.admin-sidebar__section:first-child {
+  margin-top: 0;
 }
 
 .admin-sidebar__title {

--- a/src/components/common/RoleSidebar.vue
+++ b/src/components/common/RoleSidebar.vue
@@ -36,15 +36,23 @@ function isActive(target) {
 
 <style scoped>
 .role-sidebar {
+  position: fixed;
+  left: 0;
+  top: 80px;
   width: 14%;
-  min-width: 14%;
+  height: calc(100vh - 80px);
   padding: 18px 14px 28px;
   border-right: 1px solid var(--color-border-soft);
   background: var(--color-bg-surface);
+  overflow-y: auto;
+  z-index: 99;
 }
 
 .role-sidebar__section{
-  margin-top: 26px;
+  margin-top: 24px;
+}
+.role-sidebar__section:first-child {
+  margin-top: 0;
 }
 
 .role-sidebar__title {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -293,6 +293,9 @@ const routes = [
 const router = createRouter({
     history: createWebHistory(import.meta.env.BASE_URL),
     routes,
+    scrollBehavior() {
+        return { top: 0 }
+    },
 })
 
 router.beforeEach((to) => {

--- a/src/views/common/DashboardView.vue
+++ b/src/views/common/DashboardView.vue
@@ -79,6 +79,9 @@ function handleLogout() {
   border-top: 1px solid var(--color-border-default);
   border-bottom: 1px solid var(--color-border-default);
   background: var(--color-bg-surface);
+  position: sticky;
+  top: 0;
+  z-index: 100;
 }
 
 .dashboard-brand,
@@ -151,5 +154,6 @@ function handleLogout() {
 .dashboard-content {
   display: flex;
   flex: 1;
+  margin-left: 14%;
 }
 </style>


### PR DESCRIPTION
  ## Summary
  - 스크롤 시 헤더와 사이드바가 사라지는 문제 수정
  - 뷰 이동 시 스크롤 위치가 초기화되지 않는 문제 수정

  ## Test plan
  - [x] 콘텐츠가 많은 페이지에서 스크롤 시 헤더 고정 확인
  - [ ] 스크롤 시 사이드바 고정 확인 (AdminSidebar, RoleSidebar 모두)
  - [ ] 다른 메뉴로 이동 시 스크롤이 최상단으로 초기화되는지 확인

  Closes #149