### PR TITLE
feat(notice): 공지 목록 게시판 UI 개편 및 리스트 패널 컴포넌트 분리

### DIFF
--- a/src/components/hr/common/notices/HRMNoticeListPanel.vue
+++ b/src/components/hr/common/notices/HRMNoticeListPanel.vue
@@ -1,0 +1,281 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { STATUS_STYLE, FILTER_TABS } from '@/mocks/hrmanager/noticeboard.js'
+import HRMNoticeTeamFilter from '@/components/hr/common/notices/HRMNoticeTeamFilter.vue'
+
+const props = defineProps({
+  notices:    { type: Array, required: true },
+  selectedId: { type: [Number, null], default: null },
+})
+
+const emit = defineEmits(['select', 'create'])
+
+const activeTab     = ref('')
+const orgFilter     = ref([])
+const showOrgFilter = ref(false)
+const searchQuery   = ref('')
+const PAGE_SIZE     = 8
+const currentPage   = ref(1)
+
+const filtered = computed(() => {
+  const q = searchQuery.value.trim().toLowerCase()
+  return props.notices
+    .filter(n => {
+      if (activeTab.value === '중요' && !n.isImportant) return false
+      if (activeTab.value && activeTab.value !== '중요' && n.status !== activeTab.value) return false
+      if (orgFilter.value.length && !n.targets.some(t => orgFilter.value.includes(t))) return false
+      if (q && !n.title.toLowerCase().includes(q)) return false
+      return true
+    })
+    .sort((a, b) => (b.isImportant ? 1 : 0) - (a.isImportant ? 1 : 0))
+})
+
+const totalPages = computed(() => Math.max(1, Math.ceil(filtered.value.length / PAGE_SIZE)))
+const paginated  = computed(() => {
+  const start = (currentPage.value - 1) * PAGE_SIZE
+  return filtered.value.slice(start, start + PAGE_SIZE)
+})
+const orgLabel = computed(() =>
+  orgFilter.value.length ? orgFilter.value.join(' / ') : '전체'
+)
+
+function setTab(tab) {
+  activeTab.value = tab === '전체' ? '' : (activeTab.value === tab ? '' : tab)
+  currentPage.value = 1
+}
+</script>
+
+<template>
+  <div class="notice-card">
+    <!-- 헤더 -->
+    <div class="notice-header">
+      <h2 class="notice-header__title">공지 목록</h2>
+      <span class="notice-header__count">총 {{ notices.length }}건</span>
+    </div>
+
+    <!-- 툴바 -->
+    <div class="notice-toolbar">
+      <div class="notice-tabs">
+        <button
+          v-for="tab in FILTER_TABS"
+          :key="tab"
+          class="notice-tab"
+          :class="{ 'notice-tab--active': tab === '전체' ? activeTab === '' : activeTab === tab }"
+          @click="setTab(tab)"
+        >{{ tab }}</button>
+
+        <div class="notice-org-wrap">
+          <button
+            class="notice-tab notice-tab--org"
+            :class="{ 'notice-tab--active': orgFilter.length > 0 }"
+            @click="showOrgFilter = !showOrgFilter"
+          >대상: {{ orgLabel }}</button>
+          <div v-if="showOrgFilter" class="notice-org-popup">
+            <HRMNoticeTeamFilter
+              v-model="orgFilter"
+              @close="showOrgFilter = false"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div class="notice-toolbar__actions">
+        <div class="notice-search">
+          <input
+            v-model="searchQuery"
+            class="notice-search__input"
+            placeholder="제목 검색"
+            @input="currentPage = 1"
+          />
+        </div>
+        <button class="notice-create-btn" @click="emit('create')">+ 공지 등록</button>
+      </div>
+    </div>
+
+    <!-- 게시판 -->
+    <div class="notice-board">
+      <div class="notice-board__head">
+        <span class="notice-col--num">번호</span>
+        <span class="notice-col--title">제목</span>
+        <span class="notice-col--author">작성자</span>
+        <span class="notice-col--date">날짜</span>
+        <span class="notice-col--views">조회</span>
+      </div>
+      <div v-if="filtered.length === 0" class="notice-list__empty">
+        해당 조건의 공지사항이 없습니다.
+      </div>
+      <div
+        v-for="n in paginated"
+        :key="n.id"
+        class="notice-row"
+        :class="{ 'notice-row--selected': n.id === selectedId }"
+        @click="emit('select', n.id)"
+      >
+        <span class="notice-col--num notice-row__cell">
+          {{ n.isImportant ? '📌' : n.id }}
+        </span>
+        <div class="notice-col--title notice-row__title-wrap">
+          <span
+            class="notice-badge"
+            :style="{ background: STATUS_STYLE[n.status]?.bg, color: STATUS_STYLE[n.status]?.color }"
+          >{{ n.status }}</span>
+          <p class="notice-row__title">{{ n.title }}</p>
+        </div>
+        <span class="notice-col--author notice-row__cell">{{ n.author ?? '-' }}</span>
+        <span class="notice-col--date notice-row__cell">{{ n.date ?? '미게시' }}</span>
+        <span class="notice-col--views notice-row__cell">{{ n.views ?? 0 }}</span>
+      </div>
+    </div>
+
+    <!-- 페이지네이션 -->
+    <div class="notice-pagination">
+      <button class="notice-page-btn" :disabled="currentPage === 1" @click="currentPage--">&#8249;</button>
+      <button
+        v-for="p in totalPages"
+        :key="p"
+        class="notice-page-btn"
+        :class="{ 'notice-page-btn--active': p === currentPage }"
+        @click="currentPage = p"
+      >{{ p }}</button>
+      <button class="notice-page-btn" :disabled="currentPage === totalPages" @click="currentPage++">&#8250;</button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.notice-card {
+  background: var(--color-bg-surface);
+  border: 1.5px solid var(--color-border-default);
+  border-radius: 14px;
+  padding: 28px 32px;
+  display: flex; flex-direction: column; gap: 16px;
+  overflow: hidden;
+}
+
+/* 헤더 */
+.notice-header { display: flex; align-items: center; gap: 10px; }
+.notice-header__title {
+  font-size: var(--font-size-lg); font-weight: var(--font-weight-extrabold);
+  color: var(--color-primary-800); white-space: nowrap;
+}
+.notice-header__count { font-size: var(--font-size-sm); color: #a89ed8; white-space: nowrap; }
+
+/* 툴바 */
+.notice-toolbar { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.notice-toolbar__actions { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
+.notice-tabs { display: flex; align-items: center; gap: 5px; flex-wrap: nowrap; }
+.notice-tab {
+  height: 28px; padding: 0 10px;
+  border-radius: 20px; font-size: var(--font-size-xs); font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  border: 1.5px solid var(--color-border-default);
+  background: var(--color-bg-surface);
+  color: var(--color-primary-400);
+  transition: all .15s;
+}
+.notice-tab:hover { border-color: var(--color-primary-300); color: var(--color-primary-600); }
+.notice-tab--active {
+  background: var(--color-primary-800); color: var(--color-white);
+  border-color: var(--color-primary-800);
+}
+.notice-tab--org {
+  background: var(--color-bg-surface-muted);
+  border-color: var(--color-border-strong);
+  color: var(--color-text-secondary);
+  height: auto; min-height: 30px; max-width: 110px;
+}
+.notice-tab--org.notice-tab--active {
+  background: var(--color-primary-100); color: var(--color-primary-700);
+  border-color: var(--color-primary-300);
+}
+
+.notice-org-wrap { position: relative; }
+.notice-org-popup { position: absolute; top: calc(100% + 6px); left: 0; z-index: 20; }
+
+.notice-search {
+  display: flex; align-items: center;
+  height: 30px; padding: 0 10px;
+  border: 1.5px solid var(--color-border-default);
+  border-radius: 8px; background: var(--color-bg-surface);
+}
+.notice-search:focus-within { border-color: var(--color-primary-300); }
+.notice-search__input {
+  border: none; outline: none; background: transparent;
+  font-size: var(--font-size-xs); color: var(--color-text-default);
+  width: 130px;
+}
+.notice-search__input::placeholder { color: var(--color-text-muted); }
+
+.notice-create-btn {
+  height: 30px; padding: 0 12px; flex-shrink: 0;
+  background: var(--color-primary-600); color: var(--color-white);
+  border: none; border-radius: 8px; font-size: var(--font-size-xs); font-weight: var(--font-weight-bold);
+  cursor: pointer;
+}
+
+/* 게시판 */
+.notice-board { flex: 1; overflow-y: auto; min-height: 0; display: flex; flex-direction: column; }
+
+.notice-board__head,
+.notice-row {
+  display: grid;
+  grid-template-columns: 48px 1fr 90px 80px 48px;
+  align-items: center;
+  gap: 8px; padding: 0 12px;
+}
+.notice-board__head {
+  height: 36px;
+  background: var(--color-bg-app); border-radius: 8px;
+  font-size: var(--font-size-xs); font-weight: var(--font-weight-bold);
+  color: var(--color-text-muted); flex-shrink: 0;
+}
+.notice-row {
+  height: 48px;
+  border-bottom: 1px solid var(--color-border-default);
+  cursor: pointer; transition: background .12s;
+}
+.notice-row:hover { background: var(--color-bg-app); }
+.notice-row--selected {
+  background: var(--color-primary-50, #f3f0ff);
+  border-left: 3px solid var(--color-primary-600);
+  padding-left: 10px;
+}
+.notice-list__empty {
+  padding: 32px 0; text-align: center;
+  font-size: var(--font-size-sm); color: #a89ed8;
+}
+
+/* 컬럼 */
+.notice-col--num    { font-size: var(--font-size-xs); color: var(--color-text-muted); text-align: center; }
+.notice-col--title  { overflow: hidden; text-align: center; }
+.notice-col--author { font-size: var(--font-size-xs); color: var(--color-text-muted); text-align: center; }
+.notice-col--date   { font-size: var(--font-size-xs); color: var(--color-text-muted); text-align: center; }
+.notice-col--views  { font-size: var(--font-size-xs); color: var(--color-text-muted); text-align: center; }
+
+.notice-row__title-wrap { display: flex; align-items: center; gap: 6px; overflow: hidden; min-width: 0; }
+.notice-badge {
+  display: inline-flex; align-items: center;
+  padding: 2px 8px; border-radius: 20px;
+  font-size: var(--font-size-xs); font-weight: var(--font-weight-bold);
+  white-space: nowrap;
+}
+.notice-row__title {
+  font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold);
+  color: var(--color-primary-800); margin: 0;
+  overflow: hidden; white-space: nowrap; text-overflow: ellipsis; min-width: 0;
+}
+.notice-row__cell { font-size: var(--font-size-xs); color: var(--color-text-muted); text-align: center; }
+
+/* 페이지네이션 */
+.notice-pagination { display: flex; align-items: center; justify-content: center; gap: 4px; padding-top: 4px; flex-shrink: 0; }
+.notice-page-btn {
+  min-width: 28px; height: 28px; padding: 0 6px;
+  border: 1.5px solid var(--color-border-default); border-radius: 6px;
+  background: var(--color-bg-surface); color: var(--color-text-secondary);
+  font-size: var(--font-size-xs); font-weight: var(--font-weight-semibold);
+  cursor: pointer; transition: all .15s;
+}
+.notice-page-btn:hover:not(:disabled) { border-color: var(--color-primary-300); color: var(--color-primary-600); }
+.notice-page-btn--active { background: var(--color-primary-700); color: var(--color-white); border-color: var(--color-primary-700); }
+.notice-page-btn:disabled { opacity: 0.35; cursor: default; }
+</style>

--- a/src/mocks/hrmanager/noticeboard.js
+++ b/src/mocks/hrmanager/noticeboard.js
@@ -16,7 +16,7 @@ export const FILTER_TABS = ['전체', '중요', '게시중', '예약', '임시']
 
 export const MOCK_TEAMS = ['전체', 'TL', 'GL', 'Worker', 'HRM']
 
-let _id = 5
+let _id = 14
 export const mockNotices = [
   {
     id: 1,
@@ -110,6 +110,78 @@ export const mockNotices = [
 
 ■ 예정 배포일
 - 미정`,
+    attachment: '',
+  },
+  {
+    id: 5,
+    title: '2026년 상반기 연차 사용 촉진 안내',
+    status: '게시중',
+    targets: ['TL', 'GL', 'Worker'],
+    date: '2026.03.10',
+    author: 'HRM_인사운영팀',
+    views: 95,
+    isImportant: false,
+    content: `근로기준법에 따라 상반기 연차 사용 촉진을 안내드립니다.\n\n■ 촉진 대상\n- 2025년 미사용 연차 보유 직원 전체\n\n■ 사용 권장 기간\n- 2026.04.01 ~ 2026.06.30\n\n■ 신청 방법\n- HRM 포털 > 근태 > 연차 신청\n\n■ 문의\n- HRM 인사운영팀 내선 2130`,
+    attachment: '',
+  },
+  {
+    id: 6,
+    title: '설비 점검에 따른 시스템 일시 중단 안내',
+    status: '게시중',
+    targets: ['TL', 'GL', 'Worker'],
+    date: '2026.03.08',
+    author: 'HRM_시스템팀',
+    views: 210,
+    isImportant: true,
+    content: `서버 정기 점검으로 인해 아래 일정에 시스템이 일시 중단됩니다.\n\n■ 중단 일시\n- 2026.03.22 (일) 02:00 ~ 06:00\n\n■ 영향 범위\n- HRM 포털 전체 서비스\n\n■ 유의사항\n- 점검 시간 내 데이터 저장 불가\n- 긴급 문의: HRM 시스템팀 내선 2170`,
+    attachment: '',
+  },
+  {
+    id: 7,
+    title: '2026년 복리후생 제도 변경 안내',
+    status: '게시중',
+    targets: ['TL', 'GL', 'Worker'],
+    date: '2026.03.05',
+    author: 'HRM_인사운영팀',
+    views: 183,
+    isImportant: false,
+    content: `2026년부터 적용되는 복리후생 제도 변경 사항을 안내드립니다.\n\n■ 주요 변경 내용\n- 자기개발비 연 30만원 → 50만원으로 상향\n- 건강검진 지원 항목 확대 (배우자 포함)\n- 사내 카페테리아 포인트 월 3만원 지급\n\n■ 적용 시점\n- 2026.04.01부터 적용`,
+    attachment: '',
+  },
+  {
+    id: 8,
+    title: '1분기 안전 교육 미이수자 재공지',
+    status: '게시중',
+    targets: ['Worker'],
+    date: '2026.03.03',
+    author: 'HRM_교육운영팀',
+    views: 47,
+    isImportant: true,
+    content: `1분기 안전 교육 미이수자를 대상으로 추가 교육 일정을 안내드립니다.\n\n■ 대상\n- 2026년 1분기 안전 교육 미이수 Worker\n\n■ 추가 교육 일정\n- 2026.03.26 (목) 15:00 ~ 17:00 / 현장 교육장 A동\n\n■ 유의사항\n- 미이수 시 인사 불이익 발생 가능`,
+    attachment: '',
+  },
+  {
+    id: 9,
+    title: '5월 노사협의회 의제 사전 수렴 안내',
+    status: '예약',
+    targets: ['TL', 'GL', 'Worker'],
+    date: '2026.04.10',
+    author: 'HRM_인사운영팀',
+    views: 0,
+    isImportant: false,
+    content: `5월 노사협의회 개최에 앞서 직원 의제를 사전 수렴합니다.\n\n■ 수렴 기간\n- 2026.04.01 ~ 2026.04.07\n\n■ 협의회 예정일\n- 2026.05.15 (금)`,
+    attachment: '',
+  },
+  {
+    id: 10,
+    title: '하계 휴가 일정 사전 조율 안내',
+    status: '예약',
+    targets: ['TL', 'GL', 'Worker'],
+    date: '2026.04.20',
+    author: 'HRM_인사운영팀',
+    views: 0,
+    isImportant: false,
+    content: `하계 휴가 일정 조율을 위해 사전 희망 일정을 취합합니다.\n\n■ 취합 기간\n- 2026.04.14 ~ 2026.04.18\n\n■ 하계 휴가 권장 기간\n- 2026.07.21 ~ 2026.08.15 중 5일`,
     attachment: '',
   },
 ]

--- a/src/views/hrmanager/HRMNoticeBoardView.vue
+++ b/src/views/hrmanager/HRMNoticeBoardView.vue
@@ -1,18 +1,13 @@
 <script setup>
 import { ref, computed } from 'vue'
-import {
-  mockNotices, nextId,
-  STATUS_STYLE, FILTER_TABS,
-} from '@/mocks/hrmanager/noticeboard.js'
-import HRMNoticeTeamFilter  from '@/components/hr/common/notices/HRMNoticeTeamFilter.vue'
+import { mockNotices, nextId } from '@/mocks/hrmanager/noticeboard.js'
+import HRMNoticeListPanel  from '@/components/hr/common/notices/HRMNoticeListPanel.vue'
 import HRMNoticeDetailPanel from '@/components/hr/common/notices/HRMNoticeDetailPanel.vue'
 import HRMNoticeFormModal   from '@/components/hr/common/notices/HRMNoticeFormModal.vue'
 import BaseConfirmModal     from '@/components/common/base/overlay/BaseConfirmModal.vue'
 
 const notices    = ref([...mockNotices])
-const activeTab  = ref('')
-const orgFilter  = ref([])
-const showOrgFilter = ref(false)
+const selectedId = ref(mockNotices[0]?.id ?? null)
 
 const showFormModal = ref(false)
 const editTarget    = ref(null)
@@ -37,44 +32,20 @@ function showToast(message, type = 'success') {
   toastTimer = setTimeout(() => { toast.value.show = false }, 2500)
 }
 
-const selectedId = ref(mockNotices[0]?.id ?? null)
-
-// ── 필터링 ────────────────────────────────────────────────────────
-const filtered = computed(() => {
-  return notices.value.filter(n => {
-    if (activeTab.value === '중요' && !n.isImportant) return false
-    if (activeTab.value && activeTab.value !== '중요' && n.status !== activeTab.value) return false
-    if (orgFilter.value.length && !n.targets.some(t => orgFilter.value.includes(t))) return false
-    return true
-  })
-})
-
 const selectedNotice = computed(() =>
-  filtered.value.find(n => n.id === selectedId.value) ?? filtered.value[0] ?? null
+  notices.value.find(n => n.id === selectedId.value) ?? null
 )
 
-const orgLabel = computed(() =>
-  orgFilter.value.length ? orgFilter.value.join(' / ') : '전체'
-)
-
-// ── 탭 클릭 ───────────────────────────────────────────────────────
-function setTab(tab) {
-  activeTab.value = tab === '전체' ? '' : (activeTab.value === tab ? '' : tab)
-}
-
-// ── 새 공지 등록 ──────────────────────────────────────────────────
 function openCreate() {
   editTarget.value = null
   showFormModal.value = true
 }
 
-// ── 수정 ──────────────────────────────────────────────────────────
 function openEdit(notice) {
   editTarget.value = notice
   showFormModal.value = true
 }
 
-// ── 저장 ──────────────────────────────────────────────────────────
 function handleSave(data) {
   if (editTarget.value) {
     Object.assign(editTarget.value, data)
@@ -88,7 +59,6 @@ function handleSave(data) {
   showFormModal.value = false
 }
 
-// ── 임시 저장 ─────────────────────────────────────────────────────
 function handleDraft(data) {
   if (editTarget.value) {
     Object.assign(editTarget.value, data)
@@ -101,7 +71,6 @@ function handleDraft(data) {
   showToast('임시저장되었습니다.')
 }
 
-// ── 삭제 ──────────────────────────────────────────────────────────
 function deleteNotice(id) {
   const notice = notices.value.find(n => n.id === id)
   openConfirm(
@@ -109,7 +78,7 @@ function deleteNotice(id) {
     `'${notice?.title ?? '해당 공지'}'를 삭제하시겠습니까?`,
     () => {
       notices.value = notices.value.filter(n => n.id !== id)
-      selectedId.value = filtered.value[0]?.id ?? null
+      if (selectedId.value === id) selectedId.value = notices.value[0]?.id ?? null
       showToast('공지가 삭제되었습니다.')
     }
   )
@@ -120,75 +89,13 @@ function deleteNotice(id) {
   <div class="notice-view">
     <div class="notice-grid">
 
-      <!-- 좌측: 리스트 -->
-      <div class="notice-card">
-        <!-- 헤더 -->
-        <div class="notice-header">
-          <h2 class="notice-header__title">공지 목록</h2>
-          <span class="notice-header__count">총 {{ notices.length }}건</span>
-        </div>
-
-        <!-- 필터 바 -->
-        <div class="notice-toolbar">
-          <div class="notice-tabs">
-            <button
-              v-for="tab in FILTER_TABS"
-              :key="tab"
-              class="notice-tab"
-              :class="{ 'notice-tab--active': tab === '전체' ? activeTab === '' : activeTab === tab }"
-              @click="setTab(tab)"
-            >{{ tab }}</button>
-
-            <div class="notice-org-wrap">
-              <button
-                class="notice-tab notice-tab--org"
-                :class="{ 'notice-tab--active': orgFilter.length > 0 }"
-                @click="showOrgFilter = !showOrgFilter"
-              >대상 조직: {{ orgLabel }}</button>
-              <div v-if="showOrgFilter" class="notice-org-popup">
-                <HRMNoticeTeamFilter
-                  v-model="orgFilter"
-                  @close="showOrgFilter = false"
-                />
-              </div>
-            </div>
-          </div>
-
-          <button class="notice-create-btn" @click="openCreate">+ 새 공지 등록</button>
-        </div>
-
-        <!-- 목록 -->
-        <div class="notice-list">
-          <div v-if="filtered.length === 0" class="notice-list__empty">
-            해당 조건의 공지사항이 없습니다.
-          </div>
-          <div
-            v-for="n in filtered"
-            :key="n.id"
-            class="notice-row"
-            :class="{ 'notice-row--selected': n.id === selectedNotice?.id }"
-            @click="selectedId = n.id"
-          >
-            <div class="notice-row__top">
-              <div class="notice-row__badges">
-                <span v-if="n.isImportant" class="notice-badge notice-badge--pin">PIN</span>
-                <span
-                  class="notice-badge"
-                  :style="{ background: STATUS_STYLE[n.status]?.bg, color: STATUS_STYLE[n.status]?.color }"
-                >{{ n.status }}</span>
-              </div>
-              <span class="notice-row__views">조회 {{ n.views ?? 0 }}</span>
-            </div>
-            <p class="notice-row__title">{{ n.title }}</p>
-            <p class="notice-row__preview">{{ n.content }}</p>
-            <div class="notice-row__meta">
-              <span>작성자 {{ n.author ?? '-' }}</span>
-              <span>{{ n.date ?? '미게시' }}</span>
-              <span>대상: {{ n.targets.join(' / ') }}</span>
-            </div>
-          </div>
-        </div>
-      </div>
+      <!-- 좌측: 리스트 패널 -->
+      <HRMNoticeListPanel
+        :notices="notices"
+        :selected-id="selectedId"
+        @select="selectedId = $event"
+        @create="openCreate"
+      />
 
       <!-- 우측: 상세 패널 -->
       <HRMNoticeDetailPanel
@@ -198,7 +105,6 @@ function deleteNotice(id) {
       />
     </div>
 
-    <!-- 모달 -->
     <HRMNoticeFormModal
       v-if="showFormModal"
       :edit-mode="!!editTarget"
@@ -232,6 +138,8 @@ function deleteNotice(id) {
 
 <style scoped>
 .notice-view {
+  flex: 1;
+  min-width: 0;
   height: calc(100vh - 80px);
   padding: 24px 28px;
   background: var(--color-bg-app);
@@ -250,149 +158,15 @@ function deleteNotice(id) {
   min-height: 0;
 }
 
-.notice-card {
-  background: var(--color-bg-surface);
-  border: 1.5px solid var(--color-border-default);
-  border-radius: 14px;
-  padding: 28px 32px;
-  display: flex; flex-direction: column; gap: 16px;
-  overflow: hidden;
-}
-
-/* 헤더 */
-.notice-header { display: flex; align-items: baseline; gap: 12px; }
-.notice-header__title {
-  font-size: var(--font-size-lg); font-weight: var(--font-weight-extrabold); color: var(--color-primary-800);
-}
-.notice-header__count {
-  margin-left: auto;
-  font-size: var(--font-size-sm); color: #a89ed8;
-}
-
-/* 툴바 */
-.notice-toolbar { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
-.notice-tabs { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
-.notice-tab {
-  height: 28px; padding: 0 12px;
-  border-radius: 20px; font-size: var(--font-size-xs); font-weight: var(--font-weight-semibold);
-  cursor: pointer;
-  border: 1.5px solid var(--color-border-default);
-  background: var(--color-bg-surface);
-  color: var(--color-primary-400);
-  transition: all .15s;
-}
-.notice-tab:hover { border-color: var(--color-primary-300); color: var(--color-primary-600); }
-.notice-tab--active {
-  background: var(--color-primary-800); color: var(--color-white);
-  border-color: var(--color-primary-800);
-}
-.notice-tab--org {
-  background: var(--color-bg-surface-muted);
-  border-color: var(--color-border-strong);
-  color: var(--color-text-secondary);
-}
-.notice-tab--org.notice-tab--active {
-  background: var(--color-primary-100); color: var(--color-primary-700);
-  border-color: var(--color-primary-300);
-}
-
-.notice-org-wrap { position: relative; }
-.notice-org-popup { position: absolute; top: calc(100% + 6px); left: 0; z-index: 20; }
-
-.notice-create-btn {
-  height: 30px; padding: 0 14px; flex-shrink: 0;
-  background: var(--color-primary-600); color: var(--color-white);
-  border: none; border-radius: 8px; font-size: var(--font-size-sm); font-weight: var(--font-weight-bold);
-  cursor: pointer;
-}
-
-/* 목록 */
-.notice-list { display: flex; flex-direction: column; gap: 12px; flex: 1; overflow-y: auto; min-height: 0; }
-.notice-list__empty {
-  padding: 32px 0; text-align: center;
-  font-size: var(--font-size-sm); color: #a89ed8;
-}
-
-.notice-row {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 14px 16px;
-  background: var(--color-bg-app);
-  border: 1.5px solid var(--color-border-default);
-  border-radius: 10px;
-  cursor: pointer;
-  transition: all .15s;
-}
-.notice-row:hover { border-color: var(--color-primary-300); }
-.notice-row--selected {
-  background: var(--color-primary-100);
-  border-left: 3px solid var(--color-primary-600);
-  padding-left: 14px;
-}
-
-.notice-row__top {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.notice-row__badges { display: flex; gap: 6px; }
-
-.notice-badge {
-  display: inline-flex; align-items: center;
-  padding: 3px 10px; border-radius: 20px;
-  font-size: var(--font-size-xs); font-weight: var(--font-weight-bold);
-}
-.notice-badge--pin {
-  background: var(--color-primary-100);
-  color: var(--color-primary-600);
-}
-
-.notice-row__views {
-  font-size: var(--font-size-xs);
-  color: var(--color-text-muted);
-}
-
-.notice-row__title {
-  font-size: var(--font-size-base);
-  font-weight: var(--font-weight-bold);
-  color: var(--color-primary-800);
-  margin: 0;
-}
-
-.notice-row__preview {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-default);
-  line-height: 1.5;
-  margin: 0;
-  overflow: hidden;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-}
-
-.notice-row__meta {
-  display: flex;
-  gap: 10px;
-  font-size: var(--font-size-xs);
-  color: var(--color-text-muted);
-  margin-top: 2px;
-}
-
 @media (max-width: 1100px) {
   .notice-grid { grid-template-columns: 1fr; }
 }
 
-/* ── 삭제 확인 모달 ── */
-.notice-confirm__message {
-  font-size: var(--font-size-sm); color: var(--color-text-default); padding: 8px 0;
-}
-:deep(.base-confirm-modal__primary) {
-  background: var(--color-danger);
-}
+/* 삭제 확인 모달 */
+.notice-confirm__message { font-size: var(--font-size-sm); color: var(--color-text-default); padding: 8px 0; }
+:deep(.base-confirm-modal__primary) { background: var(--color-danger); }
 
-/* ── 토스트 ── */
+/* 토스트 */
 .notice-toast {
   position: fixed; bottom: 32px; left: 50%; transform: translateX(-50%);
   display: flex; align-items: center; gap: 8px;


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                               
  - 공지 목록을 카드형에서 게시판 테이블 형태로 전면 개편 (번호 / 제목+구분배지 / 작성자 / 날짜 / 조회)                                                                                                                    
  - 중요 공지 상단 고정(📌), 실시간 제목 검색, 탭 필터(전체·중요·게시중·예약·임시), 대상 팀 필터 지원
  - 페이지당 8건 페이지네이션 추가                                                                                                                                                                                         
  - 리스트 영역을 `HRMNoticeListPanel.vue`로 분리해 View는 상태·모달 관리만 담당
  - 목 데이터 4건 → 10건으로 확장

  ## Test plan
  - [ ] 탭 필터(전체/중요/게시중/예약/임시) 클릭 시 목록 필터링 동작 확인
  - [ ] 대상 팀 필터(TL/GL/Worker/HRM) 선택 시 필터링 동작 확인
  - [ ] 제목 검색 입력 시 실시간 필터링 확인
  - [ ] 중요 공지가 항상 상단에 고정되는지 확인
  - [ ] 8건 초과 시 페이지네이션 표시 및 이동 확인
  - [ ] 공지 클릭 시 우측 상세 패널 연동 확인
  - [ ] 공지 등록/수정/삭제 후 토스트 및 목록 갱신 확인
  <img width="1912" height="847" alt="image" src="https://github.com/user-attachments/assets/e4c3f5f9-4476-4091-8c95-54fe5bf893c0" />
