### PR TITLE
refactor: 팀장 공지 보드 HRM 패널로 통일

### DIFF
--- a/src/views/teamleader/TeamLeaderNoticeBoardView.vue
+++ b/src/views/teamleader/TeamLeaderNoticeBoardView.vue
@@ -1,58 +1,29 @@
 ﻿<script setup>
 import { computed, ref } from 'vue'
-import TeamLeaderNoticeFilterBar from '@/components/hr/common/notices/TeamLeaderNoticeFilterBar.vue'
-import WorkerNoticeList from '@/components/hr/common/notices/WorkerNoticeList.vue'
-import WorkerNoticeDetail from '@/components/hr/common/notices/WorkerNoticeDetail.vue'
-import { noticeBoardFilters, noticeBoardItems } from '@/mocks/teamleader/noticeBoard'
+import HRMNoticeListPanel from '@/components/hr/common/notices/HRMNoticeListPanel.vue'
+import HRMNoticeDetailPanel from '@/components/hr/common/notices/HRMNoticeDetailPanel.vue'
+import { noticeBoardItems } from '@/mocks/teamleader/noticeBoard'
 
-const activeFilter = ref('all')
-const selectedNoticeId = ref(1)
+const selectedNoticeId = ref(noticeBoardItems[0]?.id ?? null)
 
-const filteredNotices = computed(() => {
-  if (activeFilter.value === 'all') {
-    return noticeBoardItems
-  }
-
-  if (activeFilter.value === 'hrm') {
-    return noticeBoardItems.filter((notice) => notice.author.includes('HRM'))
-  }
-
-  return noticeBoardItems.filter((notice) => notice.category === activeFilter.value)
-})
-
-const workerNotices = computed(() =>
-  filteredNotices.value.map((notice) => ({
+const notices = computed(() =>
+  noticeBoardItems.map((notice) => ({
     id: notice.id,
     title: notice.title,
-    category:
-      notice.category === 'urgent'
-        ? '긴급'
-        : notice.category === 'education'
-          ? '교육'
-          : notice.category === 'inspection'
-            ? '점검'
-            : '전체',
-    status: notice.status === '예약' ? 'scheduled' : 'active',
-    statusLabel: notice.status,
-    pinned: notice.pin,
+    status: notice.status,
+    isImportant: notice.pin,
     author: notice.author.replace('작성자 ', ''),
     date: notice.schedule,
     views: Number(String(notice.views).replace(/[^0-9]/g, '')) || 0,
-    target: notice.target.replace('대상: ', ''),
-    preview: notice.summary,
+    targets: notice.target.replace('대상: ', '').split(' / '),
     content: notice.summary,
-    attachments: notice.attachmentLabel ? notice.attachmentLabel.split(' / ') : [],
+    attachment: notice.attachmentLabel ?? '',
   }))
 )
 
 const selectedNotice = computed(() => {
-  return workerNotices.value.find((notice) => notice.id === selectedNoticeId.value) ?? workerNotices.value[0] ?? null
+  return notices.value.find((notice) => notice.id === selectedNoticeId.value) ?? notices.value[0] ?? null
 })
-
-function handleFilterChange(filterKey) {
-  activeFilter.value = filterKey
-  selectedNoticeId.value = workerNotices.value[0]?.id ?? null
-}
 
 function handleSelectNotice(noticeId) {
   selectedNoticeId.value = noticeId
@@ -68,21 +39,14 @@ function handleSelectNotice(noticeId) {
 
     <section class="teamleader-noticeboard-view__content">
       <div class="teamleader-noticeboard-view__main">
-        <TeamLeaderNoticeFilterBar
-          class="teamleader-noticeboard-view__filters"
-          :filters="noticeBoardFilters"
-          :active-filter="activeFilter"
-          @change-filter="handleFilterChange"
-        />
-
-        <WorkerNoticeList
-          :notices="workerNotices"
+        <HRMNoticeListPanel
+          :notices="notices"
           :selected-id="selectedNotice?.id"
           @select="handleSelectNotice"
         />
       </div>
 
-      <WorkerNoticeDetail v-if="selectedNotice" :notice="selectedNotice" />
+      <HRMNoticeDetailPanel v-if="selectedNotice" :notice="selectedNotice" />
     </section>
   </section>
 </template>
@@ -144,4 +108,3 @@ function handleSelectNotice(noticeId) {
   }
 }
 </style>
-


### PR DESCRIPTION
## 작업 내용
- 팀장 공지사항 보드가 워커 공지 컴포넌트가 아니라 HRM 공지 패널 구조를 사용하도록 통일했습니다.
- `TeamLeaderNoticeBoardView`에서 `WorkerNoticeList`, `WorkerNoticeDetail`, `TeamLeaderNoticeFilterBar` 참조를 제거했습니다.
- 대신 `HRMNoticeListPanel`, `HRMNoticeDetailPanel`을 사용하도록 변경했습니다.
- 팀장 공지 mock 데이터를 HRM 공지 패널이 기대하는 데이터 구조에 맞게 매핑했습니다.

## 상세 변경
- 변경 파일
  - `src/views/teamleader/TeamLeaderNoticeBoardView.vue`

## 기대 효과
- 팀장/HRM 공지 보드 UI 구조를 일관되게 유지할 수 있습니다.
- 공지 리스트/상세 패널의 역할이 통일되어 유지보수가 쉬워집니다.
- 향후 공지사항 관련 공통 수정 시 팀장 화면도 같은 패턴으로 대응할 수 있습니다.

## 검증
- `npm run build` 통과
