### PR TITLE
feat(hrm): 공지 UI 개선 및 예약 게시 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "team3-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@vuepic/vue-datepicker": "^12.1.0",
         "axios": "^1.13.6",
         "chart.js": "^4.5.1",
         "pinia": "^3.0.4",
@@ -479,6 +480,12 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@date-fns/tz": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
+      "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
+      "license": "MIT"
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
@@ -919,6 +926,68 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@floating-ui/vue": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/vue/-/vue-1.1.11.tgz",
+      "integrity": "sha512-HzHKCNVxnGS35r9fCHBc3+uCnjw9IWIlCPL683cGgM9Kgj2BiAl8x1mS7vtvP6F9S/e/q4O6MApwSHj8hNLGfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6",
+        "@floating-ui/utils": "^0.2.11",
+        "vue-demi": ">=0.13.0"
+      }
+    },
+    "node_modules/@floating-ui/vue/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1600,6 +1669,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "license": "MIT"
+    },
     "node_modules/@vitejs/plugin-vue": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.4.tgz",
@@ -1867,6 +1942,62 @@
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.30.tgz",
       "integrity": "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==",
       "license": "MIT"
+    },
+    "node_modules/@vuepic/vue-datepicker": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@vuepic/vue-datepicker/-/vue-datepicker-12.1.0.tgz",
+      "integrity": "sha512-QuWcO+CqIGYFoRNCagp9xUY9sMK/OHUlVIDxBYjw7HjCTWXfuE/r3l3loB00faEtb0Teo3DeBn26hT3tYA5pgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@date-fns/tz": "^1.4.1",
+        "@floating-ui/vue": "^1.1.9",
+        "@vueuse/core": "^14.1.0",
+        "date-fns": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "vue": ">=3.5.0"
+      }
+    },
+    "node_modules/@vueuse/core": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.2.1.tgz",
+      "integrity": "sha512-3vwDzV+GDUNpdegRY6kzpLm4Igptq+GA0QkJ3W61Iv27YWwW/ufSlOfgQIpN6FZRMG0mkaz4gglJRtq5SeJyIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "14.2.1",
+        "@vueuse/shared": "14.2.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.2.1.tgz",
+      "integrity": "sha512-1ButlVtj5Sb/HDtIy1HFr1VqCP4G6Ypqt5MAo0lCgjokrk2mvQKsK2uuy0vqu/Ks+sHfuHo0B9Y9jn9xKdjZsw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.2.1.tgz",
+      "integrity": "sha512-shTJncjV9JTI4oVNyF1FQonetYAiTBd+Qj7cY89SWbXSkx7gyhrgtEdF2ZAVWS1S3SHlaROO6F2IesJxQEkZBw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -2138,6 +2269,16 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/dayjs": {
       "version": "1.11.20",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "server": "json-server --watch db.json --port 3001"
   },
   "dependencies": {
+    "@vuepic/vue-datepicker": "^12.1.0",
     "axios": "^1.13.6",
     "chart.js": "^4.5.1",
     "pinia": "^3.0.4",

--- a/src/components/hr/common/notices/HRMNoticeFormModal.vue
+++ b/src/components/hr/common/notices/HRMNoticeFormModal.vue
@@ -2,6 +2,9 @@
 import { ref, watch } from 'vue'
 import BaseFormModal from '@/components/common/base/overlay/BaseFormModal.vue'
 import HRMNoticeTeamFilter from '@/components/hr/common/notices/HRMNoticeTeamFilter.vue'
+import { VueDatePicker } from '@vuepic/vue-datepicker'
+import '@vuepic/vue-datepicker/dist/main.css'
+import { ko } from 'date-fns/locale'
 
 const props = defineProps({
   editMode:    { type: Boolean, default: false },
@@ -9,37 +12,56 @@ const props = defineProps({
 })
 const emit = defineEmits(['close', 'save', 'draft'])
 
-const title       = ref(props.initialData.title   ?? '')
-const content     = ref(props.initialData.content ?? '')
-const attachment  = ref(props.initialData.attachment ?? '')
-const isImportant = ref(props.initialData.isImportant ?? false)
-const targets     = ref(props.initialData.targets    ?? [])
+const title         = ref(props.initialData.title   ?? '')
+const content       = ref(props.initialData.content ?? '')
+const attachment    = ref(props.initialData.attachment ?? '')
+const isImportant   = ref(props.initialData.isImportant ?? false)
+const targets       = ref(props.initialData.targets    ?? [])
+const isScheduled      = ref(props.initialData.status === '예약')
+const scheduledDateTime = ref(props.initialData.status === '예약' && props.initialData.date ? new Date(props.initialData.date.replace('.', '-').replace('.', '-')) : null)
 
 const showTeamFilter = ref(false)
 const isDragging     = ref(false)
 const fileInputRef   = ref(null)
 
 watch(() => props.initialData, d => {
-  title.value       = d.title       ?? ''
-  content.value     = d.content     ?? ''
-  attachment.value  = d.attachment  ?? ''
-  isImportant.value = d.isImportant ?? false
-  targets.value     = d.targets     ?? []
+  title.value         = d.title       ?? ''
+  content.value       = d.content     ?? ''
+  attachment.value    = d.attachment  ?? ''
+  isImportant.value   = d.isImportant ?? false
+  targets.value       = d.targets     ?? []
+  isScheduled.value       = d.status === '예약'
+  scheduledDateTime.value = d.status === '예약' && d.date ? new Date(d.date.replace('.', '-').replace('.', '-')) : null
 }, { deep: true })
 
 function buildPayload(status) {
+  let resolvedStatus = status
+  let resolvedDate = null
+
+  if (status === '임시') {
+    resolvedDate = null
+  } else if (isScheduled.value && scheduledDateTime.value) {
+    resolvedStatus = '예약'
+    const d = scheduledDateTime.value
+    const pad = n => String(n).padStart(2, '0')
+    resolvedDate = `${d.getFullYear()}.${pad(d.getMonth()+1)}.${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
+  } else {
+    resolvedStatus = isImportant.value ? '중요' : '게시중'
+    resolvedDate = new Date().toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' }).replace(/\. /g, '.').replace('.', '')
+  }
+
   return {
     title:       title.value.trim(),
     content:     content.value.trim(),
     attachment:  attachment.value.trim(),
     isImportant: isImportant.value,
     targets:     targets.value,
-    status,
-    date: status === '임시' ? null : new Date().toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' }).replace(/\. /g, '.').replace('.', ''),
+    status:      resolvedStatus,
+    date:        resolvedDate,
   }
 }
 
-function handleSave()  { emit('save',  buildPayload(isImportant.value ? '중요' : '게시중')) }
+function handleSave()  { emit('save',  buildPayload('게시중')) }
 function handleDraft() { emit('draft', buildPayload('임시')) }
 
 function onDrop(e) {
@@ -60,7 +82,7 @@ function openFilePicker() {
 
 <template>
   <BaseFormModal
-    :title="editMode ? '공지 편집' : '새 공지 등록'"
+    :title="editMode ? '공지 수정' : '새 공지 등록'"
     :confirmText="editMode ? '수정 저장' : '등록'"
     :confirmDisabled="!title.trim()"
     :showDraftButton="true"
@@ -80,7 +102,28 @@ function openFilePicker() {
       <label class="modal__label">본문</label>
       <textarea v-model="content" class="modal__textarea" rows="7" placeholder="공지 내용을 상세히 입력해주세요" />
 
-      <!-- 중요 공지 토글 + 공개 범위 -->
+      <!-- 공개 범위 -->
+      <div class="modal__target-group modal__target-group--row">
+        <span class="modal__target-label">공개 범위 설정</span>
+        <div class="modal__target-wrap">
+          <button
+            class="modal__target-btn"
+            :class="{ 'modal__target-btn--active': targets.length > 0 }"
+            @click="showTeamFilter = !showTeamFilter"
+          >
+            <span>{{ targets.length ? targets.join(' / ') : '선택' }}</span>
+            <span class="modal__target-caret" />
+          </button>
+          <div v-if="showTeamFilter" class="modal__target-popup">
+            <HRMNoticeTeamFilter
+              v-model="targets"
+              @close="showTeamFilter = false"
+            />
+          </div>
+        </div>
+      </div>
+
+      <!-- 토글 옵션 -->
       <div class="modal__options-row">
         <label class="modal__toggle-label">
           <span class="modal__toggle-switch" :class="{ 'modal__toggle-switch--on': isImportant }" @click="isImportant = !isImportant">
@@ -89,25 +132,26 @@ function openFilePicker() {
           <span class="modal__toggle-text">중요 공지</span>
         </label>
 
-        <div class="modal__target-group">
-          <span class="modal__target-label">공개 범위 설정</span>
-          <div class="modal__target-wrap">
-            <button
-              class="modal__target-btn"
-              :class="{ 'modal__target-btn--active': targets.length > 0 }"
-              @click="showTeamFilter = !showTeamFilter"
-            >
-              <span>{{ targets.length ? targets.join(' / ') : '선택' }}</span>
-              <span class="modal__target-caret" />
-            </button>
-            <div v-if="showTeamFilter" class="modal__target-popup">
-              <HRMNoticeTeamFilter
-                v-model="targets"
-                @close="showTeamFilter = false"
-              />
-            </div>
-          </div>
-        </div>
+        <label class="modal__toggle-label">
+          <span class="modal__toggle-switch" :class="{ 'modal__toggle-switch--on': isScheduled }" @click="isScheduled = !isScheduled; if (!isScheduled) scheduledDate = ''">
+            <span class="modal__toggle-knob" />
+          </span>
+          <span class="modal__toggle-text">예약 게시</span>
+        </label>
+      </div>
+
+      <!-- 예약 날짜 피커 -->
+      <div v-if="isScheduled" class="modal__schedule-row">
+        <label class="modal__label">예약 게시일시</label>
+        <VueDatePicker
+          v-model="scheduledDateTime"
+          :locale="ko"
+          :enable-time-picker="true"
+          :min-date="new Date()"
+          placeholder="날짜와 시간을 선택하세요"
+          :teleport="false"
+          class="modal__datepicker"
+        />
       </div>
 
       <!-- 첨부 파일 -->
@@ -148,6 +192,23 @@ function openFilePicker() {
   color: var(--color-primary-600);
   margin-top: 4px;
 }
+.modal__schedule-row { display: flex; flex-direction: column; gap: 6px; }
+.modal__datepicker { width: 100%; }
+:deep(.dp__input) {
+  height: 42px;
+  border: 1.5px solid var(--color-border-default);
+  border-radius: 8px;
+  font-size: var(--font-size-sm);
+  color: var(--color-primary-800);
+  background: var(--color-bg-app);
+  font-family: inherit;
+}
+:deep(.dp__input:focus) { border-color: var(--color-primary-400); }
+
+.modal-schedule-enter-active,
+.modal-schedule-leave-active { transition: all 0.2s ease; }
+.modal-schedule-enter-from,
+.modal-schedule-leave-to { opacity: 0; transform: translateY(-6px); }
 
 .modal__input {
   width: 100%; height: 42px;
@@ -176,7 +237,13 @@ function openFilePicker() {
 .modal__options-row {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 24px;
+}
+
+.modal__target-group--row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 /* 토글 스위치 */
@@ -221,7 +288,6 @@ function openFilePicker() {
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-left: auto;
 }
 
 .modal__target-label {
@@ -267,7 +333,7 @@ function openFilePicker() {
 .modal__target-popup {
   position: absolute;
   bottom: calc(100% + 6px);
-  right: 0;
+  left: 0;
   z-index: 10;
 }
 

--- a/src/components/hr/common/notices/HRMNoticeListPanel.vue
+++ b/src/components/hr/common/notices/HRMNoticeListPanel.vue
@@ -164,7 +164,7 @@ function setTab(tab) {
 /* 툴바 */
 .notice-toolbar { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
 .notice-toolbar__actions { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
-.notice-tabs { display: flex; align-items: center; gap: 5px; flex-wrap: nowrap; }
+.notice-tabs { display: flex; align-items: center; gap: 5px; flex-wrap: wrap; flex-shrink: 1; min-width: 0; }
 .notice-tab {
   height: 28px; padding: 0 10px;
   border-radius: 20px; font-size: var(--font-size-xs); font-weight: var(--font-weight-semibold);
@@ -173,6 +173,7 @@ function setTab(tab) {
   background: var(--color-bg-surface);
   color: var(--color-primary-400);
   transition: all .15s;
+  white-space: nowrap;
 }
 .notice-tab:hover { border-color: var(--color-primary-300); color: var(--color-primary-600); }
 .notice-tab--active {

--- a/src/mocks/hrmanager/noticeboard.js
+++ b/src/mocks/hrmanager/noticeboard.js
@@ -14,7 +14,7 @@ export const STATUS_STYLE = {
 
 export const FILTER_TABS = ['전체', '중요', '게시중', '예약', '임시']
 
-export const MOCK_TEAMS = ['전체', 'TL', 'GL', 'Worker', 'HRM']
+export const MOCK_TEAMS = ['전체', 'TL', 'DL', 'Worker', 'HRM']
 
 let _id = 14
 export const mockNotices = [
@@ -22,7 +22,7 @@ export const mockNotices = [
     id: 1,
     title: 'KPI 리포트 반영 일정 및 평가 결과 공개 기준',
     status: '게시중',
-    targets: ['TL', 'GL', 'Worker'],
+    targets: ['TL', 'DL', 'Worker'],
     date: '2026.03.18',
     author: 'HRM_평가운영팀',
     views: 128,
@@ -36,7 +36,7 @@ export const mockNotices = [
 
 ■ KPI 리포트 반영 기준
 - 1분기 정량 평가: AI 산출 E_idx 기준
-- 1분기 정성 평가: TL 1차 + GL 2차 평가 합산
+- 1분기 정성 평가: TL 1차 + DL 2차 평가 합산
 - 이의신청은 시스템 내 이의신청 메뉴에서 진행
 
 ■ 문의
@@ -47,7 +47,7 @@ export const mockNotices = [
     id: 2,
     title: '2026년 1분기 승진 심사 대상자 안내',
     status: '게시중',
-    targets: ['TL', 'GL'],
+    targets: ['TL', 'DL'],
     date: '2026.03.15',
     author: 'HRM_인사운영팀',
     views: 74,
@@ -72,7 +72,7 @@ export const mockNotices = [
     id: 3,
     title: '4월 정기 교육 일정 사전 안내',
     status: '예약',
-    targets: ['TL', 'GL', 'Worker'],
+    targets: ['TL', 'DL', 'Worker'],
     date: '2026.03.25',
     author: 'HRM_교육운영팀',
     views: 0,
@@ -82,7 +82,7 @@ export const mockNotices = [
 ■ 교육 일정
 - 안전 보건 교육: 2026.04.03 (목) 14:00 ~ 16:00
 - 품질 관리 역량 교육: 2026.04.08 (화) 10:00 ~ 12:00
-- 리더십 향상 과정 (TL/GL): 2026.04.10 (목) 13:00 ~ 17:00
+- 리더십 향상 과정 (TL/DL): 2026.04.10 (목) 13:00 ~ 17:00
 
 ■ 신청 방법
 - HRM 포털 > 교육신청 메뉴에서 신청
@@ -116,7 +116,7 @@ export const mockNotices = [
     id: 5,
     title: '2026년 상반기 연차 사용 촉진 안내',
     status: '게시중',
-    targets: ['TL', 'GL', 'Worker'],
+    targets: ['TL', 'DL', 'Worker'],
     date: '2026.03.10',
     author: 'HRM_인사운영팀',
     views: 95,
@@ -128,7 +128,7 @@ export const mockNotices = [
     id: 6,
     title: '설비 점검에 따른 시스템 일시 중단 안내',
     status: '게시중',
-    targets: ['TL', 'GL', 'Worker'],
+    targets: ['TL', 'DL', 'Worker'],
     date: '2026.03.08',
     author: 'HRM_시스템팀',
     views: 210,
@@ -140,7 +140,7 @@ export const mockNotices = [
     id: 7,
     title: '2026년 복리후생 제도 변경 안내',
     status: '게시중',
-    targets: ['TL', 'GL', 'Worker'],
+    targets: ['TL', 'DL', 'Worker'],
     date: '2026.03.05',
     author: 'HRM_인사운영팀',
     views: 183,
@@ -164,7 +164,7 @@ export const mockNotices = [
     id: 9,
     title: '5월 노사협의회 의제 사전 수렴 안내',
     status: '예약',
-    targets: ['TL', 'GL', 'Worker'],
+    targets: ['TL', 'DL', 'Worker'],
     date: '2026.04.10',
     author: 'HRM_인사운영팀',
     views: 0,
@@ -176,7 +176,7 @@ export const mockNotices = [
     id: 10,
     title: '하계 휴가 일정 사전 조율 안내',
     status: '예약',
-    targets: ['TL', 'GL', 'Worker'],
+    targets: ['TL', 'DL', 'Worker'],
     date: '2026.04.20',
     author: 'HRM_인사운영팀',
     views: 0,

--- a/src/views/hrmanager/HRMDashboardView.vue
+++ b/src/views/hrmanager/HRMDashboardView.vue
@@ -149,4 +149,8 @@ function metricValue(key, suffix) {
   width: 100%;
   box-sizing: border-box;
 }
+
+:deep(.base-stat-card) {
+  align-items: center;
+}
 </style>


### PR DESCRIPTION
## Summary
  - 목데이터 GL → DL 변경
  - 공지 목록 탭 버튼 텍스트 줄바꿈 방지 및 overflow 처리
  - 대시보드 StatCard 수직 가운데 정렬 (HRM 화면에만 override)
  - 공지 등록/수정 모달 레이아웃 재구성 (공개범위 단독 행, 토글 정리)
  - 모달 제목 '공지 편집' → '공지 수정' 변경
  - 예약 게시 토글 추가 — ON 시 날짜+시간 피커 노출 (@vuepic/vue-datepicker)
  - 예약 상태로 저장 시 status: '예약', date: 'YYYY.MM.DD HH:mm' 형태로 저장

  ## Test plan
  - [ ] 공지 목록 탭 버튼이 좁은 화면에서 줄바꿈 없이 wrap 처리되는지 확인
  - [ ] 대시보드 StatCard 라벨/값 수직 가운데 정렬 확인
  - [ ] 공지 등록 모달 — 공개범위, 중요/예약 토글 레이아웃 확인
  - [ ] 예약 게시 토글 ON 시 날짜+시간 피커 노출 확인
  - [ ] 예약 날짜 설정 후 등록 시 status '예약'으로 저장 확인
  - [ ] 예약 토글 OFF 시 날짜 초기화 및 게시중으로 저장 확인

  ## 참고사항
  - vue datepicker 플러그인 설치했으니 npm i 하고 확인해주세요