### PR TITLE
feat: TL/DL 평가 및 HRM 평가기간 관리 화면 백엔드 연동 

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,4 +9,45 @@
 html, body, #app {
   height: 100%;
 }
+
+textarea,
+input[type='text'],
+input[type='search'],
+input[type='number'],
+input[type='email'],
+input[type='password'],
+input[type='url'],
+input[type='tel'],
+select {
+  transition:
+    border-color 0.16s ease,
+    box-shadow 0.16s ease,
+    background-color 0.16s ease;
+}
+
+textarea:focus,
+input[type='text']:focus,
+input[type='search']:focus,
+input[type='number']:focus,
+input[type='email']:focus,
+input[type='password']:focus,
+input[type='url']:focus,
+input[type='tel']:focus,
+select:focus {
+  outline: none;
+  border-color: var(--color-primary-400, #8a7cff);
+  box-shadow: 0 0 0 1px rgba(107, 86, 246, 0.18);
+}
+
+textarea:focus-visible,
+input[type='text']:focus-visible,
+input[type='search']:focus-visible,
+input[type='number']:focus-visible,
+input[type='email']:focus-visible,
+input[type='password']:focus-visible,
+input[type='url']:focus-visible,
+input[type='tel']:focus-visible,
+select:focus-visible {
+  outline: none;
+}
 </style>

--- a/src/components/common/sidebar/menuConfig.js
+++ b/src/components/common/sidebar/menuConfig.js
@@ -38,6 +38,7 @@ export const roleSidebarSections = {
         { label: '대시보드', icon: '👥', to: { name: 'HRDashboard' } },
         { label: '평가 승인', icon: '✅', to: { name: 'ApprovalReview' } },
         { label: 'KPI 리포트', icon: '📊', to: { name: 'HRMKpiReport' } },
+        { label: '평가기간 관리', icon: '📅', to: { name: 'EvaluationPeriod' } },
         { label: '평가 기준 설정', icon: '🎯', to: { name: 'EvaluationCriteria' } },
         { label: '승급 심사', icon: '🏆', to: { name: 'PromotionReview' } },
         { label: '조직도 관리', icon: '📘', to: { name: 'OrganizationManagement' } },

--- a/src/components/hr/common/evaluation/AiEvaluationFormPanel.vue
+++ b/src/components/hr/common/evaluation/AiEvaluationFormPanel.vue
@@ -1,0 +1,377 @@
+<script setup>
+function defaultNoop() {}
+
+const props = defineProps({
+  title: {
+    type: String,
+    required: true,
+  },
+  description: {
+    type: String,
+    default: '',
+  },
+  modelValue: {
+    type: String,
+    default: '',
+  },
+  noticeText: {
+    type: String,
+    default: '',
+  },
+  editorPlaceholder: {
+    type: String,
+    default: '',
+  },
+  recordingState: {
+    type: String,
+    default: 'idle',
+  },
+  uploadedFileName: {
+    type: String,
+    default: '',
+  },
+  showReplayButton: {
+    type: Boolean,
+    default: false,
+  },
+  showGuideButton: {
+    type: Boolean,
+    default: false,
+  },
+  guideButtonLabel: {
+    type: String,
+    default: '작성 가이드',
+  },
+  guideActive: {
+    type: Boolean,
+    default: false,
+  },
+  guideDisabled: {
+    type: Boolean,
+    default: false,
+  },
+  readonly: {
+    type: Boolean,
+    default: false,
+  },
+  recordingSummaryRenderer: {
+    type: Function,
+    default: null,
+  },
+})
+
+const emit = defineEmits([
+  'update:modelValue',
+  'voice-input',
+  'file-selected',
+  'convert-text',
+  'replay-audio',
+  'toggle-guide',
+])
+
+function handleFileChange(event) {
+  const [file] = event.target.files ?? []
+  emit('file-selected', file ?? null)
+  event.target.value = ''
+}
+
+function renderRecordingSummary() {
+  return (props.recordingSummaryRenderer ?? defaultNoop)()
+}
+</script>
+
+<template>
+  <section class="evaluation-form-panel">
+    <header class="evaluation-form-panel__header">
+      <div>
+        <h2 class="evaluation-form-panel__title">{{ title }}</h2>
+        <p v-if="description" class="evaluation-form-panel__description">
+          {{ description }}
+        </p>
+      </div>
+    </header>
+
+    <slot name="summary" />
+
+    <div class="evaluation-form-panel__toolbar">
+      <div class="evaluation-form-panel__toolbar-left">
+        <button
+          type="button"
+          class="evaluation-form-panel__tool-button"
+          :class="{ 'evaluation-form-panel__tool-button--active': recordingState !== 'idle' }"
+          @click="emit('voice-input')"
+        >
+          음성 인식 시작
+        </button>
+        <label class="evaluation-form-panel__tool-button">
+          파일 업로드
+          <input class="evaluation-form-panel__file-input" type="file" accept=".txt,.md,.log" @change="handleFileChange" />
+        </label>
+        <button type="button" class="evaluation-form-panel__tool-button" @click="emit('convert-text')">텍스트 변환</button>
+        <button
+          v-if="showReplayButton"
+          type="button"
+          class="evaluation-form-panel__tool-button"
+          @click="emit('replay-audio')"
+        >
+          다시 듣기
+        </button>
+      </div>
+      <button
+        v-if="showGuideButton"
+        type="button"
+        class="evaluation-form-panel__guide-button"
+        :class="{ 'evaluation-form-panel__guide-button--active': guideActive }"
+        :disabled="guideDisabled"
+        @click="emit('toggle-guide')"
+      >
+        {{ guideButtonLabel }}
+      </button>
+    </div>
+
+    <div v-if="noticeText" class="evaluation-form-panel__notice">
+      {{ noticeText }}
+    </div>
+
+    <div v-if="recordingState !== 'idle' || uploadedFileName" class="evaluation-form-panel__status-row">
+      <span v-if="recordingState !== 'idle'" class="evaluation-form-panel__status-chip">
+        {{ recordingState === 'recording' ? '음성 입력 mock 진행 중' : '음성 초안 준비 완료' }}
+      </span>
+      <span v-if="uploadedFileName" class="evaluation-form-panel__status-chip evaluation-form-panel__status-chip--file">
+        업로드 파일: {{ uploadedFileName }}
+      </span>
+    </div>
+
+    <textarea
+      class="evaluation-form-panel__editor"
+      :class="{ 'evaluation-form-panel__editor--readonly': readonly }"
+      :value="modelValue"
+      :placeholder="editorPlaceholder"
+      :readonly="readonly"
+      @input="!readonly && emit('update:modelValue', $event.target.value)"
+    ></textarea>
+
+    <div class="evaluation-form-panel__recording-zone">
+      <slot name="recording-zone">
+        <div v-if="recordingSummaryRenderer" class="evaluation-form-panel__recording-summary">
+          <strong>{{ renderRecordingSummary().title }}</strong>
+          <p>{{ renderRecordingSummary().description }}</p>
+        </div>
+        <div v-else class="evaluation-form-panel__recording-ring">
+          <div class="evaluation-form-panel__recording-icon">🎤</div>
+        </div>
+      </slot>
+    </div>
+
+    <footer v-if="$slots.footer" class="evaluation-form-panel__footer">
+      <slot name="footer" />
+    </footer>
+  </section>
+</template>
+
+<style scoped>
+.evaluation-form-panel {
+  padding: 22px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 24px;
+  background: var(--color-bg-surface);
+}
+
+.evaluation-form-panel__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 16px;
+}
+
+.evaluation-form-panel__title {
+  margin: 0;
+  font-size: 26px;
+  color: var(--color-primary-800);
+}
+
+.evaluation-form-panel__description {
+  margin: 8px 0 0;
+  font-size: 14px;
+  color: var(--color-text-muted);
+}
+
+.evaluation-form-panel__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-top: 14px;
+  border-top: 1px solid var(--color-border-soft);
+}
+
+.evaluation-form-panel__toolbar-left {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.evaluation-form-panel__tool-button,
+.evaluation-form-panel__guide-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 38px;
+  padding: 0 16px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 12px;
+  background: var(--color-bg-surface);
+  color: var(--color-primary-600);
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1;
+  box-sizing: border-box;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.evaluation-form-panel__tool-button--active {
+  background: var(--color-primary-100);
+  color: var(--color-primary-700);
+}
+
+.evaluation-form-panel__file-input {
+  display: none;
+}
+
+.evaluation-form-panel__guide-button {
+  background: linear-gradient(180deg, #f0edff 0%, #d9d1ff 100%);
+}
+
+.evaluation-form-panel__guide-button--active {
+  border-color: #cfc7ff;
+  box-shadow: 0 0 0 3px rgba(91, 80, 214, 0.08);
+}
+
+.evaluation-form-panel__notice {
+  margin-top: 14px;
+  padding: 14px 16px;
+  border: 1px solid #ffdca6;
+  border-radius: 14px;
+  background: #fff5df;
+  font-size: 13px;
+  line-height: 1.6;
+  color: #946200;
+}
+
+.evaluation-form-panel__status-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.evaluation-form-panel__status-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 34px;
+  padding: 0 14px;
+  border-radius: 999px;
+  background: #e9fbf6;
+  color: #168267;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.evaluation-form-panel__status-chip--file {
+  background: #f4f2ff;
+  color: var(--color-primary-700);
+}
+
+.evaluation-form-panel__editor {
+  width: 100%;
+  min-height: 250px;
+  margin-top: 14px;
+  padding: 16px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 18px;
+  resize: vertical;
+  font: inherit;
+  line-height: 1.8;
+  color: var(--color-primary-800);
+  box-sizing: border-box;
+}
+
+.evaluation-form-panel__editor--readonly {
+  background: linear-gradient(135deg, #f8f7ff 0%, #f1effe 100%);
+  border-color: #e0dbff;
+  color: #6e68b2;
+  cursor: default;
+  resize: none;
+  outline: none;
+}
+
+.evaluation-form-panel__editor--readonly:focus {
+  border-color: #e0dbff;
+  outline: none;
+  box-shadow: none;
+}
+
+.evaluation-form-panel__recording-zone {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 132px;
+  margin-top: 14px;
+  border-radius: 20px;
+  background: linear-gradient(180deg, rgba(174, 236, 227, 0.5) 0%, rgba(232, 251, 247, 0.85) 100%);
+}
+
+.evaluation-form-panel__recording-ring {
+  width: 106px;
+  height: 106px;
+  border-radius: 50%;
+  border: 4px solid rgba(16, 147, 127, 0.22);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.evaluation-form-panel__recording-icon {
+  width: 86px;
+  height: 86px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #08c8a7;
+  font-size: 34px;
+}
+
+.evaluation-form-panel__recording-summary {
+  text-align: center;
+  color: #168267;
+}
+
+.evaluation-form-panel__recording-summary strong {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 18px;
+}
+
+.evaluation-form-panel__recording-summary p {
+  margin: 0;
+}
+
+.evaluation-form-panel__footer {
+  display: grid;
+  gap: 14px;
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid var(--color-border-soft);
+}
+
+@media (max-width: 720px) {
+  .evaluation-form-panel__header,
+  .evaluation-form-panel__toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+</style>

--- a/src/components/hr/common/evaluation/EvaluationMemberCard.vue
+++ b/src/components/hr/common/evaluation/EvaluationMemberCard.vue
@@ -1,0 +1,236 @@
+<script setup>
+import { computed } from 'vue'
+import { TIER_BADGE_STYLES as tierColors } from '@/constants'
+
+const props = defineProps({
+  memberId: { type: [String, Number], required: true },
+  name: { type: String, required: true },
+  avatar: { type: String, default: '?' },
+  avatarTone: { type: String, default: '' },
+  avatarColor: { type: String, default: '' },
+  tier: { type: String, default: '' },
+  meta: { type: String, default: '' },
+  status: { type: String, default: 'not_started' },
+  statusLabel: { type: String, default: '' },
+  statusDate: { type: String, default: '' },
+  selected: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['select'])
+const avatarStyle = computed(() => (props.avatarColor ? { background: props.avatarColor } : null))
+</script>
+
+<template>
+  <article
+    class="evaluation-member-card"
+    :class="[`evaluation-member-card--${status}`, { 'evaluation-member-card--selected': selected }]"
+    tabindex="0"
+    @click="emit('select', memberId)"
+    @keydown.enter="emit('select', memberId)"
+    @keydown.space.prevent="emit('select', memberId)"
+  >
+    <div class="evaluation-member-card__left">
+      <div
+        class="evaluation-member-card__avatar"
+        :class="avatarTone ? `evaluation-member-card__avatar--${avatarTone}` : ''"
+        :style="avatarStyle"
+      >
+        {{ avatar }}
+      </div>
+      <div class="evaluation-member-card__copy">
+        <div class="evaluation-member-card__name-row">
+          <strong class="evaluation-member-card__name">{{ name }}</strong>
+          <span
+            v-if="tier"
+            class="evaluation-member-card__tier"
+            :style="{ background: tierColors[tier]?.bg, color: tierColors[tier]?.text }"
+          >
+            {{ tier }}
+          </span>
+        </div>
+        <p v-if="meta" class="evaluation-member-card__meta">{{ meta }}</p>
+        <span v-if="statusLabel" class="evaluation-member-card__status" :class="`evaluation-member-card__status--${status}`">
+          {{ statusLabel }}
+        </span>
+      </div>
+    </div>
+    <span v-if="statusDate" class="evaluation-member-card__date">{{ statusDate }}</span>
+  </article>
+</template>
+
+<style scoped>
+.evaluation-member-card {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: 18px;
+  border: 1px solid var(--color-border-soft);
+  background: #f4f5f9;
+  cursor: pointer;
+  transition:
+    border-color 0.16s ease,
+    background-color 0.16s ease,
+    transform 0.16s ease;
+}
+
+.evaluation-member-card:hover {
+  transform: translateY(-1px);
+}
+
+.evaluation-member-card--submitted {
+  background: #e8faf4;
+  border-color: #a7e9d0;
+}
+
+.evaluation-member-card--in_progress,
+.evaluation-member-card--in-progress {
+  background: #f1ecff;
+  border-color: #d4c8ff;
+}
+
+.evaluation-member-card--not_started,
+.evaluation-member-card--not-started {
+  background: #f4f5f9;
+  border-color: #e0e3eb;
+}
+
+.evaluation-member-card--submitted.evaluation-member-card--selected {
+  background: #dff8ee;
+  border-color: #9fdcc5;
+}
+
+.evaluation-member-card--in_progress.evaluation-member-card--selected,
+.evaluation-member-card--in-progress.evaluation-member-card--selected {
+  background: #e4dbff;
+  border-color: #c8baff;
+}
+
+.evaluation-member-card--not_started.evaluation-member-card--selected,
+.evaluation-member-card--not-started.evaluation-member-card--selected {
+  background: #ececf1;
+  border-color: #d8dbe6;
+}
+
+.evaluation-member-card__left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.evaluation-member-card__avatar {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-inverse);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-bold);
+  flex-shrink: 0;
+}
+
+.evaluation-member-card__avatar--purple {
+  background: #5f50d6;
+}
+
+.evaluation-member-card__avatar--green {
+  background: #269063;
+}
+
+.evaluation-member-card__avatar--gold {
+  background: #c08b00;
+}
+
+.evaluation-member-card__copy {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.evaluation-member-card__name-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.evaluation-member-card__name {
+  color: var(--color-primary-800);
+  font-size: var(--font-size-base-plus);
+  white-space: nowrap;
+}
+
+.evaluation-member-card__tier {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 7px;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-extrabold);
+  flex-shrink: 0;
+}
+
+.evaluation-member-card__meta {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs-plus);
+  line-height: 1.5;
+  white-space: normal;
+  word-break: keep-all;
+}
+
+.evaluation-member-card__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+}
+
+.evaluation-member-card__status--submitted {
+  color: #168765;
+}
+
+.evaluation-member-card__status--in_progress,
+.evaluation-member-card__status--in-progress {
+  color: #6a57d3;
+}
+
+.evaluation-member-card__status--not_started,
+.evaluation-member-card__status--not-started {
+  color: #7c8397;
+}
+
+.evaluation-member-card__date {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 52px;
+  min-height: 28px;
+  padding: 0 10px;
+  border-radius: 999px;
+  background: var(--color-bg-surface-muted);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+@media (max-width: 720px) {
+  .evaluation-member-card {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .evaluation-member-card__date {
+    padding-left: 54px;
+  }
+}
+</style>

--- a/src/components/hr/departmentleader/second-evaluation/DepartmentLeaderEvalFormPanel.vue
+++ b/src/components/hr/departmentleader/second-evaluation/DepartmentLeaderEvalFormPanel.vue
@@ -5,6 +5,7 @@ import DepartmentLeaderFirstEvaluationSummary from './DepartmentLeaderFirstEvalu
 
 const props = defineProps({
   member: { type: Object, default: null },
+  readonly: { type: Boolean, default: false },
 })
 
 const emit = defineEmits(['save', 'submit'])
@@ -69,6 +70,7 @@ function handleConvertText() {
     :show-guide-button="true"
     :guide-button-label="'1차 평가 참고'"
     :guide-disabled="true"
+    :readonly="readonly"
     :recording-summary-renderer="() => ({ title: '2차 평가 작성 현황', description: `${draftText.trim().length}자 입력 완료` })"
     @update:model-value="draftText = $event"
     @voice-input="handleVoiceInput"
@@ -81,19 +83,24 @@ function handleConvertText() {
 
     <template #footer>
       <div class="eval-form__actions">
-        <span class="eval-form__submit-hint" :class="{ 'eval-form__submit-hint--ready': canSubmit }">
-          {{ canSubmit ? '제출 가능한 상태입니다. 검토 후 최종 제출하세요.' : '2차 평가는 20자 이상 입력해야 제출할 수 있습니다.' }}
-        </span>
-        <button class="eval-form__btn eval-form__btn--save" @click="emit('save', draftText)">
-          임시저장
-        </button>
-        <button
-          class="eval-form__btn eval-form__btn--submit"
-          :disabled="!canSubmit"
-          @click="emit('submit', draftText)"
+        <span
+          class="eval-form__submit-hint"
+          :class="{ 'eval-form__submit-hint--ready': readonly || canSubmit, 'eval-form__submit-hint--submitted': readonly }"
         >
-          최종 제출
-        </button>
+          {{ readonly ? '제출이 완료된 평가입니다.' : canSubmit ? '제출 가능한 상태입니다. 검토 후 최종 제출하세요.' : '2차 평가는 20자 이상 입력해야 제출할 수 있습니다.' }}
+        </span>
+        <template v-if="!readonly">
+          <button class="eval-form__btn eval-form__btn--save" @click="emit('save', draftText)">
+            임시저장
+          </button>
+          <button
+            class="eval-form__btn eval-form__btn--submit"
+            :disabled="!canSubmit"
+            @click="emit('submit', draftText)"
+          >
+            최종 제출
+          </button>
+        </template>
       </div>
     </template>
   </AiEvaluationFormPanel>
@@ -146,6 +153,11 @@ function handleConvertText() {
 
 .eval-form__submit-hint--ready {
   color: #1d7f5f;
+}
+
+.eval-form__submit-hint--submitted {
+  color: #1d7f5f;
+  font-weight: var(--font-weight-semibold);
 }
 
 .eval-form__btn {

--- a/src/components/hr/departmentleader/second-evaluation/DepartmentLeaderEvalFormPanel.vue
+++ b/src/components/hr/departmentleader/second-evaluation/DepartmentLeaderEvalFormPanel.vue
@@ -1,6 +1,7 @@
 <script setup>
-import { ref, watch, computed } from 'vue'
-import { TIER_BADGE_STYLES as tierColors, scoreToStars } from '@/constants'
+import { computed, ref, watch } from 'vue'
+import AiEvaluationFormPanel from '@/components/hr/common/evaluation/AiEvaluationFormPanel.vue'
+import DepartmentLeaderFirstEvaluationSummary from './DepartmentLeaderFirstEvaluationSummary.vue'
 
 const props = defineProps({
   member: { type: Object, default: null },
@@ -8,133 +9,94 @@ const props = defineProps({
 
 const emit = defineEmits(['save', 'submit'])
 
-// Local copy of evaluations so edits don't mutate prop directly
-const localEvals = ref([])
+const draftText = ref('')
+const recordingState = ref('idle')
+const uploadedFileName = ref('')
+const uploadedText = ref('')
 
 watch(
   () => props.member,
-  (m) => {
-    if (!m) return
-    localEvals.value = m.evaluations.map((e) => ({ ...e }))
+  (member) => {
+    draftText.value = member?.secondEvaluationDraft ?? ''
+    recordingState.value = 'idle'
+    uploadedFileName.value = ''
+    uploadedText.value = ''
   },
   { immediate: true },
 )
 
-function updateScore(idx, raw) {
-  const score = Math.min(100, Math.max(0, Number(raw) || 0))
-  localEvals.value[idx].score = score
-  localEvals.value[idx].stars = scoreToStars(score)
+const canSubmit = computed(() => draftText.value.trim().length >= 20)
+
+function handleVoiceInput() {
+  recordingState.value = recordingState.value === 'recording' ? 'ready' : 'recording'
+  if (recordingState.value === 'recording') {
+    uploadedText.value = ''
+  } else {
+    uploadedText.value =
+      '음성 입력 mock 초안입니다. 1차 평가 내용과 현업 관찰 내용을 바탕으로 2차 평가 의견을 정리한 뒤 최종 문장을 직접 보완하세요.'
+  }
 }
 
-function setStars(idx, stars) {
-  localEvals.value[idx].stars = stars
+async function handleFileChange(file) {
+  if (!file) return
+
+  uploadedFileName.value = file.name
+  if (file.type.startsWith('text/') || /\.(txt|md|log)$/i.test(file.name)) {
+    uploadedText.value = await file.text()
+    return
+  }
+
+  uploadedText.value = `[업로드 파일 mock] ${file.name} 파일이 선택되었습니다. 실제 변환은 후속 API 연동 단계에서 지원됩니다.`
 }
 
-const canSubmit = computed(() =>
-  localEvals.value.every(
-    (e) => e.score > 0 && String(e.comment).trim() !== '',
-  ),
-)
-
+function handleConvertText() {
+  if (!uploadedText.value) return
+  draftText.value = uploadedText.value
+}
 </script>
 
 <template>
-  <section v-if="member" class="eval-form">
-    <!-- Member header -->
-    <div class="eval-form__header">
-      <div class="eval-form__avatar" :style="{ background: member.avatarColor }">
-        {{ member.avatar }}
+  <AiEvaluationFormPanel
+    v-if="member"
+    class="department-evaluation-form-panel"
+    :title="`${member.name} 2차 평가 작성`"
+    :description="`${member.code} | ${member.team} | ${member.experience}`"
+    :model-value="draftText"
+    :notice-text="'팀리더 1차 평가 내용과 AI 권고 점수는 참고 자료입니다. 음성 입력 또는 파일 업로드로 초안을 만든 뒤 아래 편집 영역에서 2차 평가 문장을 직접 완성하세요.'"
+    :editor-placeholder="'2차 평가 의견을 입력하세요. 1차 평가 내용 검토, 종합 판단, 보완 의견이 드러나도록 작성합니다.'"
+    :recording-state="recordingState"
+    :uploaded-file-name="uploadedFileName"
+    :show-guide-button="true"
+    :guide-button-label="'1차 평가 참고'"
+    :guide-disabled="true"
+    :recording-summary-renderer="() => ({ title: '2차 평가 작성 현황', description: `${draftText.trim().length}자 입력 완료` })"
+    @update:model-value="draftText = $event"
+    @voice-input="handleVoiceInput"
+    @file-selected="handleFileChange"
+    @convert-text="handleConvertText"
+  >
+    <template #summary>
+      <DepartmentLeaderFirstEvaluationSummary :summary="member.firstEvaluationSummary" />
+    </template>
+
+    <template #footer>
+      <div class="eval-form__actions">
+        <span class="eval-form__submit-hint" :class="{ 'eval-form__submit-hint--ready': canSubmit }">
+          {{ canSubmit ? '제출 가능한 상태입니다. 검토 후 최종 제출하세요.' : '2차 평가는 20자 이상 입력해야 제출할 수 있습니다.' }}
+        </span>
+        <button class="eval-form__btn eval-form__btn--save" @click="emit('save', draftText)">
+          임시저장
+        </button>
+        <button
+          class="eval-form__btn eval-form__btn--submit"
+          :disabled="!canSubmit"
+          @click="emit('submit', draftText)"
+        >
+          최종 제출
+        </button>
       </div>
-      <div class="eval-form__member-info">
-        <div class="eval-form__name-row">
-          <span class="eval-form__name">{{ member.name }}</span>
-          <span
-            class="eval-form__tier-badge"
-            :style="{ background: tierColors[member.tier]?.bg, color: tierColors[member.tier]?.text }"
-          >{{ member.tier }}</span>
-        </div>
-        <span class="eval-form__meta">2차인 · {{ member.tier }}-Tier · {{ member.experience }}</span>
-      </div>
-    </div>
-
-    <!-- AI recommendation -->
-    <div class="eval-form__ai-box">
-      <span class="eval-form__ai-label">AI 산출 정량 평균 점수 권고</span>
-      <div class="eval-form__ai-scores">
-        <div class="eval-form__ai-score">
-          <span class="eval-form__ai-value">{{ member.aiRecommended.quantitative }}</span>
-          <span class="eval-form__ai-kind">정량</span>
-        </div>
-        <div class="eval-form__ai-divider" />
-        <div class="eval-form__ai-score">
-          <span class="eval-form__ai-value">{{ member.aiRecommended.qualitative }}</span>
-          <span class="eval-form__ai-kind">정성</span>
-        </div>
-        <div class="eval-form__ai-divider" />
-        <div class="eval-form__ai-score">
-          <span class="eval-form__ai-value">{{ member.aiRecommended.composite }}</span>
-          <span class="eval-form__ai-kind">종합</span>
-        </div>
-      </div>
-    </div>
-
-    <!-- Evaluation categories -->
-    <div class="eval-form__categories">
-      <div
-        v-for="(item, idx) in localEvals"
-        :key="item.category"
-        class="eval-category"
-      >
-        <div class="eval-category__title-row">
-          <span class="eval-category__name">{{ item.category }}</span>
-          <input
-            class="eval-category__score"
-            type="number"
-            min="0"
-            max="100"
-            :value="localEvals[idx].score"
-            @input="updateScore(idx, $event.target.value)"
-          />
-        </div>
-
-        <!-- Stars -->
-        <div class="eval-category__stars">
-          <span
-            v-for="s in 5"
-            :key="s"
-            class="eval-category__star"
-            :class="{ 'eval-category__star--filled': s <= item.stars }"
-            @click="setStars(idx, s)"
-          >★</span>
-        </div>
-
-        <!-- Comment input -->
-        <input
-          v-model="localEvals[idx].comment"
-          class="eval-category__input"
-          type="text"
-          :placeholder="`${item.category} 코멘트 입력...`"
-        />
-      </div>
-    </div>
-
-    <!-- Action buttons -->
-    <div class="eval-form__actions">
-      <span v-if="!canSubmit" class="eval-form__submit-hint">
-        모든 항목의 점수와 코멘트를 입력해야 제출할 수 있습니다.
-      </span>
-      <button class="eval-form__btn eval-form__btn--save" @click="emit('save', localEvals)">
-        임시저장
-      </button>
-      <button
-        class="eval-form__btn eval-form__btn--submit"
-        :disabled="!canSubmit"
-        @click="emit('submit', localEvals)"
-      >
-        최종 제출
-      </button>
-    </div>
-  </section>
+    </template>
+  </AiEvaluationFormPanel>
 
   <section v-else class="eval-form eval-form--empty">
     <p>좌측 목록에서 팀원을 선택하세요.</p>
@@ -161,198 +123,11 @@ const canSubmit = computed(() =>
   font-size: var(--font-size-base);
 }
 
-/* Header */
-.eval-form__header {
-  display: flex;
-  align-items: center;
-  gap: 16px;
+.department-evaluation-form-panel {
+  overflow-y: auto;
+  max-height: calc(100vh - 200px);
 }
 
-.eval-form__avatar {
-  width: 56px;
-  height: 56px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #fff;
-  font-size: var(--font-size-xl);
-  font-weight: var(--font-weight-bold);
-  flex-shrink: 0;
-}
-
-.eval-form__member-info {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.eval-form__name-row {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.eval-form__name {
-  font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-extrabold);
-  color: var(--color-primary-800);
-}
-
-.eval-form__tier-badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 26px;
-  height: 26px;
-  border-radius: 8px;
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-extrabold);
-}
-
-.eval-form__meta {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-muted);
-}
-
-/* AI recommendation box */
-.eval-form__ai-box {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 14px 20px;
-  border-radius: 14px;
-  background: #f0eeff;
-}
-
-.eval-form__ai-label {
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-primary-700);
-  white-space: nowrap;
-}
-
-.eval-form__ai-scores {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.eval-form__ai-score {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 2px;
-}
-
-.eval-form__ai-value {
-  font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-extrabold);
-  color: var(--color-primary-800);
-}
-
-.eval-form__ai-kind {
-  font-size: var(--font-size-xs);
-  color: var(--color-text-muted);
-}
-
-.eval-form__ai-divider {
-  width: 1px;
-  height: 28px;
-  background: var(--color-border-default);
-}
-
-/* Categories */
-.eval-form__categories {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-}
-
-.eval-category {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.eval-category__title-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.eval-category__name {
-  font-size: var(--font-size-md);
-  font-weight: var(--font-weight-bold);
-  color: var(--color-primary-800);
-}
-
-.eval-category__score {
-  width: 72px;
-  text-align: center;
-  font-size: var(--font-size-md);
-  font-weight: var(--font-weight-extrabold);
-  color: var(--color-primary-600);
-  border: 1.5px solid var(--color-primary-300);
-  border-radius: 8px;
-  padding: 4px 8px;
-  background: var(--color-primary-50, #f5f3ff);
-  outline: none;
-  -moz-appearance: textfield;
-  transition: border-color 0.15s;
-}
-.eval-category__score:focus {
-  border-color: var(--color-primary-500);
-}
-.eval-category__score::-webkit-inner-spin-button,
-.eval-category__score::-webkit-outer-spin-button {
-  -webkit-appearance: none;
-}
-
-/* Stars */
-.eval-category__stars {
-  display: flex;
-  gap: 4px;
-}
-
-.eval-category__star {
-  font-size: var(--font-size-xl);
-  color: #ddd;
-  cursor: pointer;
-  line-height: 1;
-  transition: color 0.1s;
-}
-
-.eval-category__star--filled {
-  color: #f5a623;
-}
-
-.eval-category__star:hover {
-  color: #f5c060;
-}
-
-/* Comment input */
-.eval-category__input {
-  width: 100%;
-  height: 40px;
-  padding: 0 14px;
-  border: 1px solid var(--color-border-default);
-  border-radius: 10px;
-  font-size: var(--font-size-sm);
-  color: var(--color-text-default);
-  background: var(--color-bg-surface-muted);
-  box-sizing: border-box;
-  outline: none;
-}
-.eval-category__input::placeholder {
-  color: var(--color-text-muted);
-}
-.eval-category__input:focus {
-  border-color: var(--color-primary-400);
-}
-
-/* Action buttons */
 .eval-form__actions {
   display: flex;
   align-items: center;
@@ -369,6 +144,10 @@ const canSubmit = computed(() =>
   text-align: left;
 }
 
+.eval-form__submit-hint--ready {
+  color: #1d7f5f;
+}
+
 .eval-form__btn {
   height: 42px;
   padding: 0 24px;
@@ -379,6 +158,7 @@ const canSubmit = computed(() =>
   border: none;
   transition: opacity 0.15s;
 }
+
 .eval-form__btn:hover {
   opacity: 0.85;
 }

--- a/src/components/hr/departmentleader/second-evaluation/DepartmentLeaderEvalMemberListPanel.vue
+++ b/src/components/hr/departmentleader/second-evaluation/DepartmentLeaderEvalMemberListPanel.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, computed } from 'vue'
-import { TIER_BADGE_STYLES as tierColors } from '@/constants'
+import EvaluationMemberCard from '@/components/hr/common/evaluation/EvaluationMemberCard.vue'
 
 const props = defineProps({
   members: { type: Array, default: () => [] },
@@ -10,9 +10,9 @@ const props = defineProps({
 const emit = defineEmits(['select'])
 
 const statusConfig = {
-  submitted:    { label: '제출 완료', icon: '✓', cardClass: 'card--submitted' },
-  in_progress:  { label: '작성 중',   icon: '✏', cardClass: 'card--in-progress' },
-  not_started:  { label: '미작성',    icon: '⊘', cardClass: 'card--not-started' },
+  submitted: { label: '제출 완료' },
+  in_progress: { label: '작성 중' },
+  not_started: { label: '미작성' },
 }
 
 const search = ref('')
@@ -31,9 +31,10 @@ const statusOptions = [
 
 const filtered = computed(() =>
   props.members.filter((m) => {
+    const keyword = search.value.trim()
     const matchTeam   = teamFilter.value   === '전체' || m.team   === teamFilter.value
     const matchStatus = statusFilter.value === '전체' || m.status === statusFilter.value
-    const matchSearch = m.name.includes(search.value.trim())
+    const matchSearch = !keyword || m.name.includes(keyword) || m.team?.includes(keyword)
     return matchTeam && matchStatus && matchSearch
   })
 )
@@ -55,12 +56,15 @@ const statusFilterLabel = computed(
 
 <template>
   <section class="eval-member-list">
-    <!-- Header -->
-    <h3 class="eval-member-list__title">팀원 평가 현황</h3>
+    <div class="eval-member-list__header">
+      <div>
+        <p class="eval-member-list__eyebrow">평가 대상 현황</p>
+        <h3 class="eval-member-list__title">대상자 목록</h3>
+      </div>
+      <span class="eval-member-list__count">총 {{ members.length }}명</span>
+    </div>
 
-    <!-- Filters -->
     <div class="eval-member-list__filters">
-      <!-- Team dropdown -->
       <div class="eval-member-list__dropdown-wrap">
         <button class="eval-member-list__filter-btn" @click="teamDropdownOpen = !teamDropdownOpen; statusDropdownOpen = false">
           <span class="eval-member-list__filter-label">팀: {{ teamFilter }}</span>
@@ -77,7 +81,6 @@ const statusFilterLabel = computed(
         </ul>
       </div>
 
-      <!-- Status dropdown -->
       <div class="eval-member-list__dropdown-wrap">
         <button class="eval-member-list__filter-btn" @click="statusDropdownOpen = !statusDropdownOpen; teamDropdownOpen = false">
           <span class="eval-member-list__filter-label">상태: {{ statusFilterLabel }}</span>
@@ -95,42 +98,34 @@ const statusFilterLabel = computed(
       </div>
     </div>
 
-    <!-- Search -->
-    <div class="eval-member-list__search">
-      <span class="eval-member-list__search-icon">🔍</span>
+    <label class="eval-member-list__search" aria-label="평가 대상 검색">
+      <span class="eval-member-list__search-icon" aria-hidden="true">⌕</span>
       <input
         v-model="search"
         class="eval-member-list__search-input"
-        placeholder="팀원 검색..."
+        placeholder="이름 또는 팀명으로 검색"
       />
-    </div>
+    </label>
 
     <ul class="eval-member-list__list">
       <li
         v-for="m in filtered"
         :key="m.id"
-        class="eval-card"
-        :class="[statusConfig[m.status]?.cardClass, { 'eval-card--selected': m.id === selectedId }]"
-        @click="emit('select', m)"
+        class="eval-member-list__item"
       >
-        <div class="eval-card__left">
-          <div class="eval-card__avatar" :style="{ background: m.avatarColor }">
-            {{ m.avatar }}
-          </div>
-          <div class="eval-card__info">
-            <div class="eval-card__name-row">
-              <span class="eval-card__name">{{ m.name }}</span>
-              <span
-                class="eval-card__tier"
-                :style="{ background: tierColors[m.tier]?.bg, color: tierColors[m.tier]?.text }"
-              >{{ m.tier }}</span>
-            </div>
-            <span class="eval-card__status">
-              {{ statusConfig[m.status]?.icon }} {{ statusConfig[m.status]?.label }}
-            </span>
-          </div>
-        </div>
-        <span class="eval-card__date">{{ m.statusDate }}</span>
+        <EvaluationMemberCard
+          :member-id="m.id"
+          :name="m.name"
+          :avatar="m.avatar"
+          :avatar-color="m.avatarColor"
+          :tier="m.tier"
+          :meta="`${m.team} | ${m.position ?? '직무 정보 없음'}`"
+          :status="m.status"
+          :status-label="statusConfig[m.status]?.label"
+          :status-date="m.statusDate"
+          :selected="m.id === selectedId"
+          @select="emit('select', m)"
+        />
       </li>
     </ul>
 
@@ -139,49 +134,81 @@ const statusFilterLabel = computed(
 
 <style scoped>
 .eval-member-list {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-rows: auto auto auto minmax(0, 1fr);
   gap: 12px;
   padding: 20px;
   border: 1px solid var(--color-border-default);
   border-radius: 24px;
   background: var(--color-bg-surface);
   height: 100%;
+  min-height: 0;
   box-sizing: border-box;
   overflow: hidden;
 }
 
-.eval-member-list__title {
-  font-size: var(--font-size-sm);
+.eval-member-list__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.eval-member-list__eyebrow {
+  margin: 0 0 4px;
+  font-size: var(--font-size-xs-plus);
   font-weight: var(--font-weight-bold);
-  color: var(--color-primary-600);
+  color: var(--color-primary-500);
+}
+
+.eval-member-list__title {
   margin: 0;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary-800);
+}
+
+.eval-member-list__count {
+  display: inline-flex;
+  align-items: center;
+  min-height: 32px;
+  padding: 0 12px;
+  border-radius: 999px;
+  background: var(--color-primary-100);
+  color: var(--color-primary-700);
+  font-size: var(--font-size-xs-plus);
+  font-weight: var(--font-weight-semibold);
+  white-space: nowrap;
 }
 
 .eval-member-list__filters {
   display: flex;
   gap: 8px;
+  flex-wrap: wrap;
 }
 
 .eval-member-list__dropdown-wrap {
   position: relative;
   flex: 1;
+  min-width: 0;
 }
 
 .eval-member-list__filter-btn {
   width: 100%;
-  background: var(--color-primary-100);
-  border: none;
-  border-radius: var(--radius-sm);
-  padding: 6px 12px;
+  height: 38px;
+  padding: 0 36px 0 14px;
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-default);
+  border-radius: 12px;
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-semibold);
   color: var(--color-primary-700);
   cursor: pointer;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   position: relative;
+  box-sizing: border-box;
 }
 
 .eval-member-list__filter-label {
@@ -194,33 +221,36 @@ const statusFilterLabel = computed(
   position: absolute;
   right: 10px;
   flex-shrink: 0;
+  color: var(--color-text-muted);
 }
 
 .eval-member-list__dropdown {
   position: absolute;
   top: calc(100% + 6px);
-  right: 0;
+  left: 0;
   z-index: 10;
   list-style: none;
-  min-width: 140px;
+  width: 100%;
   padding: 0;
   margin: 0;
   background: var(--color-bg-surface);
   border: 1px solid var(--color-border-default);
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-soft);
+  border-radius: 14px;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
   overflow: hidden;
 }
 
 .eval-member-list__dropdown-item {
-  padding: 10px 16px;
+  padding: 10px 14px;
   font-size: var(--font-size-sm);
   cursor: pointer;
   color: var(--color-text-default);
 }
+
 .eval-member-list__dropdown-item:hover {
   background: var(--color-primary-100);
 }
+
 .eval-member-list__dropdown-item--active {
   font-weight: var(--font-weight-bold);
   color: var(--color-primary-700);
@@ -230,25 +260,29 @@ const statusFilterLabel = computed(
   display: flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
   border: 1px solid var(--color-border-default);
-  border-radius: var(--radius-sm);
-  padding: 8px 12px;
+  border-radius: 14px;
+  padding: 10px 12px;
   background: var(--color-bg-surface-muted);
 }
 
 .eval-member-list__search-icon {
-  font-size: var(--font-size-base);
   flex-shrink: 0;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-base-plus);
 }
 
 .eval-member-list__search-input {
+  width: 100%;
+  min-width: 0;
   border: none;
   background: transparent;
   outline: none;
   font-size: var(--font-size-sm);
   color: var(--color-text-default);
-  width: 100%;
 }
+
 .eval-member-list__search-input::placeholder {
   color: var(--color-text-muted);
 }
@@ -258,132 +292,29 @@ const statusFilterLabel = computed(
   display: flex;
   flex-direction: column;
   gap: 10px;
-  padding: 2px;
+  padding: 0 4px 0 0;
   margin: 0;
-  flex: 1;
+  min-height: 0;
   overflow-y: auto;
 }
 
-/* Card base */
-.eval-card {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 14px 16px;
-  border-radius: 16px;
-  cursor: pointer;
-  border: 1px solid transparent;
-  transition: background 0.15s;
+.eval-member-list__item {
+  list-style: none;
 }
 
-.eval-card__left {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
+@media (max-width: 720px) {
+  .eval-member-list {
+    padding: 16px;
+  }
 
-/* Status variants */
-.card--submitted {
-  background: #e8faf4;
-  border-color: #a7e9d0;
-}
+  .eval-member-list__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 
-.card--in-progress {
-  background: #1e1650;
-  border-color: #3d2fa0;
-}
+  .eval-member-list__filters {
+    flex-direction: column;
+  }
 
-.card--not-started {
-  background: #f7f7f9;
-  border-color: var(--color-border-soft);
-}
-
-.eval-card--selected {
-  outline: 2px solid var(--color-primary-400);
-}
-
-/* Avatar */
-.eval-card__avatar {
-  width: 42px;
-  height: 42px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #fff;
-  font-size: var(--font-size-md);
-  font-weight: var(--font-weight-bold);
-  flex-shrink: 0;
-}
-
-/* Info */
-.eval-card__info {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.eval-card__name-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.eval-card__name {
-  font-size: var(--font-size-base);
-  font-weight: var(--font-weight-bold);
-}
-
-.card--submitted .eval-card__name,
-.card--not-started .eval-card__name {
-  color: var(--color-primary-800);
-}
-
-.card--in-progress .eval-card__name {
-  color: #fff;
-}
-
-.eval-card__tier {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 22px;
-  height: 22px;
-  border-radius: 6px;
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-extrabold);
-}
-
-.eval-card__status {
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-semibold);
-}
-
-.card--submitted .eval-card__status {
-  color: #16a37a;
-}
-
-.card--in-progress .eval-card__status {
-  color: #c4b8ff;
-}
-
-.card--not-started .eval-card__status {
-  color: var(--color-text-muted);
-}
-
-/* Date */
-.eval-card__date {
-  font-size: var(--font-size-xs);
-  flex-shrink: 0;
-}
-
-.card--submitted .eval-card__date,
-.card--not-started .eval-card__date {
-  color: var(--color-text-muted);
-}
-
-.card--in-progress .eval-card__date {
-  color: #c4b8ff;
 }
 </style>

--- a/src/components/hr/departmentleader/second-evaluation/DepartmentLeaderFirstEvaluationSummary.vue
+++ b/src/components/hr/departmentleader/second-evaluation/DepartmentLeaderFirstEvaluationSummary.vue
@@ -1,0 +1,124 @@
+<script setup>
+defineProps({
+  summary: {
+    type: Object,
+    default: null,
+  },
+})
+</script>
+
+<template>
+  <section v-if="summary" class="first-evaluation-summary">
+    <div class="first-evaluation-summary__header">
+      <div>
+        <p class="first-evaluation-summary__eyebrow">1차 평가 요약</p>
+        <h3 class="first-evaluation-summary__title">팀리더 평가 내용 및 점수</h3>
+      </div>
+      <div class="first-evaluation-summary__scores">
+        <div class="first-evaluation-summary__score">
+          <strong>{{ summary.quantitativeScore }}</strong>
+          <span>정량</span>
+        </div>
+        <div class="first-evaluation-summary__score">
+          <strong>{{ summary.qualitativeScore }}</strong>
+          <span>정성</span>
+        </div>
+        <div class="first-evaluation-summary__score">
+          <strong>{{ summary.compositeScore }}</strong>
+          <span>종합</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="first-evaluation-summary__comment-card">
+      <p class="first-evaluation-summary__comment-label">팀리더 정성 평가</p>
+      <p class="first-evaluation-summary__comment">
+        {{ summary.qualitativeComment }}
+      </p>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.first-evaluation-summary {
+  display: grid;
+  gap: 14px;
+  margin-bottom: 16px;
+  padding: 18px;
+  border: 1px solid #dcd6ff;
+  border-radius: 20px;
+  background: linear-gradient(180deg, #faf8ff 0%, #f4f1ff 100%);
+}
+
+.first-evaluation-summary__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.first-evaluation-summary__eyebrow {
+  margin: 0 0 4px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--color-primary-500);
+}
+
+.first-evaluation-summary__title {
+  margin: 0;
+  font-size: 18px;
+  color: var(--color-primary-800);
+}
+
+.first-evaluation-summary__scores {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.first-evaluation-summary__score {
+  min-width: 72px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid #e1dbff;
+  text-align: center;
+}
+
+.first-evaluation-summary__score strong {
+  display: block;
+  font-size: 20px;
+  color: var(--color-primary-800);
+}
+
+.first-evaluation-summary__score span {
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+.first-evaluation-summary__comment-card {
+  padding: 14px 16px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid #e8e2ff;
+}
+
+.first-evaluation-summary__comment-label {
+  margin: 0 0 8px;
+  font-size: 12px;
+  font-weight: 700;
+  color: #6a57d3;
+}
+
+.first-evaluation-summary__comment {
+  margin: 0;
+  line-height: 1.7;
+  color: var(--color-primary-800);
+}
+
+@media (max-width: 720px) {
+  .first-evaluation-summary__header {
+    flex-direction: column;
+  }
+}
+</style>

--- a/src/components/hr/teamleader/qualitative-evaluation/TeamLeaderAiEvaluationActionBar.vue
+++ b/src/components/hr/teamleader/qualitative-evaluation/TeamLeaderAiEvaluationActionBar.vue
@@ -45,9 +45,11 @@ const emit = defineEmits(['close', 'save-draft', 'submit'])
   display: flex;
   justify-content: flex-end;
   gap: 10px;
-  padding: 0;
-  border: none;
-  background: transparent;
+  padding: 12px 14px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
 }
 
 .evaluation-action-bar__actions {
@@ -84,6 +86,7 @@ const emit = defineEmits(['close', 'save-draft', 'submit'])
 @media (max-width: 720px) {
   .evaluation-action-bar {
     justify-content: stretch;
+    padding: 12px;
   }
 
   .evaluation-action-bar__actions {

--- a/src/components/hr/teamleader/qualitative-evaluation/TeamLeaderAiEvaluationMemberListPanel.vue
+++ b/src/components/hr/teamleader/qualitative-evaluation/TeamLeaderAiEvaluationMemberListPanel.vue
@@ -1,7 +1,7 @@
 ﻿<script setup>
 import { computed, ref, watch } from 'vue'
 import { BaseEmptyState, BaseFilterTabs } from '@/components/common/base'
-import { TIER_BADGE_STYLES as tierColors } from '@/constants'
+import EvaluationMemberCard from '@/components/hr/common/evaluation/EvaluationMemberCard.vue'
 
 const props = defineProps({
   members: {
@@ -25,9 +25,9 @@ const statusFilter = ref('all')
 const currentPage = ref(1)
 
 const statusConfig = {
-  submitted: { label: '제출 완료', toneClass: 'member-card--submitted', metaClass: 'member-card__status--submitted' },
-  in_progress: { label: '작성 중', toneClass: 'member-card--in-progress', metaClass: 'member-card__status--in-progress' },
-  not_started: { label: '미작성', toneClass: 'member-card--not-started', metaClass: 'member-card__status--not-started' },
+  submitted: { label: '제출 완료' },
+  in_progress: { label: '작성 중' },
+  not_started: { label: '미작성' },
 }
 
 const statusTabs = computed(() => {
@@ -121,41 +121,21 @@ function goToPage(page) {
 
     <template v-if="filteredMembers.length">
       <div class="member-list-panel__list">
-        <article
+        <EvaluationMemberCard
           v-for="member in pagedMembers"
           :key="member.id"
-          class="member-card"
-          :class="[
-            statusConfig[member.status]?.toneClass,
-            { 'member-card--selected': String(member.id) === selectedId },
-          ]"
-          tabindex="0"
-          @click="selectMember(member.id)"
-          @keydown.enter="selectMember(member.id)"
-          @keydown.space.prevent="selectMember(member.id)"
-        >
-          <div class="member-card__left">
-            <div class="member-card__avatar" :class="`member-card__avatar--${member.avatarTone}`">
-              {{ member.avatar }}
-            </div>
-            <div class="member-card__copy">
-              <div class="member-card__name-row">
-                <strong class="member-card__name">{{ member.name }}</strong>
-                <span
-                  class="member-card__tier"
-                  :style="{ background: tierColors[member.tier]?.bg, color: tierColors[member.tier]?.text }"
-                >
-                  {{ member.tier }}
-                </span>
-              </div>
-              <p class="member-card__meta">{{ member.code }} | {{ member.scoreHint }}</p>
-              <span class="member-card__status" :class="statusConfig[member.status]?.metaClass">
-                {{ statusConfig[member.status]?.label }}
-              </span>
-            </div>
-          </div>
-          <span v-if="member.statusDate" class="member-card__date">{{ member.statusDate }}</span>
-        </article>
+          :member-id="member.id"
+          :name="member.name"
+          :avatar="member.avatar"
+          :avatar-tone="member.avatarTone"
+          :tier="member.tier"
+          :meta="`${member.code} | ${member.periodHint} | ${member.scoreHint}`"
+          :status="member.status"
+          :status-label="statusConfig[member.status]?.label"
+          :status-date="member.statusDate"
+          :selected="String(member.id) === selectedId"
+          @select="selectMember"
+        />
       </div>
 
       <div v-if="filteredMembers.length > 0" class="member-list-panel__pagination">
@@ -297,146 +277,6 @@ function goToPage(page) {
   color: var(--color-text-inverse);
 }
 
-.member-card {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 14px 16px;
-  border-radius: 18px;
-  border: 1px solid transparent;
-  background: #fcfbff;
-  cursor: pointer;
-  transition:
-    border-color 0.16s ease,
-    background-color 0.16s ease,
-    transform 0.16s ease;
-}
-
-.member-card:hover {
-  transform: translateY(-1px);
-}
-
-.member-card--selected {
-  border-color: var(--color-primary-300);
-  box-shadow: 0 0 0 3px rgba(107, 86, 246, 0.12);
-}
-
-.member-card--submitted {
-  background: #eefbf6;
-  border-color: #b8ead5;
-}
-
-.member-card--in-progress {
-  background: #f6f3ff;
-  border-color: #ddd5ff;
-}
-
-.member-card--not-started {
-  background: #f8f8fb;
-  border-color: var(--color-border-soft);
-}
-
-.member-card__left {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  min-width: 0;
-}
-
-.member-card__avatar {
-  width: 42px;
-  height: 42px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--color-text-inverse);
-  font-size: var(--font-size-md);
-  font-weight: var(--font-weight-bold);
-  flex-shrink: 0;
-}
-
-.member-card__avatar--purple {
-  background: #5f50d6;
-}
-
-.member-card__avatar--green {
-  background: #269063;
-}
-
-.member-card__avatar--gold {
-  background: #c08b00;
-}
-
-.member-card__copy {
-  display: grid;
-  gap: 4px;
-  min-width: 0;
-}
-
-.member-card__name-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  min-width: 0;
-}
-
-.member-card__name {
-  color: var(--color-primary-800);
-  font-size: var(--font-size-base-plus);
-  white-space: nowrap;
-}
-
-.member-card__tier {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  border-radius: 7px;
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-extrabold);
-  flex-shrink: 0;
-}
-
-.member-card__meta {
-  margin: 0;
-  color: var(--color-text-muted);
-  font-size: var(--font-size-xs-plus);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.member-card__status {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-semibold);
-}
-
-.member-card__status--submitted {
-  color: #168765;
-}
-
-.member-card__status--in-progress {
-  color: var(--color-primary-700);
-}
-
-.member-card__status--not-started {
-  color: var(--color-text-muted);
-}
-
-.member-card__date {
-  color: var(--color-text-muted);
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-medium);
-  white-space: nowrap;
-  flex-shrink: 0;
-}
-
 @media (max-width: 720px) {
   .member-list-panel {
     padding: 16px;
@@ -445,15 +285,6 @@ function goToPage(page) {
   .member-list-panel__header {
     flex-direction: column;
     align-items: flex-start;
-  }
-
-  .member-card {
-    align-items: flex-start;
-    flex-direction: column;
-  }
-
-  .member-card__date {
-    padding-left: 54px;
   }
 
   .member-list-panel__pagination {

--- a/src/components/hr/teamleader/qualitative-evaluation/TeamLeaderAiEvaluationPanel.vue
+++ b/src/components/hr/teamleader/qualitative-evaluation/TeamLeaderAiEvaluationPanel.vue
@@ -1,5 +1,7 @@
 <script setup>
 import { BaseModal } from '@/components/common/base'
+import AiEvaluationFormPanel from '@/components/hr/common/evaluation/AiEvaluationFormPanel.vue'
+import TeamLeaderAiEvaluationActionBar from './TeamLeaderAiEvaluationActionBar.vue'
 
 defineProps({
   selectedTarget: {
@@ -18,6 +20,14 @@ defineProps({
     type: String,
     default: '',
   },
+  actionDisabled: {
+    type: Boolean,
+    default: false,
+  },
+  readonly: {
+    type: Boolean,
+    default: false,
+  },
 })
 
 const emit = defineEmits([
@@ -27,6 +37,9 @@ const emit = defineEmits([
   'convert-text',
   'replay-audio',
   'toggle-guide',
+  'close',
+  'save-draft',
+  'submit',
 ])
 
 const structureSteps = [
@@ -44,81 +57,37 @@ const checklistItems = [
   '생산성, 품질, 협업 등 결과가 문장에 들어갔는가',
   '모호한 인상평가 대신 업무 사실 중심으로 썼는가',
 ]
-
-function handleFileChange(event) {
-  const [file] = event.target.files ?? []
-  emit('file-selected', file ?? null)
-  event.target.value = ''
-}
 </script>
 
 <template>
-  <section class="evaluation-form-panel">
-    <header class="evaluation-form-panel__header">
-      <div>
-        <h2 class="evaluation-form-panel__title">{{ selectedTarget.voiceLabel }}</h2>
-        <p class="evaluation-form-panel__description">
-          {{ selectedTarget.voiceDescription }}
-        </p>
-      </div>
-      <button type="button" class="evaluation-form-panel__voice-chip" @click="emit('voice-input')">
-        음성 입력
-      </button>
-    </header>
-
-    <div class="evaluation-form-panel__toolbar">
-      <div class="evaluation-form-panel__toolbar-left">
-        <button
-          type="button"
-          class="evaluation-form-panel__tool-button"
-          :class="{ 'evaluation-form-panel__tool-button--active': recordingState !== 'idle' }"
-          @click="emit('voice-input')"
-        >
-          음성 인식 시작
-        </button>
-        <label class="evaluation-form-panel__tool-button">
-          파일 업로드
-          <input class="evaluation-form-panel__file-input" type="file" accept=".txt,.md,.log" @change="handleFileChange" />
-        </label>
-        <button type="button" class="evaluation-form-panel__tool-button" @click="emit('convert-text')">텍스트 변환</button>
-        <button type="button" class="evaluation-form-panel__tool-button" @click="emit('replay-audio')">다시 듣기</button>
-      </div>
-      <button
-        type="button"
-        class="evaluation-form-panel__guide-button"
-        :class="{ 'evaluation-form-panel__guide-button--active': guideOpen }"
-        @click="emit('toggle-guide')"
-      >
-        작성 가이드
-      </button>
-    </div>
-
-    <div class="evaluation-form-panel__notice">
-      음성 인식 결과가 누락되거나 문장이 비문으로 바뀔 수 있습니다.
-      변환 결과는 초안으로만 사용하고 아래 패널에서 최종 평가 문장을 직접 수정하세요.
-    </div>
-
-    <div v-if="recordingState !== 'idle' || uploadedFileName" class="evaluation-form-panel__status-row">
-      <span v-if="recordingState !== 'idle'" class="evaluation-form-panel__status-chip">
-        {{ recordingState === 'recording' ? '음성 입력 mock 진행 중' : '음성 초안 준비 완료' }}
-      </span>
-      <span v-if="uploadedFileName" class="evaluation-form-panel__status-chip evaluation-form-panel__status-chip--file">
-        업로드 파일: {{ uploadedFileName }}
-      </span>
-    </div>
-
-    <textarea
-      class="evaluation-form-panel__editor"
-      :value="selectedTarget.convertedText"
-      @input="emit('update:converted-text', $event.target.value)"
-    ></textarea>
-
-    <div class="evaluation-form-panel__recording-zone">
-      <div class="evaluation-form-panel__recording-ring">
-        <div class="evaluation-form-panel__recording-icon">🎤</div>
-      </div>
-    </div>
-  </section>
+  <AiEvaluationFormPanel
+    :title="selectedTarget.voiceLabel"
+    :description="selectedTarget.voiceDescription"
+    :model-value="selectedTarget.convertedText"
+    :readonly="readonly"
+    :notice-text="'음성 인식 결과가 누락되거나 문장이 비문으로 바뀔 수 있습니다. 변환 결과는 초안으로만 사용하고 아래 패널에서 최종 평가 문장을 직접 수정하세요.'"
+    :recording-state="recordingState"
+    :uploaded-file-name="uploadedFileName"
+    :show-replay-button="true"
+    :show-guide-button="true"
+    :guide-active="guideOpen"
+    :recording-summary-renderer="() => ({ title: '1차 평가 작성 현황', description: `${(selectedTarget.convertedText ?? '').trim().length}자 입력 완료` })"
+    @update:model-value="emit('update:converted-text', $event)"
+    @voice-input="emit('voice-input')"
+    @file-selected="emit('file-selected', $event)"
+    @convert-text="emit('convert-text')"
+    @replay-audio="emit('replay-audio')"
+    @toggle-guide="emit('toggle-guide')"
+  >
+    <template #footer>
+      <TeamLeaderAiEvaluationActionBar
+        :disabled="actionDisabled"
+        @close="emit('close')"
+        @save-draft="emit('save-draft')"
+        @submit="emit('submit')"
+      />
+    </template>
+  </AiEvaluationFormPanel>
 
   <BaseModal
     v-if="guideOpen"
@@ -177,130 +146,6 @@ function handleFileChange(event) {
 </template>
 
 <style scoped>
-.evaluation-form-panel {
-  padding: 22px;
-  border: 1px solid var(--color-border-default);
-  border-radius: 24px;
-  background: var(--color-bg-surface);
-}
-
-.evaluation-form-panel__header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 18px;
-  margin-bottom: 16px;
-}
-
-.evaluation-form-panel__title {
-  font-size: 26px;
-  color: var(--color-primary-800);
-}
-
-.evaluation-form-panel__description {
-  margin-top: 8px;
-  font-size: 14px;
-  color: var(--color-text-muted);
-}
-
-.evaluation-form-panel__voice-chip {
-  height: 34px;
-  padding: 0 14px;
-  border: none;
-  border-radius: 999px;
-  background: rgba(174, 236, 227, 0.6);
-  color: #10937f;
-  font-weight: 700;
-  cursor: pointer;
-}
-
-.evaluation-form-panel__toolbar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding-top: 14px;
-  border-top: 1px solid var(--color-border-soft);
-}
-
-.evaluation-form-panel__toolbar-left {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-
-.evaluation-form-panel__tool-button,
-.evaluation-form-panel__guide-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  height: 38px;
-  padding: 0 16px;
-  border: 1px solid var(--color-border-default);
-  border-radius: 12px;
-  background: var(--color-bg-surface);
-  color: var(--color-primary-600);
-  font-size: 14px;
-  font-weight: 700;
-  line-height: 1;
-  box-sizing: border-box;
-  white-space: nowrap;
-  cursor: pointer;
-}
-
-.evaluation-form-panel__tool-button--active {
-  background: var(--color-primary-100);
-  color: var(--color-primary-700);
-}
-
-.evaluation-form-panel__file-input {
-  display: none;
-}
-
-.evaluation-form-panel__guide-button {
-  background: linear-gradient(180deg, #f0edff 0%, #d9d1ff 100%);
-}
-
-.evaluation-form-panel__guide-button--active {
-  border-color: #cfc7ff;
-  box-shadow: 0 0 0 3px rgba(91, 80, 214, 0.08);
-}
-
-.evaluation-form-panel__notice {
-  margin-top: 14px;
-  padding: 14px 16px;
-  border: 1px solid #ffdca6;
-  border-radius: 14px;
-  background: #fff5df;
-  font-size: 13px;
-  line-height: 1.6;
-  color: #946200;
-}
-
-.evaluation-form-panel__status-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  margin-top: 12px;
-}
-
-.evaluation-form-panel__status-chip {
-  display: inline-flex;
-  align-items: center;
-  min-height: 34px;
-  padding: 0 14px;
-  border-radius: 999px;
-  background: #e9fbf6;
-  color: #168267;
-  font-size: 13px;
-  font-weight: 700;
-}
-
-.evaluation-form-panel__status-chip--file {
-  background: #f4f2ff;
-  color: var(--color-primary-700);
-}
-
 .evaluation-guide {
   display: grid;
   gap: 18px;
@@ -408,58 +253,30 @@ function handleFileChange(event) {
   font-weight: 900;
 }
 
-.evaluation-form-panel__editor {
-  width: 100%;
-  min-height: 250px;
-  margin-top: 14px;
-  padding: 16px;
-  border: 1px solid var(--color-border-default);
-  border-radius: 18px;
-  resize: vertical;
-  font: inherit;
-  line-height: 1.8;
-  color: var(--color-primary-800);
-  box-sizing: border-box;
+.evaluation-form-panel__feedback {
+  margin: 0;
+  padding: 12px 14px;
+  border-radius: 14px;
+  font-size: 13px;
+  font-weight: 600;
 }
 
-.evaluation-form-panel__recording-zone {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 132px;
-  margin-top: 14px;
-  border-radius: 20px;
-  background: linear-gradient(180deg, rgba(174, 236, 227, 0.5) 0%, rgba(232, 251, 247, 0.85) 100%);
+.evaluation-form-panel__feedback--muted {
+  background: #f6f7fb;
+  color: var(--color-text-muted);
 }
 
-.evaluation-form-panel__recording-ring {
-  width: 106px;
-  height: 106px;
-  border-radius: 50%;
-  border: 4px solid rgba(16, 147, 127, 0.22);
-  display: flex;
-  align-items: center;
-  justify-content: center;
+.evaluation-form-panel__feedback--draft {
+  background: #f6f3ff;
+  color: var(--color-primary-700);
 }
 
-.evaluation-form-panel__recording-icon {
-  width: 86px;
-  height: 86px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: #08c8a7;
-  font-size: 34px;
+.evaluation-form-panel__feedback--submitted {
+  background: #eefbf6;
+  color: #1d7f5f;
 }
 
 @media (max-width: 720px) {
-  .evaluation-form-panel__header,
-  .evaluation-form-panel__toolbar {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
   .evaluation-guide__header {
     flex-direction: column;
   }

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -1,2 +1,3 @@
 export const API_BASE = import.meta.env.VITE_API_BASE ?? 'http://localhost:3001'
 export const ADMIN_API_BASE = import.meta.env.VITE_ADMIN_API_BASE ?? 'http://localhost:8080'
+export const HR_API_BASE = import.meta.env.VITE_HR_API_BASE ?? 'http://localhost:8081'

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,4 +1,4 @@
-export { API_BASE, ADMIN_API_BASE } from './api'
+export { API_BASE, ADMIN_API_BASE, HR_API_BASE } from './api'
 
 export {
   TIERS,

--- a/src/mocks/departmentleader/secondEvaluation.js
+++ b/src/mocks/departmentleader/secondEvaluation.js
@@ -12,6 +12,15 @@ export const evalMembers = [
     experience: '경력 3년 2월',
     status: 'submitted',
     statusDate: '03.05',
+    secondEvaluationDraft:
+      '1차 평가에서 확인된 강점을 유지하면서도, 팀 내 표준화 작업과 후배 지원 측면에서 조직 기여를 더 확장할 수 있을 것으로 판단됩니다. 현재 수준의 안정적인 성과를 감안할 때 상위 역할 수행 가능성도 높습니다.',
+    firstEvaluationSummary: {
+      quantitativeScore: 94.2,
+      qualitativeScore: 91.0,
+      compositeScore: 92.6,
+      qualitativeComment:
+        '야간 설비 이상 상황에서도 원인을 빠르게 특정했고, 정비 담당과의 협업을 주도해 재가동 시간을 단축했다. 이후 동일 이슈 재발 방지용 점검 포인트를 팀에 공유했다.',
+    },
     aiRecommended: { quantitative: 94.2, qualitative: 89.4, composite: 91.8 },
     evaluations: [
       { category: '직무 태도',    stars: 5, score: 95, comment: '작업 숙련도 매우 높음' },
@@ -32,6 +41,15 @@ export const evalMembers = [
     experience: '경력 2년 5월',
     status: 'submitted',
     statusDate: '03.06',
+    secondEvaluationDraft:
+      '업무 수행 안정성과 협업 태도는 전반적으로 우수합니다. 다만 예외 상황 대응 시 판단 근거와 후속 공유를 조금 더 명확히 남기면 팀 차원의 신뢰도와 재현 가능성이 더 높아질 것으로 보입니다.',
+    firstEvaluationSummary: {
+      quantitativeScore: 86.1,
+      qualitativeScore: 84.0,
+      compositeScore: 85.0,
+      qualitativeComment:
+        '업무 수행이 안정적이고 협업 태도도 좋다. 다만 돌발 이슈 대응에서는 보고 속도는 좋지만, 선제적 공유와 후속 정리까지 이어지는 부분은 조금 더 보완이 필요하다.',
+    },
     aiRecommended: { quantitative: 86.1, qualitative: 82.7, composite: 84.0 },
     evaluations: [
       { category: '직무 태도',    stars: 4, score: 85, comment: '성실한 업무 태도' },
@@ -52,6 +70,15 @@ export const evalMembers = [
     experience: '경력 2년 8월',
     status: 'in_progress',
     statusDate: '오늘',
+    secondEvaluationDraft:
+      '1차 평가에서 드러난 설비 최적화 기여는 긍정적입니다. 2차 평가에서는 문제 상황에서의 설명력과 의사결정 근거 공유를 더 보완할 필요가 있다고 판단합니다.',
+    firstEvaluationSummary: {
+      quantitativeScore: 83.4,
+      qualitativeScore: 80.0,
+      compositeScore: 81.7,
+      qualitativeComment:
+        '설비 최적화와 팀 협업 측면에서 기여도가 보였고 학습 속도도 양호했다. 다만 이슈 발생 시 판단 근거를 더 명확히 공유하면 신뢰도가 올라갈 것으로 보인다.',
+    },
     aiRecommended: { quantitative: 83.4, qualitative: 79.1, composite: 81.2 },
     evaluations: [
       { category: '직무 태도',    stars: 4, score: 82, comment: '팀 내 협력 우수, 지각 없음' },
@@ -72,6 +99,14 @@ export const evalMembers = [
     experience: '경력 1년 3월',
     status: 'not_started',
     statusDate: '—',
+    secondEvaluationDraft: '',
+    firstEvaluationSummary: {
+      quantitativeScore: 72.8,
+      qualitativeScore: 74.0,
+      compositeScore: 73.4,
+      qualitativeComment:
+        '기초 수행 역량은 확보하고 있으나, 업무 우선순위 판단과 커뮤니케이션 일관성은 추가 관찰이 필요하다. 반복 업무 정확도는 유지하되 상황 대응력 보완이 요구된다.',
+    },
     aiRecommended: { quantitative: 72.8, qualitative: 75.3, composite: 74.0 },
     evaluations: [
       { category: '직무 태도',    stars: 3, score: 72, comment: '' },

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -114,6 +114,11 @@ const routes = [
         name: 'HRMNoticeBoard',
         component: () => import('@/views/hrmanager/HRMNoticeBoardView.vue'),
       },
+      {
+        path: 'evaluation-period',
+        name: 'EvaluationPeriod',
+        component: () => import('@/views/hrmanager/HRMEvaluationPeriodView.vue'),
+      },
     ],
   },
 

--- a/src/services/departmentleader/evaluationApi.js
+++ b/src/services/departmentleader/evaluationApi.js
@@ -1,0 +1,26 @@
+import hrApi from '@/services/hrApi'
+
+/** DL 2차 평가 대상 목록 */
+export function fetchDlTargets(periodId) {
+  return hrApi.get('/api/v1/hr/department-leader/evaluations/targets', {
+    params: periodId ? { periodId } : {},
+  })
+}
+
+/** DL — 특정 사원 1차 평가 상세 (TL 코멘트·점수) */
+export function fetchDlEvaluationDetail(employeeId, periodId) {
+  return hrApi.get(`/api/v1/hr/department-leader/evaluations/${employeeId}`, {
+    params: periodId ? { periodId } : {},
+  })
+}
+
+/** DL 2차 평가 임시저장 / 제출 */
+export function updateDlEvaluation(employeeId, { status, evaluationPeriodId, evalItems, evalComment, inputMethod }) {
+  return hrApi.patch(`/api/v1/hr/department-leader/evaluations/${employeeId}`, {
+    status,
+    evaluationPeriodId,
+    evalItems: evalItems ?? null,
+    evalComment: evalComment ?? null,
+    inputMethod,
+  })
+}

--- a/src/services/hrApi.js
+++ b/src/services/hrApi.js
@@ -1,0 +1,83 @@
+import axios from 'axios'
+import { HR_API_BASE, ADMIN_API_BASE } from '@/constants'
+import { useAuthStore } from '@/stores/auth'
+
+const hrApi = axios.create({
+  baseURL: HR_API_BASE,
+  timeout: 5000,
+  withCredentials: true,
+})
+
+hrApi.interceptors.request.use((config) => {
+  const authStore = useAuthStore()
+  if (authStore.accessToken) {
+    config.headers.Authorization = `Bearer ${authStore.accessToken}`
+  }
+  return config
+})
+
+let isRefreshing = false
+let failedQueue = []
+
+function processQueue(error, token) {
+  failedQueue.forEach(({ resolve, reject }) => {
+    if (error) {
+      reject(error)
+    } else {
+      resolve(token)
+    }
+  })
+  failedQueue = []
+}
+
+hrApi.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config
+
+    if (error.response?.status !== 401 || originalRequest._retry) {
+      return Promise.reject(error)
+    }
+
+    if (isRefreshing) {
+      return new Promise((resolve, reject) => {
+        failedQueue.push({ resolve, reject })
+      }).then((token) => {
+        originalRequest.headers.Authorization = `Bearer ${token}`
+        return hrApi(originalRequest)
+      })
+    }
+
+    originalRequest._retry = true
+    isRefreshing = true
+
+    try {
+      const res = await axios.post(
+        `${ADMIN_API_BASE}/api/v1/auth/refresh`,
+        null,
+        { withCredentials: true }
+      )
+
+      if (res.data?.success && res.data.data?.accessToken) {
+        const newToken = res.data.data.accessToken
+        const authStore = useAuthStore()
+        authStore.setToken(newToken)
+        processQueue(null, newToken)
+        originalRequest.headers.Authorization = `Bearer ${newToken}`
+        return hrApi(originalRequest)
+      }
+    } catch (refreshError) {
+      processQueue(refreshError, null)
+      const authStore = useAuthStore()
+      authStore.clearAuth()
+      window.location.href = '/login'
+      return Promise.reject(refreshError)
+    } finally {
+      isRefreshing = false
+    }
+
+    return Promise.reject(error)
+  }
+)
+
+export default hrApi

--- a/src/services/hrmanager/evaluationPeriodApi.js
+++ b/src/services/hrmanager/evaluationPeriodApi.js
@@ -1,0 +1,51 @@
+import hrApi from '@/services/hrApi'
+
+/** active 알고리즘 버전 ID 조회 (HR 서버 경유) */
+export async function fetchActiveAlgorithmVersionId() {
+  const res = await hrApi.get('/api/v1/hr/evaluation-periods/active-algorithm')
+  const id = res.data?.data
+  if (!id) throw new Error('활성화된 알고리즘 버전이 없습니다.')
+  return id
+}
+
+/** 평가기간 목록 조회 */
+export function fetchEvaluationPeriods(params = {}) {
+  return hrApi.get('/api/v1/hr/evaluation-periods', { params })
+}
+
+/** 평가기간 생성 */
+export function createEvaluationPeriod({ algorithmVersionId, evalYear, evalSequence, evalType, startDate, endDate }) {
+  return hrApi.post('/api/v1/hr/evaluation-periods', {
+    algorithmVersionId,
+    evalYear,
+    evalSequence,
+    evalType,
+    startDate,
+    endDate,
+  })
+}
+
+/** 평가기간 수정 (startDate, endDate, algorithmVersionId 변경) */
+export function updateEvaluationPeriod(periodId, { startDate, endDate, algorithmVersionId }) {
+  return hrApi.patch(`/api/v1/hr/evaluation-periods/${periodId}`, {
+    startDate,
+    endDate,
+    algorithmVersionId,
+    status: 'IN_PROGRESS',
+  })
+}
+
+/** 평가기간 마감 */
+export function closeEvaluationPeriod(periodId) {
+  return hrApi.patch(`/api/v1/hr/evaluation-periods/${periodId}`, { status: 'CLOSING' })
+}
+
+/** 평가기간 확정 */
+export function confirmEvaluationPeriod(periodId) {
+  return hrApi.patch(`/api/v1/hr/evaluation-periods/${periodId}`, { status: 'CONFIRMED' })
+}
+
+/** 평가기간 삭제 (관련 평가내역 포함) */
+export function deleteEvaluationPeriod(periodId) {
+  return hrApi.delete(`/api/v1/hr/evaluation-periods/${periodId}`)
+}

--- a/src/services/teamleader/evaluationApi.js
+++ b/src/services/teamleader/evaluationApi.js
@@ -1,0 +1,19 @@
+import hrApi from '@/services/hrApi'
+
+/** TL 평가 대상 목록 조회 */
+export function fetchTlTargets(periodId) {
+  return hrApi.get('/api/v1/hr/team-leader/evaluations/targets', {
+    params: periodId ? { periodId } : {},
+  })
+}
+
+/** TL 정성 평가 임시저장 / 제출 */
+export function updateTlEvaluation(evaluateeId, { status, evaluationPeriodId, evalItems, evalComment, inputMethod }) {
+  return hrApi.patch(`/api/v1/hr/team-leader/evaluations/${evaluateeId}`, {
+    status,
+    evaluationPeriodId,
+    evalItems: evalItems ?? null,
+    evalComment: evalComment ?? null,
+    inputMethod,
+  })
+}

--- a/src/views/departmentleader/DepartmentLeaderSecondEvaluationView.vue
+++ b/src/views/departmentleader/DepartmentLeaderSecondEvaluationView.vue
@@ -1,18 +1,51 @@
 <script setup>
-import { ref, computed, onBeforeUnmount } from 'vue'
+import { ref, computed, onBeforeUnmount, onMounted } from 'vue'
 import { BaseToast } from '@/components/common/base/overlay'
 import DepartmentLeaderEvalMemberListPanel from '@/components/hr/departmentleader/second-evaluation/DepartmentLeaderEvalMemberListPanel.vue'
 import DepartmentLeaderEvalFormPanel from '@/components/hr/departmentleader/second-evaluation/DepartmentLeaderEvalFormPanel.vue'
-import { evalMembers, evalDeadline } from '@/mocks/departmentleader/secondEvaluation.js'
+import { fetchDlTargets, fetchDlEvaluationDetail, updateDlEvaluation } from '@/services/departmentleader/evaluationApi'
 
-const members = ref(evalMembers.map((m) => ({ ...m })))
-const selectedMember = ref(members.value[2]) // 황자현 selected by default
-const deadline = evalDeadline
-const totalCount = members.value.length
-const submittedCount = computed(() => members.value.filter((m) => m.status === 'submitted').length)
-const progressPercent = computed(() => (submittedCount.value / totalCount) * 100)
+const members = ref([])
+const selectedMember = ref(null)
+const evalPeriodId = ref(null)
 const toast = ref({ show: false, message: '', type: 'success' })
 let toastTimer = null
+
+const totalCount = computed(() => members.value.length)
+const submittedCount = computed(() => members.value.filter((m) => m.status === 'submitted').length)
+const progressPercent = computed(() => (totalCount.value > 0 ? (submittedCount.value / totalCount.value) * 100 : 0))
+const isSubmitted = computed(() => selectedMember.value?.status === 'submitted')
+
+const AVATAR_COLORS = ['#5f50d6', '#269063', '#c08b00', '#b03060', '#2070b0', '#806030']
+
+function avatarColor(name) {
+  let hash = 0
+  for (const ch of name ?? '') hash = (hash * 31 + ch.charCodeAt(0)) & 0xffff
+  return AVATAR_COLORS[hash % AVATAR_COLORS.length]
+}
+
+function mapStatus(apiStatus) {
+  if (apiStatus === 'SUBMITTED' || apiStatus === 'CONFIRMED') return 'submitted'
+  if (apiStatus === 'DRAFT') return 'in_progress'
+  return 'not_started'
+}
+
+function mapTarget(t) {
+  return {
+    id: t.evaluateeId,
+    name: t.employeeName,
+    avatar: (t.employeeName ?? '?')[0],
+    avatarColor: avatarColor(t.employeeName),
+    tier: t.employeeTier ?? '—',
+    code: '',
+    team: '',
+    experience: '',
+    status: mapStatus(t.status),
+    statusDate: '—',
+    secondEvaluationDraft: t.evalComment ?? '',
+    firstEvaluationSummary: null,
+  }
+}
 
 function showToast(message, type = 'success') {
   if (toastTimer) clearTimeout(toastTimer)
@@ -22,26 +55,95 @@ function showToast(message, type = 'success') {
   }, 2500)
 }
 
-function handleSave(draftText) {
-  const m = members.value.find((m) => m.id === selectedMember.value.id)
-  if (!m) return
-  m.secondEvaluationDraft = draftText
-  if (m.status === 'not_started') m.status = 'in_progress'
-  selectedMember.value = { ...m }
-  showToast('임시저장 되었습니다.')
+async function loadTargets() {
+  try {
+    const res = await fetchDlTargets()
+    const { evalPeriodId: pid, targets } = res.data.data
+    evalPeriodId.value = pid
+    members.value = targets.map(mapTarget)
+    if (members.value.length > 0) {
+      await handleSelect(members.value[0])
+    }
+  } catch {
+    showToast('평가 대상 목록을 불러오지 못했습니다.', 'error')
+  }
 }
 
-function handleSubmit(draftText) {
-  const m = members.value.find((m) => m.id === selectedMember.value.id)
-  if (!m) return
-  m.secondEvaluationDraft = draftText
-  m.status = 'submitted'
-  const today = new Date()
-  m.statusDate = `${String(today.getMonth() + 1).padStart(2, '0')}.${String(today.getDate()).padStart(2, '0')}`
-  selectedMember.value = { ...m }
-  showToast('최종 제출 완료되었습니다.')
+async function handleSelect(member) {
+  selectedMember.value = { ...member }
+  if (member.firstEvaluationSummary != null) return
+
+  try {
+    const res = await fetchDlEvaluationDetail(member.id, evalPeriodId.value)
+    const detail = res.data.data
+    const idx = members.value.findIndex((m) => m.id === member.id)
+    if (idx === -1) return
+    const updated = {
+      ...members.value[idx],
+      firstEvaluationSummary: {
+        quantitativeScore: null,
+        qualitativeScore: detail.firstStageScore ?? null,
+        compositeScore: null,
+        qualitativeComment: detail.evalComment ?? '',
+      },
+    }
+    members.value[idx] = updated
+    if (selectedMember.value?.id === member.id) {
+      selectedMember.value = updated
+    }
+  } catch {
+    // 1차 평가 상세가 없으면 summary null 유지 (v-if로 처리)
+  }
 }
 
+async function handleSave(draftText) {
+  if (!selectedMember.value || !evalPeriodId.value) return
+  try {
+    await updateDlEvaluation(selectedMember.value.id, {
+      status: 'DRAFT',
+      evaluationPeriodId: evalPeriodId.value,
+      evalComment: draftText,
+      inputMethod: 'TEXT',
+    })
+    const idx = members.value.findIndex((m) => m.id === selectedMember.value.id)
+    const updated = { ...members.value[idx], secondEvaluationDraft: draftText, status: 'in_progress' }
+    members.value[idx] = updated
+    selectedMember.value = updated
+    showToast('임시저장 되었습니다.')
+  } catch {
+    showToast('임시저장에 실패했습니다.', 'error')
+  }
+}
+
+async function handleSubmit(draftText) {
+  if (!selectedMember.value || !evalPeriodId.value) return
+  if (isSubmitted.value) return
+  try {
+    await updateDlEvaluation(selectedMember.value.id, {
+      status: 'SUBMITTED',
+      evaluationPeriodId: evalPeriodId.value,
+      evalComment: draftText,
+      inputMethod: 'TEXT',
+    })
+    const idx = members.value.findIndex((m) => m.id === selectedMember.value.id)
+    const updated = { ...members.value[idx], secondEvaluationDraft: draftText, status: 'submitted' }
+    members.value[idx] = updated
+    selectedMember.value = updated
+    showToast('최종 제출 완료되었습니다.')
+  } catch (e) {
+    const errCode = e?.response?.data?.errorCode
+    if (errCode === 'CONFLICT_008') {
+      const idx = members.value.findIndex((m) => m.id === selectedMember.value.id)
+      const updated = { ...members.value[idx], status: 'submitted' }
+      members.value[idx] = updated
+      selectedMember.value = updated
+    } else {
+      showToast('제출에 실패했습니다.', 'error')
+    }
+  }
+}
+
+onMounted(loadTargets)
 onBeforeUnmount(() => {
   if (toastTimer) clearTimeout(toastTimer)
 })
@@ -51,12 +153,11 @@ onBeforeUnmount(() => {
   <section class="dl-eval-view">
     <!-- Progress bar -->
     <div class="dl-eval-view__progress-bar">
-      <span class="dl-eval-view__progress-label">1분기 평가 진행률</span>
+      <span class="dl-eval-view__progress-label">평가 진행률</span>
       <div class="dl-eval-view__bar-track">
         <div class="dl-eval-view__bar-fill" :style="{ width: progressPercent + '%' }" />
       </div>
       <span class="dl-eval-view__progress-count">{{ submittedCount }} / {{ totalCount }}명 완료</span>
-      <span class="dl-eval-view__deadline">마감: {{ deadline }}</span>
     </div>
 
     <!-- Content -->
@@ -64,10 +165,11 @@ onBeforeUnmount(() => {
       <DepartmentLeaderEvalMemberListPanel
         :members="members"
         :selected-id="selectedMember?.id ?? null"
-        @select="selectedMember = $event"
+        @select="handleSelect($event)"
       />
       <DepartmentLeaderEvalFormPanel
         :member="selectedMember"
+        :readonly="isSubmitted"
         @save="handleSave"
         @submit="handleSubmit"
       />
@@ -125,13 +227,6 @@ onBeforeUnmount(() => {
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-bold);
   color: var(--color-primary-700);
-  white-space: nowrap;
-}
-
-.dl-eval-view__deadline {
-  font-size: var(--font-size-sm);
-  color: #e05a5a;
-  font-weight: var(--font-weight-semibold);
   white-space: nowrap;
 }
 

--- a/src/views/departmentleader/DepartmentLeaderSecondEvaluationView.vue
+++ b/src/views/departmentleader/DepartmentLeaderSecondEvaluationView.vue
@@ -1,35 +1,50 @@
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, onBeforeUnmount } from 'vue'
+import { BaseToast } from '@/components/common/base/overlay'
 import DepartmentLeaderEvalMemberListPanel from '@/components/hr/departmentleader/second-evaluation/DepartmentLeaderEvalMemberListPanel.vue'
 import DepartmentLeaderEvalFormPanel from '@/components/hr/departmentleader/second-evaluation/DepartmentLeaderEvalFormPanel.vue'
 import { evalMembers, evalDeadline } from '@/mocks/departmentleader/secondEvaluation.js'
 
-const members = ref(evalMembers.map((m) => ({ ...m, evaluations: m.evaluations.map((e) => ({ ...e })) })))
+const members = ref(evalMembers.map((m) => ({ ...m })))
 const selectedMember = ref(members.value[2]) // 황자현 selected by default
 const deadline = evalDeadline
 const totalCount = members.value.length
 const submittedCount = computed(() => members.value.filter((m) => m.status === 'submitted').length)
 const progressPercent = computed(() => (submittedCount.value / totalCount) * 100)
+const toast = ref({ show: false, message: '', type: 'success' })
+let toastTimer = null
 
-function handleSave(evals) {
-  const m = members.value.find((m) => m.id === selectedMember.value.id)
-  if (!m) return
-  m.evaluations = evals.map((e) => ({ ...e }))
-  if (m.status === 'not_started') m.status = 'in_progress'
-  selectedMember.value = { ...m }
-  alert('임시저장 되었습니다.')
+function showToast(message, type = 'success') {
+  if (toastTimer) clearTimeout(toastTimer)
+  toast.value = { show: true, message, type }
+  toastTimer = setTimeout(() => {
+    toast.value.show = false
+  }, 2500)
 }
 
-function handleSubmit(evals) {
+function handleSave(draftText) {
   const m = members.value.find((m) => m.id === selectedMember.value.id)
   if (!m) return
-  m.evaluations = evals.map((e) => ({ ...e }))
+  m.secondEvaluationDraft = draftText
+  if (m.status === 'not_started') m.status = 'in_progress'
+  selectedMember.value = { ...m }
+  showToast('임시저장 되었습니다.')
+}
+
+function handleSubmit(draftText) {
+  const m = members.value.find((m) => m.id === selectedMember.value.id)
+  if (!m) return
+  m.secondEvaluationDraft = draftText
   m.status = 'submitted'
   const today = new Date()
   m.statusDate = `${String(today.getMonth() + 1).padStart(2, '0')}.${String(today.getDate()).padStart(2, '0')}`
   selectedMember.value = { ...m }
-  alert('최종 제출 완료되었습니다.')
+  showToast('최종 제출 완료되었습니다.')
 }
+
+onBeforeUnmount(() => {
+  if (toastTimer) clearTimeout(toastTimer)
+})
 </script>
 
 <template>
@@ -57,6 +72,7 @@ function handleSubmit(evals) {
         @submit="handleSubmit"
       />
     </div>
+    <BaseToast :show="toast.show" :message="toast.message" :type="toast.type" />
   </section>
 </template>
 
@@ -122,9 +138,10 @@ function handleSubmit(evals) {
 /* Content grid */
 .dl-eval-view__content {
   display: grid;
-  grid-template-columns: 300px 1fr;
-  gap: 20px;
+  grid-template-columns: minmax(270px, 0.72fr) minmax(0, 1.6fr);
+  gap: 18px;
   align-items: stretch;
+  min-height: 0;
 }
 
 @media (max-width: 900px) {

--- a/src/views/hrmanager/HRMEvaluationPeriodView.vue
+++ b/src/views/hrmanager/HRMEvaluationPeriodView.vue
@@ -1,0 +1,941 @@
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import {
+  fetchEvaluationPeriods,
+  createEvaluationPeriod,
+  updateEvaluationPeriod,
+  closeEvaluationPeriod,
+  confirmEvaluationPeriod,
+  deleteEvaluationPeriod,
+  fetchActiveAlgorithmVersionId,
+} from '@/services/hrmanager/evaluationPeriodApi'
+
+// ── 상태 ──────────────────────────────────────────────
+const periods = ref([])
+const isLoading = ref(false)
+const actionLoading = ref(false) // 삭제/마감/확정 등 개별 액션 로딩
+const toast = ref({ show: false, message: '', type: 'success' })
+let toastTimer = null
+
+// 모달
+const modalMode = ref('') // 'create' | 'edit'
+const modalOpen = ref(false)
+const submitting = ref(false)
+
+const CURRENT_YEAR = new Date().getFullYear()
+const CURRENT_MONTH = new Date().getMonth() + 1
+
+const emptyForm = () => ({
+  _year: CURRENT_YEAR,
+  _month: CURRENT_MONTH,
+  evalSequence: 1,
+  evalType: 'QUALITATIVE',
+  startDate: '',
+  endDate: '',
+})
+const form = ref(emptyForm())
+const editingPeriodId = ref(null)
+
+// ── 필터 ──────────────────────────────────────────────
+const filterYear = ref('')
+const filterStatus = ref('')
+
+const STATUS_LABEL = { IN_PROGRESS: '진행중', CLOSING: '마감', CONFIRMED: '확정' }
+const STATUS_CLASS = {
+  IN_PROGRESS: 'period-table__badge--inprogress',
+  CLOSING: 'period-table__badge--closing',
+  CONFIRMED: 'period-table__badge--confirmed',
+}
+
+const STATUS_DESCRIPTION = {
+  IN_PROGRESS: '평가 입력이 진행 중인 기간',
+  CLOSING: '입력이 마감되고 확정을 기다리는 기간',
+  CONFIRMED: '결과가 최종 확정된 기간',
+}
+
+// ── API 호출 ──────────────────────────────────────────
+async function loadPeriods() {
+  isLoading.value = true
+  try {
+    const params = {}
+    if (filterYear.value) params.year = filterYear.value
+    if (filterStatus.value) params.status = filterStatus.value
+    const res = await fetchEvaluationPeriods(params)
+    periods.value = res.data.data.content ?? []
+  } catch {
+    showToast('평가기간 목록을 불러오지 못했습니다.', 'error')
+  } finally {
+    isLoading.value = false
+  }
+}
+
+onMounted(loadPeriods)
+
+// ── 토스트 ────────────────────────────────────────────
+function showToast(message, type = 'success') {
+  if (toastTimer) clearTimeout(toastTimer)
+  toast.value = { show: true, message, type }
+  toastTimer = setTimeout(() => { toast.value.show = false }, 2500)
+}
+
+// ── 모달 ──────────────────────────────────────────────
+function openCreate() {
+  form.value = emptyForm()
+  editingPeriodId.value = null
+  modalMode.value = 'create'
+  modalOpen.value = true
+}
+
+function openEdit(period) {
+  form.value = {
+    algorithmVersionId: period.algorithmVersionId ?? 1,
+    evalYear: period.evalYear,
+    evalSequence: period.evalSequence,
+    evalType: period.evalType,
+    startDate: period.startDate,
+    endDate: period.endDate,
+  }
+  editingPeriodId.value = period.evalPeriodId
+  modalMode.value = 'edit'
+  modalOpen.value = true
+}
+
+function closeModal() {
+  modalOpen.value = false
+}
+
+// ── 저장 ──────────────────────────────────────────────
+async function handleSave() {
+  if (!form.value.startDate || !form.value.endDate) {
+    showToast('시작일과 종료일을 입력해주세요.', 'error')
+    return
+  }
+  if (form.value.startDate > form.value.endDate) {
+    showToast('종료일은 시작일 이후여야 합니다.', 'error')
+    return
+  }
+
+  submitting.value = true
+  try {
+    if (modalMode.value === 'create') {
+      const algorithmVersionId = await fetchActiveAlgorithmVersionId()
+      const evalYear = form.value._year * 100 + form.value._month
+      await createEvaluationPeriod({ ...form.value, evalYear, algorithmVersionId })
+      showToast('평가기간이 생성되었습니다.')
+    } else {
+      await updateEvaluationPeriod(editingPeriodId.value, form.value)
+      showToast('평가기간이 수정되었습니다.')
+    }
+    closeModal()
+  } catch (e) {
+    const msg = e.response?.data?.message ?? '저장에 실패했습니다.'
+    showToast(msg, 'error')
+    closeModal()
+  } finally {
+    submitting.value = false
+    await loadPeriods()
+  }
+}
+
+// ── 마감 / 확정 / 삭제 ───────────────────────────────
+async function handleClose(period) {
+  if (!confirm(`"${formatPeriodLabel(period)}" 평가기간을 마감하시겠습니까?`)) return
+  actionLoading.value = true
+  try {
+    await closeEvaluationPeriod(period.evalPeriodId)
+    showToast('평가기간이 마감되었습니다.')
+    await loadPeriods()
+  } catch (e) {
+    const msg = e.response?.data?.message ?? '마감에 실패했습니다.'
+    showToast(msg, 'error')
+  } finally {
+    actionLoading.value = false
+  }
+}
+
+async function handleConfirm(period) {
+  if (!confirm(`"${formatPeriodLabel(period)}" 평가기간을 확정하시겠습니까?`)) return
+  actionLoading.value = true
+  try {
+    await confirmEvaluationPeriod(period.evalPeriodId)
+    showToast('평가기간이 확정되었습니다.')
+    await loadPeriods()
+  } catch (e) {
+    const msg = e.response?.data?.message ?? '확정에 실패했습니다.'
+    showToast(msg, 'error')
+  } finally {
+    actionLoading.value = false
+  }
+}
+
+async function handleDelete(period) {
+  if (!confirm(`"${formatPeriodLabel(period)}" 평가기간과 관련 평가내역을 삭제하시겠습니까?`)) return
+  actionLoading.value = true
+  try {
+    await deleteEvaluationPeriod(period.evalPeriodId)
+    showToast('평가기간이 삭제되었습니다.')
+    await loadPeriods()
+  } catch (e) {
+    const msg = e.response?.data?.message ?? '삭제에 실패했습니다.'
+    showToast(msg, 'error')
+  } finally {
+    actionLoading.value = false
+  }
+}
+
+// ── 날짜 범위 (선택한 연도+월 기준) ──────────────────
+const dateMin = computed(() => {
+  const m = String(form.value._month).padStart(2, '0')
+  return `${form.value._year}-${m}-01`
+})
+const dateMax = computed(() => {
+  const lastDay = new Date(form.value._year, form.value._month, 0).getDate()
+  const m = String(form.value._month).padStart(2, '0')
+  return `${form.value._year}-${m}-${lastDay}`
+})
+
+// 필터용 연도 옵션
+const yearOptions = computed(() => {
+  const cur = new Date().getFullYear()
+  return [cur - 1, cur, cur + 1]
+})
+
+const totalCount = computed(() => periods.value.length)
+const inProgressCount = computed(() => periods.value.filter((p) => p.status === 'IN_PROGRESS').length)
+const closingCount = computed(() => periods.value.filter((p) => p.status === 'CLOSING').length)
+const confirmedCount = computed(() => periods.value.filter((p) => p.status === 'CONFIRMED').length)
+
+function parsePeriodYear(evalYear) {
+  const s = String(evalYear)
+  if (s.length === 6) return { year: s.slice(0, 4), month: parseInt(s.slice(4, 6)) }
+  return { year: s, month: null }
+}
+
+function formatPeriodLabel(period) {
+  const { year, month } = parsePeriodYear(period.evalYear)
+  const monthStr = month ? ` ${month}월` : ''
+  return `${year}년${monthStr} ${period.evalSequence}차`
+}
+
+function formatDateRange(period) {
+  return `${period.startDate} ~ ${period.endDate}`
+}
+
+function getDurationDays(period) {
+  if (!period.startDate || !period.endDate) return '-'
+  const start = new Date(period.startDate)
+  const end = new Date(period.endDate)
+  const diff = Math.round((end - start) / (1000 * 60 * 60 * 24)) + 1
+  return Number.isNaN(diff) ? '-' : `${diff}일`
+}
+</script>
+
+<template>
+  <section class="period-view">
+    <div class="period-view__header">
+      <div>
+        <p class="period-view__eyebrow">평가 기간 관리</p>
+        <h2 class="period-view__title">평가기간 설정</h2>
+        <p class="period-view__subtitle">
+          진행중, 마감, 확정 상태를 확인하고 필요한 기간만 바로 조치할 수 있습니다.
+        </p>
+      </div>
+    </div>
+
+    <div class="period-panel">
+      <div class="period-panel__toolbar">
+        <div class="period-panel__filters">
+          <label class="period-panel__filter">
+            <span class="period-panel__filter-label">연도</span>
+            <select class="period-view__select" v-model="filterYear" @change="loadPeriods">
+              <option value="">전체 연도</option>
+              <option v-for="y in yearOptions" :key="y" :value="y">{{ y }}년</option>
+            </select>
+          </label>
+          <label class="period-panel__filter">
+            <span class="period-panel__filter-label">상태</span>
+            <select class="period-view__select" v-model="filterStatus" @change="loadPeriods">
+              <option value="">전체 상태</option>
+              <option value="IN_PROGRESS">진행중</option>
+              <option value="CLOSING">마감</option>
+              <option value="CONFIRMED">확정</option>
+            </select>
+          </label>
+          <button class="period-view__btn period-view__btn--outline period-panel__refresh" @click="loadPeriods">
+            새로고침
+          </button>
+        </div>
+        <div class="period-panel__actions">
+          <button class="period-view__btn period-view__btn--primary" @click="openCreate">
+            + 평가기간 생성
+          </button>
+        </div>
+      </div>
+
+      <div class="period-panel__meta">
+        <span class="period-panel__result">총 {{ totalCount }}개 · 진행중 {{ inProgressCount }} · 마감 {{ closingCount }} · 확정 {{ confirmedCount }}</span>
+        <span class="period-panel__hint">현재 필요한 평가기간만 간결하게 관리할 수 있도록 정리된 목록입니다.</span>
+      </div>
+
+      <div class="period-view__table-wrap">
+        <table class="period-table" v-if="!isLoading && !actionLoading">
+          <thead class="period-table__head">
+            <tr>
+              <th>평가기간</th>
+              <th>운영 기간</th>
+              <th>기간 길이</th>
+              <th>상태</th>
+              <th>작업</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-if="periods.length === 0">
+              <td colspan="5" class="period-table__empty">
+                <strong>등록된 평가기간이 없습니다.</strong>
+                <span>새 평가기간을 생성하면 이 영역에 상태와 작업 흐름이 표시됩니다.</span>
+              </td>
+            </tr>
+            <tr v-for="p in periods" :key="p.evalPeriodId" class="period-table__row">
+              <td class="period-table__period-cell">
+                <strong class="period-table__period-title">{{ formatPeriodLabel(p) }}</strong>
+                <span class="period-table__period-subtitle">{{ p.evalType === 'QUALITATIVE' ? '정성 평가' : p.evalType }}</span>
+              </td>
+              <td class="period-table__range">{{ formatDateRange(p) }}</td>
+              <td>{{ getDurationDays(p) }}</td>
+              <td>
+                <span class="period-table__badge" :class="STATUS_CLASS[p.status]">
+                  {{ STATUS_LABEL[p.status] ?? p.status }}
+                </span>
+                <p class="period-table__status-note">{{ STATUS_DESCRIPTION[p.status] }}</p>
+              </td>
+              <td class="period-table__actions">
+                <button
+                  v-if="p.status === 'IN_PROGRESS'"
+                  class="period-table__action-btn period-table__action-btn--edit"
+                  :disabled="actionLoading"
+                  @click="openEdit(p)"
+                >기간 수정</button>
+                <button
+                  v-if="p.status === 'IN_PROGRESS'"
+                  class="period-table__action-btn period-table__action-btn--close"
+                  :disabled="actionLoading"
+                  @click="handleClose(p)"
+                >마감 처리</button>
+                <button
+                  v-if="p.status === 'CLOSING'"
+                  class="period-table__action-btn period-table__action-btn--confirm"
+                  :disabled="actionLoading"
+                  @click="handleConfirm(p)"
+                >최종 확정</button>
+                <span v-if="p.status === 'CONFIRMED'" class="period-table__done">완료된 평가기간</span>
+                <button
+                  class="period-table__action-btn period-table__action-btn--delete"
+                  :disabled="actionLoading"
+                  @click="handleDelete(p)"
+                >삭제</button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <div v-if="isLoading || actionLoading" class="period-view__loading">
+          <span class="period-view__spinner"></span>
+          {{ isLoading ? '목록을 불러오는 중...' : '처리 중...' }}
+        </div>
+      </div>
+    </div>
+
+    <div v-if="modalOpen" class="period-modal__overlay" @click.self="closeModal">
+      <div class="period-modal">
+        <div class="period-modal__header">
+          <h3 class="period-modal__title">{{ modalMode === 'create' ? '평가기간 생성' : '평가기간 수정' }}</h3>
+          <button class="period-modal__close" @click="closeModal">✕</button>
+        </div>
+
+        <div class="period-modal__body">
+          <div class="period-modal__row" v-if="modalMode === 'create'">
+            <label class="period-modal__label">평가 연도 / 월</label>
+            <div class="period-modal__row-inline">
+              <select class="period-modal__input" v-model.number="form._year">
+                <option v-for="y in yearOptions" :key="y" :value="y">{{ y }}년</option>
+              </select>
+              <select class="period-modal__input" v-model.number="form._month">
+                <option v-for="m in 12" :key="m" :value="m">{{ m }}월</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="period-modal__row" v-if="modalMode === 'create'">
+            <label class="period-modal__label">차수</label>
+            <select class="period-modal__input" v-model.number="form.evalSequence">
+              <option v-for="w in 5" :key="w" :value="w">{{ w }}차</option>
+            </select>
+          </div>
+
+          <div class="period-modal__row" v-if="modalMode === 'create'">
+            <label class="period-modal__label">평가 유형</label>
+            <select class="period-modal__input" v-model="form.evalType">
+              <option value="QUALITATIVE">정성 평가</option>
+              <option value="QUANTITATIVE">정량 평가</option>
+              <option value="COMPREHENSIVE">종합 평가</option>
+            </select>
+          </div>
+
+          <div class="period-modal__row">
+            <label class="period-modal__label">시작일</label>
+            <input type="date" class="period-modal__input" v-model="form.startDate"
+              :min="dateMin" :max="dateMax" />
+          </div>
+
+          <div class="period-modal__row">
+            <label class="period-modal__label">종료일</label>
+            <input type="date" class="period-modal__input" v-model="form.endDate"
+              :min="form.startDate || dateMin" :max="dateMax" />
+          </div>
+
+          <div class="period-modal__notice">
+            저장 후 진행중 상태에서는 기간 수정과 마감이 가능하고, 마감 이후에는 최종 확정만 가능합니다.
+          </div>
+        </div>
+
+        <div class="period-modal__footer">
+          <button class="period-view__btn period-view__btn--outline" @click="closeModal">취소</button>
+          <button
+            class="period-view__btn period-view__btn--primary"
+            @click="handleSave"
+            :disabled="submitting"
+          >
+            {{ submitting ? '저장 중...' : '저장' }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div
+      v-if="toast.show"
+      class="period-view__toast"
+      :class="`period-view__toast--${toast.type}`"
+    >
+      {{ toast.message }}
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.period-view {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 28px;
+  background: var(--color-bg-app);
+  overflow: auto;
+  min-height: 0;
+  position: relative;
+}
+
+.period-view__header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.period-view__eyebrow {
+  margin: 0 0 4px;
+  color: var(--color-primary-500);
+  font-size: var(--font-size-xs-plus);
+  font-weight: var(--font-weight-semibold);
+}
+
+.period-view__title {
+  margin: 0;
+  color: var(--color-primary-800);
+  font-size: 32px;
+  font-weight: var(--font-weight-bold);
+  line-height: 1.15;
+}
+
+.period-view__subtitle {
+  margin: 8px 0 0;
+  max-width: 680px;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: 1.6;
+}
+
+.period-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 18px;
+  border-radius: 22px;
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-default);
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.04);
+}
+
+.period-panel__toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 16px;
+}
+
+.period-panel__filters {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.period-panel__filter {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.period-panel__filter-label {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--color-text-muted);
+}
+
+.period-panel__actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.period-panel__refresh {
+  align-self: flex-end;
+}
+
+.period-panel__meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+  padding: 0 6px;
+}
+
+.period-panel__result {
+  color: var(--color-primary-800);
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+}
+
+.period-panel__hint {
+  color: var(--color-text-muted);
+  font-size: 12px;
+}
+
+.period-view__select {
+  min-width: 144px;
+  height: 42px;
+  padding: 0 14px;
+  border: 1.5px solid var(--color-border-default);
+  border-radius: 10px;
+  font-size: var(--font-size-sm);
+  background: var(--color-bg-surface);
+  color: var(--color-text-primary);
+  cursor: pointer;
+}
+
+.period-view__btn {
+  height: 42px;
+  padding: 0 20px;
+  border-radius: 10px;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+  cursor: pointer;
+  border: none;
+}
+
+.period-view__btn--primary {
+  background: var(--color-primary-600);
+  color: var(--color-white);
+}
+
+.period-view__btn--primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.period-view__btn--outline {
+  background: var(--color-bg-surface);
+  color: var(--color-primary-600);
+  border: 1.5px solid var(--color-primary-300);
+}
+
+.period-view__table-wrap {
+  flex: 1;
+  border: 1px solid var(--color-border-default);
+  border-radius: 18px;
+  overflow: hidden;
+  background: var(--color-bg-surface);
+}
+
+.period-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.period-table__head th {
+  padding: 16px 18px;
+  background: var(--color-bg-subtle, #f8f9fb);
+  font-size: 12px;
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-muted);
+  text-align: left;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  border-bottom: 1px solid var(--color-border-default);
+}
+
+.period-table__row td {
+  padding: 18px;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-primary);
+  border-bottom: 1px solid var(--color-border-subtle, #f0f1f5);
+  vertical-align: middle;
+}
+
+.period-table__row:hover td {
+  background: rgba(111, 90, 220, 0.02);
+}
+
+.period-table__row:last-child td {
+  border-bottom: none;
+}
+
+.period-table__empty {
+  text-align: center;
+  padding: 64px 24px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.period-table__empty strong,
+.period-table__empty span {
+  display: block;
+}
+
+.period-table__empty strong {
+  margin-bottom: 8px;
+  color: var(--color-primary-800);
+  font-size: 16px;
+}
+
+.period-table__period-cell {
+  min-width: 200px;
+}
+
+.period-table__period-title {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 15px;
+  font-weight: 800;
+  color: var(--color-primary-900, #231a58);
+}
+
+.period-table__period-subtitle {
+  display: block;
+  color: var(--color-text-muted);
+  font-size: 12px;
+}
+
+.period-table__range {
+  color: var(--color-text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+.period-table__badge {
+  display: inline-block;
+  padding: 5px 12px;
+  border-radius: 20px;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.period-table__badge--inprogress {
+  background: #e8f4ff;
+  color: #1a6abf;
+}
+
+.period-table__badge--closing {
+  background: #fff3e0;
+  color: #b45309;
+}
+
+.period-table__badge--confirmed {
+  background: #eefbf6;
+  color: #1d7f5f;
+}
+
+.period-table__status-note {
+  margin: 8px 0 0;
+  color: var(--color-text-muted);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.period-table__actions {
+  min-width: 200px;
+}
+
+.period-table__actions > * {
+  margin-right: 8px;
+  margin-bottom: 6px;
+  vertical-align: middle;
+}
+
+.period-table__actions > *:last-child {
+  margin-right: 0;
+}
+
+.period-table__actions .period-table__done {
+  display: inline-block;
+  margin-bottom: 0;
+}
+
+.period-table__action-btn {
+  height: 34px;
+  padding: 0 14px;
+  border-radius: 8px;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  border: none;
+}
+
+.period-table__action-btn--edit {
+  background: var(--color-bg-subtle, #f0f1f5);
+  color: var(--color-text-primary);
+}
+
+.period-table__action-btn--close {
+  background: #fff3e0;
+  color: #b45309;
+}
+
+.period-table__action-btn--confirm {
+  background: var(--color-primary-600);
+  color: var(--color-white);
+}
+
+.period-table__action-btn--delete {
+  background: #fff0f0;
+  color: #c0392b;
+}
+
+.period-table__action-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.period-table__done {
+  font-size: 12px;
+  color: #1d7f5f;
+  font-weight: 700;
+}
+
+.period-view__loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  text-align: center;
+  padding: 72px 24px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.period-view__spinner {
+  width: 18px;
+  height: 18px;
+  border: 2px solid var(--color-border-default);
+  border-top-color: var(--color-primary-500);
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* 모달 */
+.period-modal__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.period-modal {
+  background: var(--color-bg-surface);
+  border-radius: 16px;
+  width: 420px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
+  display: flex;
+  flex-direction: column;
+}
+
+.period-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 24px 0;
+}
+
+.period-modal__title {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary-800);
+}
+
+.period-modal__close {
+  background: none;
+  border: none;
+  font-size: 18px;
+  cursor: pointer;
+  color: var(--color-text-muted);
+  padding: 0;
+  line-height: 1;
+}
+
+.period-modal__body {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 20px 24px;
+}
+
+.period-modal__row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.period-modal__label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-secondary);
+}
+
+.period-modal__hint {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.period-modal__input {
+  height: 40px;
+  padding: 0 12px;
+  border: 1.5px solid var(--color-border-default);
+  border-radius: 8px;
+  font-size: var(--font-size-base);
+  color: var(--color-text-primary);
+  background: var(--color-bg-app);
+}
+
+.period-modal__input:focus {
+  outline: none;
+  border-color: var(--color-primary-400);
+}
+
+.period-modal__row-inline {
+  display: flex;
+  gap: 8px;
+}
+
+.period-modal__row-inline .period-modal__input {
+  flex: 1;
+}
+
+.period-modal__static {
+  height: 40px;
+  padding: 0 12px;
+  display: flex;
+  align-items: center;
+  border: 1.5px solid var(--color-border-default);
+  border-radius: 8px;
+  font-size: var(--font-size-base);
+  color: var(--color-text-muted);
+  background: var(--color-bg-subtle, #f8f9fb);
+}
+
+.period-modal__notice {
+  padding: 14px 16px;
+  border-radius: 12px;
+  background: rgba(111, 90, 220, 0.06);
+  color: var(--color-text-secondary);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.period-modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 0 24px 20px;
+}
+
+/* 토스트 */
+.period-view__toast {
+  position: fixed;
+  bottom: 32px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 12px 24px;
+  border-radius: 10px;
+  font-size: 14px;
+  font-weight: 600;
+  z-index: 2000;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+}
+
+.period-view__toast--success {
+  background: #eefbf6;
+  color: #1d7f5f;
+}
+
+.period-view__toast--error {
+  background: #fff0f0;
+  color: #c0392b;
+}
+
+@media (max-width: 1080px) {
+  .period-panel__toolbar,
+  .period-panel__meta {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
+@media (max-width: 768px) {
+  .period-view {
+    padding: 18px;
+  }
+
+  .period-view__title {
+    font-size: 26px;
+  }
+
+  .period-view__table-wrap {
+    overflow: auto;
+  }
+
+  .period-table {
+    min-width: 760px;
+  }
+
+  .period-modal {
+    width: calc(100vw - 24px);
+  }
+}
+</style>

--- a/src/views/teamleader/TeamLeaderAiEvaluationView.vue
+++ b/src/views/teamleader/TeamLeaderAiEvaluationView.vue
@@ -1,51 +1,76 @@
 ﻿<script setup>
-import { computed, reactive, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
 import { BaseProgressBar } from '@/components/common/base'
+import { BaseToast } from '@/components/common/base/overlay'
 import TeamLeaderAiEvaluationMemberListPanel from '@/components/hr/teamleader/qualitative-evaluation/TeamLeaderAiEvaluationMemberListPanel.vue'
 import TeamLeaderAiEvaluationPanel from '@/components/hr/teamleader/qualitative-evaluation/TeamLeaderAiEvaluationPanel.vue'
-import TeamLeaderAiEvaluationActionBar from '@/components/hr/teamleader/qualitative-evaluation/TeamLeaderAiEvaluationActionBar.vue'
-import { aiEvaluationTargets, aiEvaluationSelectedTarget } from '@/mocks/teamleader/aiEvaluation'
+import { fetchTlTargets, updateTlEvaluation } from '@/services/teamleader/evaluationApi'
 
-const selectedTargetId = ref(String(aiEvaluationTargets[0]?.id ?? ''))
-const actionFeedback = ref('')
-const actionFeedbackTone = ref('muted')
+const AVATAR_TONES = ['purple', 'green', 'gold']
+const STATUS_MAP = { NO_INPUT: 'not_started', DRAFT: 'in_progress', SUBMITTED: 'submitted' }
+
+const rawTargets = ref([])
+const evalPeriodId = ref(null)
+
+const selectedTargetId = ref('')
 const guideOpen = ref(false)
 const recordingState = ref('idle')
 const uploadedFileName = ref('')
 const uploadedText = ref('')
+const toast = ref({ show: false, message: '', type: 'success' })
+let toastTimer = null
 
-function buildConvertedText(target) {
-  return aiEvaluationSelectedTarget.convertedText.replaceAll('김신우', target.name)
-}
-
-const evaluationDrafts = reactive(
-  Object.fromEntries(
-    aiEvaluationTargets.map((target) => [String(target.id), buildConvertedText(target)]),
-  ),
-)
-
-const savedDrafts = reactive(
-  Object.fromEntries(
-    aiEvaluationTargets.map((target) => [String(target.id), buildConvertedText(target)]),
-  ),
-)
-
+const evaluationDrafts = reactive({})
+const savedDrafts = reactive({})
 const submittedEvaluations = reactive({})
 
+function mapTarget(target, index) {
+  const evaluationPeriodId = target.evaluationPeriodId ?? null
+  return {
+    id: `${target.evaluateeId}:${evaluationPeriodId ?? 'none'}`,
+    evaluateeId: String(target.evaluateeId),
+    evaluationPeriodId,
+    name: target.employeeName,
+    code: target.employeeCode,
+    tier: target.employeeTier,
+    scoreHint: target.totalScore != null ? `Overall ${target.totalScore}` : target.employeeTier,
+    periodHint: evaluationPeriodId ? '진행중 기간' : '기간 미지정',
+    avatar: target.employeeName?.[0] ?? '?',
+    avatarTone: AVATAR_TONES[index % AVATAR_TONES.length],
+  }
+}
+
+onMounted(async () => {
+  try {
+    const res = await fetchTlTargets()
+    const data = res.data.data
+    evalPeriodId.value = data.evalPeriodId
+    rawTargets.value = data.targets.map(mapTarget)
+    data.targets.forEach((t) => {
+      const targetKey = `${t.evaluateeId}:${t.evaluationPeriodId ?? 'none'}`
+      evaluationDrafts[targetKey] = t.evalComment ?? ''
+      savedDrafts[targetKey] = t.evalComment ?? ''
+      if (t.status === 'SUBMITTED') {
+        submittedEvaluations[targetKey] = true
+      }
+    })
+    if (rawTargets.value.length) {
+      selectedTargetId.value = rawTargets.value[0].id
+    }
+  } catch (e) {
+    updateFeedback('평가 대상 목록을 불러오지 못했습니다.', 'muted')
+  }
+})
+
 const memberListItems = computed(() =>
-  aiEvaluationTargets.map((target) => {
+  rawTargets.value.map((target) => {
     const targetId = String(target.id)
-    const baselineText = buildConvertedText(target)
-    const draftText = evaluationDrafts[targetId] ?? baselineText
     const hasSubmitted = Boolean(submittedEvaluations[targetId])
-    const hasEdited = draftText !== baselineText
+    const hasEdited = Boolean(evaluationDrafts[targetId])
 
     let status = 'not_started'
-    if (hasSubmitted) {
-      status = 'submitted'
-    } else if (hasEdited) {
-      status = 'in_progress'
-    }
+    if (hasSubmitted) status = 'submitted'
+    else if (hasEdited) status = 'in_progress'
 
     return {
       ...target,
@@ -60,10 +85,7 @@ const submittedCount = computed(
 )
 
 const evaluationCompletionRate = computed(() => {
-  if (!memberListItems.value.length) {
-    return 0
-  }
-
+  if (!memberListItems.value.length) return 0
   return Math.round((submittedCount.value / memberListItems.value.length) * 100)
 })
 
@@ -74,9 +96,7 @@ watch(
       selectedTargetId.value = ''
       return
     }
-
     const hasSelectedTarget = targets.some((target) => String(target.id) === selectedTargetId.value)
-
     if (!hasSelectedTarget) {
       selectedTargetId.value = String(targets[0].id)
     }
@@ -85,17 +105,13 @@ watch(
 )
 
 const selectedTarget = computed(() => {
-  const target = aiEvaluationTargets.find((item) => String(item.id) === selectedTargetId.value) ?? aiEvaluationTargets[0]
-
-  if (!target) {
-    return aiEvaluationSelectedTarget
-  }
+  const target = rawTargets.value.find((item) => String(item.id) === selectedTargetId.value)
+  if (!target) return { voiceLabel: '', voiceDescription: '', convertedText: '' }
 
   return {
-    ...aiEvaluationSelectedTarget,
     voiceLabel: `${target.name} 음성 초안 작성`,
     voiceDescription: `${target.name} (${target.code}) 평가 내용을 음성으로 작성하고 텍스트로 변환할 수 있습니다.`,
-    convertedText: evaluationDrafts[String(target.id)] ?? buildConvertedText(target),
+    convertedText: evaluationDrafts[String(target.id)] ?? '',
   }
 })
 
@@ -104,73 +120,91 @@ function handleSelectTarget(targetId) {
 }
 
 function handleUpdateConvertedText(value) {
-  if (!selectedTargetId.value) {
-    return
-  }
-
+  if (!selectedTargetId.value) return
   evaluationDrafts[selectedTargetId.value] = value
 }
 
 function updateFeedback(message, tone = 'muted') {
-  actionFeedback.value = message
-  actionFeedbackTone.value = tone
+  if (toastTimer) clearTimeout(toastTimer)
+  toast.value = {
+    show: true,
+    message,
+    type: tone === 'muted' ? 'error' : 'success',
+  }
+  toastTimer = setTimeout(() => {
+    toast.value.show = false
+  }, 2500)
 }
 
 function handleCloseEditor() {
-  if (!selectedTargetId.value) {
-    return
-  }
-
-  const fallbackTarget = aiEvaluationTargets.find((target) => String(target.id) === selectedTargetId.value)
-  const fallbackText = fallbackTarget ? buildConvertedText(fallbackTarget) : ''
-
-  evaluationDrafts[selectedTargetId.value] =
-    submittedEvaluations[selectedTargetId.value] ?? savedDrafts[selectedTargetId.value] ?? fallbackText
-
+  if (!selectedTargetId.value) return
+  evaluationDrafts[selectedTargetId.value] = savedDrafts[selectedTargetId.value] ?? ''
   updateFeedback('현재 대상자의 편집 내용을 마지막 저장 기준으로 되돌렸습니다.', 'muted')
 }
 
-function handleSaveDraft() {
-  if (!selectedTargetId.value) {
+async function handleSaveDraft() {
+  if (!selectedTargetId.value) return
+
+  const currentTarget = rawTargets.value.find((t) => t.id === selectedTargetId.value)
+  if (!currentTarget?.evaluationPeriodId) return
+  try {
+    await updateTlEvaluation(currentTarget.evaluateeId, {
+      status: 'DRAFT',
+      evaluationPeriodId: currentTarget.evaluationPeriodId,
+      evalComment: evaluationDrafts[selectedTargetId.value] || null,
+      inputMethod: 'TEXT',
+    })
+    savedDrafts[selectedTargetId.value] = evaluationDrafts[selectedTargetId.value]
+    updateFeedback(`${currentTarget?.name ?? '선택한 대상'} 평가 초안을 임시 저장했습니다.`, 'draft')
+  } catch (e) {
+    updateFeedback('임시 저장에 실패했습니다.', 'muted')
+  }
+}
+
+async function handleSubmitEvaluation() {
+  if (!selectedTargetId.value) return
+
+  if (submittedEvaluations[selectedTargetId.value]) {
+    updateFeedback('이미 제출된 평가입니다.', 'muted')
     return
   }
 
-  savedDrafts[selectedTargetId.value] = evaluationDrafts[selectedTargetId.value]
-
-  const currentTarget = aiEvaluationTargets.find((target) => String(target.id) === selectedTargetId.value)
-  updateFeedback(`${currentTarget?.name ?? '선택한 대상'} 평가 초안을 임시 저장했습니다.`, 'draft')
-}
-
-function handleSubmitEvaluation() {
-  if (!selectedTargetId.value) {
+  const evalComment = evaluationDrafts[selectedTargetId.value]
+  if (!evalComment || evalComment.trim().length < 20) {
+    updateFeedback('평가 코멘트는 20자 이상 입력해야 합니다.', 'muted')
     return
   }
 
-  submittedEvaluations[selectedTargetId.value] = evaluationDrafts[selectedTargetId.value]
-
-  const currentTarget = aiEvaluationTargets.find((target) => String(target.id) === selectedTargetId.value)
-  updateFeedback(`${currentTarget?.name ?? '선택한 대상'} 평가 내용을 제출했습니다.`, 'submitted')
-}
-
-function buildVoiceMockText(target) {
-  return `[음성 입력 mock 초안] ${target.name} 사원은 최근 설비 이상 상황에서 원인을 빠르게 확인했고, 관련 담당자와 즉시 협업해 생산 차질을 최소화했습니다. 이후 재발 방지를 위해 점검 포인트를 정리해 팀에 공유했습니다.`
+  const currentTarget = rawTargets.value.find((t) => t.id === selectedTargetId.value)
+  if (!currentTarget?.evaluationPeriodId) return
+  try {
+    await updateTlEvaluation(currentTarget.evaluateeId, {
+      status: 'SUBMITTED',
+      evaluationPeriodId: currentTarget.evaluationPeriodId,
+      evalComment,
+      inputMethod: 'TEXT',
+    })
+    submittedEvaluations[selectedTargetId.value] = true
+    updateFeedback(`${currentTarget?.name ?? '선택한 대상'} 평가 내용을 제출했습니다.`, 'submitted')
+  } catch (e) {
+    if (e.response?.data?.errorCode === 'CONFLICT_008') {
+      submittedEvaluations[selectedTargetId.value] = true
+      updateFeedback(`${currentTarget?.name ?? '선택한 대상'} 평가는 이미 제출되었습니다.`, 'submitted')
+      return
+    }
+    const msg = e.response?.data?.message ?? '제출에 실패했습니다.'
+    updateFeedback(msg, 'muted')
+  }
 }
 
 function handleVoiceInput() {
-  if (!selectedTargetId.value) {
-    return
-  }
-
+  if (!selectedTargetId.value) return
   recordingState.value = recordingState.value === 'recording' ? 'ready' : 'recording'
-
   if (recordingState.value === 'recording') {
-    updateFeedback('음성 입력 mock 상태로 전환했습니다. 다시 누르면 초안 준비 상태로 바뀝니다.', 'muted')
-    return
+    updateFeedback('음성 인식 중입니다. 다시 누르면 중지합니다.', 'muted')
+  } else {
+    updateFeedback('음성 초안이 준비되었습니다. 텍스트 변환 버튼으로 편집 영역에 반영할 수 있습니다.', 'draft')
   }
-
-  const currentTarget = aiEvaluationTargets.find((target) => String(target.id) === selectedTargetId.value)
-  uploadedText.value = currentTarget ? buildVoiceMockText(currentTarget) : ''
-  updateFeedback('음성 초안이 준비되었습니다. 텍스트 변환 버튼으로 편집 영역에 반영할 수 있습니다.', 'draft')
 }
 
 async function handleFileSelected(file) {
@@ -191,34 +225,29 @@ async function handleFileSelected(file) {
 }
 
 function handleConvertText() {
-  if (!selectedTargetId.value) {
+  if (!selectedTargetId.value) return
+
+  if (!uploadedText.value) {
+    updateFeedback('변환할 음성 또는 업로드 텍스트가 없습니다.', 'muted')
     return
   }
 
-  const currentTarget = aiEvaluationTargets.find((target) => String(target.id) === selectedTargetId.value)
-  const sourceText = uploadedText.value || (currentTarget ? buildVoiceMockText(currentTarget) : '')
-
-  if (!sourceText) {
-    updateFeedback('변환할 mock 음성 또는 업로드 텍스트가 없습니다.', 'muted')
-    return
-  }
-
-  evaluationDrafts[selectedTargetId.value] = sourceText
+  evaluationDrafts[selectedTargetId.value] = uploadedText.value
   updateFeedback('텍스트 변환 결과를 편집 영역에 반영했습니다.', 'draft')
 }
 
 function handleReplayAudio() {
-  if (!selectedTargetId.value) {
-    return
-  }
-
-  updateFeedback('현재는 mock 단계이므로 다시 듣기 대신 준비된 초안 상태만 확인할 수 있습니다.', 'muted')
+  updateFeedback('다시 듣기는 준비 중입니다.', 'muted')
 }
 
 function handleToggleGuide() {
   guideOpen.value = !guideOpen.value
   updateFeedback(guideOpen.value ? '작성 가이드를 열었습니다.' : '작성 가이드를 닫았습니다.', 'muted')
 }
+
+onBeforeUnmount(() => {
+  if (toastTimer) clearTimeout(toastTimer)
+})
 </script>
 
 <template>
@@ -247,40 +276,30 @@ function handleToggleGuide() {
 
       <TeamLeaderAiEvaluationPanel
         :selected-target="selectedTarget"
+        :readonly="!!submittedEvaluations[selectedTargetId]"
         :guide-open="guideOpen"
         :recording-state="recordingState"
         :uploaded-file-name="uploadedFileName"
+        :action-disabled="!selectedTargetId"
         @update:converted-text="handleUpdateConvertedText"
         @voice-input="handleVoiceInput"
         @file-selected="handleFileSelected"
         @convert-text="handleConvertText"
         @replay-audio="handleReplayAudio"
         @toggle-guide="handleToggleGuide"
-      />
-    </section>
-
-    <section class="teamleader-ai-evaluation-view__actions">
-      <TeamLeaderAiEvaluationActionBar
-        :disabled="!selectedTargetId"
         @close="handleCloseEditor"
         @save-draft="handleSaveDraft"
         @submit="handleSubmitEvaluation"
       />
-      <p
-        v-if="actionFeedback"
-        class="teamleader-ai-evaluation-view__feedback"
-        :class="`teamleader-ai-evaluation-view__feedback--${actionFeedbackTone}`"
-      >
-        {{ actionFeedback }}
-      </p>
     </section>
+    <BaseToast :show="toast.show" :message="toast.message" :type="toast.type" />
   </section>
 </template>
 
 <style scoped>
 .teamleader-ai-evaluation-view {
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr) auto;
+  grid-template-rows: auto minmax(0, 1fr);
   flex: 1;
   width: 100%;
   min-width: 0;
@@ -289,7 +308,8 @@ function handleToggleGuide() {
   padding: 12px 10px;
   background: var(--color-bg-app);
   box-sizing: border-box;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .teamleader-ai-evaluation-view__progress-card {
@@ -330,35 +350,6 @@ function handleToggleGuide() {
   min-height: 0;
 }
 
-.teamleader-ai-evaluation-view__actions {
-  display: grid;
-  gap: 14px;
-  margin-top: 14px;
-}
-
-.teamleader-ai-evaluation-view__feedback {
-  margin: 0;
-  padding: 12px 14px;
-  border-radius: 14px;
-  font-size: 13px;
-  font-weight: 600;
-}
-
-.teamleader-ai-evaluation-view__feedback--muted {
-  background: #f6f7fb;
-  color: var(--color-text-muted);
-}
-
-.teamleader-ai-evaluation-view__feedback--draft {
-  background: #f6f3ff;
-  color: var(--color-primary-700);
-}
-
-.teamleader-ai-evaluation-view__feedback--submitted {
-  background: #eefbf6;
-  color: #1d7f5f;
-}
-
 @media (max-width: 1120px) {
   .teamleader-ai-evaluation-view__content {
     grid-template-columns: 1fr;
@@ -368,6 +359,9 @@ function handleToggleGuide() {
 @media (max-width: 720px) {
   .teamleader-ai-evaluation-view {
     padding: 12px;
+    height: auto;
+    min-height: calc(100vh - 80px);
+    overflow: auto;
   }
 
   .teamleader-ai-evaluation-view__progress-copy {


### PR DESCRIPTION
## 변경 내용

  ### HRM 평가기간 관리
  - 평가기간 목록 조회·생성·수정·마감·확정 API 연동
  - evaluationPeriodApi.js 추가

  ### TL 1차 평가
  - 임시저장·제출 API 연동 (PATCH /api/v1/hr/team-leader/evaluations/{empId})
  - 평가 대상 선택 시 기존 작성 내용(evalComment) textarea에 표시
  - 제출 완료된 평가 textarea readonly 처리 (연보라 배경, 입력 불가)
  - 이미 제출된 평가 재제출 시 API 호출 없이 안내 메시지 표시

  ### DL 2차 평가
  - 임시저장·제출 API 연동

  ### 공통
  - AiEvaluationFormPanel readonly prop 추가
  - hrApi.js 추가