### PR TITLE
refactor: KMS 프론트 상태 명칭과 스킬갭 연동

### DIFF
--- a/src/components/kms/common/knowledge-hub/teamleader/TeamLeaderKnowledgeHubContributors.vue
+++ b/src/components/kms/common/knowledge-hub/teamleader/TeamLeaderKnowledgeHubContributors.vue
@@ -1,8 +1,11 @@
-﻿<script setup>
-defineProps({
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
   ranking: { type: Array, default: () => [] },
 })
 
+const topRanking = computed(() => props.ranking.slice(0, 3))
 </script>
 
 <template>
@@ -12,7 +15,7 @@ defineProps({
     </div>
 
     <div class="contributors__list">
-      <article v-for="person in ranking" :key="person.rank" class="contributors__row">
+      <article v-for="person in topRanking" :key="person.rank" class="contributors__row">
         <div class="contributors__left">
           <span class="contributors__rank">{{ person.rank }}</span>
           <span class="contributors__avatar" :style="{ background: person.avatarColor }">{{ person.initial }}</span>

--- a/src/components/kms/worker/skill-gap/WorkerCustomizedLearningRecommendations.vue
+++ b/src/components/kms/worker/skill-gap/WorkerCustomizedLearningRecommendations.vue
@@ -6,6 +6,8 @@ const props = defineProps({
   articles: { type: Array, required: true },
 })
 
+const emit = defineEmits(['open-article'])
+
 const localCourses = ref([])
 
 // Initialize or update local copy when prop changes
@@ -18,6 +20,10 @@ const startCourse = (id) => {
   if (course && course.status === '시작하기') {
     course.status = '진행중'
   }
+}
+
+const openArticle = (article) => {
+  emit('open-article', article)
 }
 </script>
 
@@ -59,10 +65,16 @@ const startCourse = (id) => {
     <div class="lr__articles">
       <span class="lr__articles-label">📘 관련 KMS 지식</span>
       <div class="lr__articles-list">
-        <div v-for="article in articles" :key="article.id" class="lr__article">
+        <button
+          v-for="article in articles"
+          :key="article.id"
+          type="button"
+          class="lr__article"
+          @click="openArticle(article)"
+        >
           <span class="lr__article-title">{{ article.title }}</span>
           <span class="lr__article-likes">👍{{ article.likes }}</span>
-        </div>
+        </button>
       </div>
     </div>
   </div>
@@ -217,10 +229,12 @@ const startCourse = (id) => {
   align-items: center;
   justify-content: space-between;
   padding: 12px 16px;
+  border: none;
   background: rgba(255, 255, 255, 0.08);
   border-radius: var(--radius-sm);
   cursor: pointer;
   transition: background 0.15s;
+  text-align: left;
 }
 
 .lr__article:hover {

--- a/src/components/kms/worker/skill-gap/WorkerCustomizedLearningRecommendations.vue
+++ b/src/components/kms/worker/skill-gap/WorkerCustomizedLearningRecommendations.vue
@@ -25,6 +25,14 @@ const startCourse = (id) => {
 const openArticle = (article) => {
   emit('open-article', article)
 }
+
+const tierClass = (tier) => {
+  if (tier === 'S') return 'lr__article-bullet--s'
+  if (tier === 'A') return 'lr__article-bullet--a'
+  if (tier === 'B') return 'lr__article-bullet--b'
+  if (tier === 'C') return 'lr__article-bullet--c'
+  return ''
+}
 </script>
 
 <template>
@@ -72,7 +80,11 @@ const openArticle = (article) => {
           class="lr__article"
           @click="openArticle(article)"
         >
-          <span class="lr__article-title">{{ article.title }}</span>
+          <div class="lr__article-head">
+            <span class="lr__article-bullet" :class="tierClass(article.authorTier)">{{ article.authorTier || '?' }}</span>
+            <span class="lr__article-title">{{ article.title }}</span>
+          </div>
+          <p v-if="article.preview" class="lr__article-preview">{{ article.preview }}</p>
           <span class="lr__article-likes">👍{{ article.likes }}</span>
         </button>
       </div>
@@ -89,6 +101,7 @@ const openArticle = (article) => {
   display: flex;
   flex-direction: column;
   gap: 16px;
+  height: 100%;
 }
 
 .lr__label {
@@ -204,52 +217,119 @@ const openArticle = (article) => {
 
 /* ── Related Articles ──────────────────────────────────── */
 .lr__articles {
-  background: var(--color-primary-800);
+  background: linear-gradient(180deg, #312376 0%, #24195e 100%);
   border-radius: var(--radius-md);
-  padding: 20px;
+  padding: 18px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 10px;
+  flex: 1;
+  min-height: 0;
 }
 
 .lr__articles-label {
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 700;
   color: var(--color-white);
+  letter-spacing: 0.02em;
 }
 
 .lr__articles-list {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
+  flex: 1;
+  min-height: 0;
 }
 
 .lr__article {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px 16px;
-  border: none;
+  display: grid;
+  gap: 6px;
+  width: 100%;
+  min-height: 0;
+  flex: 1 1 0;
+  padding: 12px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
   background: rgba(255, 255, 255, 0.08);
-  border-radius: var(--radius-sm);
+  border-radius: 16px;
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
   text-align: left;
 }
 
 .lr__article:hover {
   background: rgba(255, 255, 255, 0.14);
+  border-color: rgba(255, 255, 255, 0.28);
+  transform: translateY(-1px);
+}
+
+.lr__article-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.lr__article-bullet {
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.16);
+  color: var(--color-white);
+  font-size: 10px;
+  font-weight: 800;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.lr__article-bullet--s {
+  background: #00bf95;
+  color: #fff;
+}
+
+.lr__article-bullet--a {
+  background: var(--color-primary-500);
+  color: #fff;
+}
+
+.lr__article-bullet--b {
+  background: #ffd166;
+  color: #2d237c;
+}
+
+.lr__article-bullet--c {
+  background: #ef476f;
+  color: #fff;
 }
 
 .lr__article-title {
   font-size: 13px;
   font-weight: 600;
   color: var(--color-white);
+  line-height: 1.45;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.lr__article-preview {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.45;
+  color: rgba(255, 255, 255, 0.74);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .lr__article-likes {
-  font-size: 12px;
-  color: rgba(255, 255, 255, 0.7);
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.72);
   flex-shrink: 0;
+  justify-self: end;
 }
 </style>

--- a/src/components/kms/worker/skill-gap/WorkerSkillGapAiAnalysisReport.vue
+++ b/src/components/kms/worker/skill-gap/WorkerSkillGapAiAnalysisReport.vue
@@ -45,16 +45,6 @@ function barPercent(current, target) {
       </div>
     </div>
 
-    <!-- S+ Prediction -->
-    <div class="ar__prediction">
-      <span class="ar__prediction-title">📅 예상 S+ 달성</span>
-      <p class="ar__prediction-normal">
-        현재 성장률 유지 시: <strong>{{ report.prediction.normalDate }}</strong>
-      </p>
-      <p class="ar__prediction-fast">
-        가속 훈련 시: {{ report.prediction.acceleratedDate }}
-      </p>
-    </div>
   </div>
 </template>
 
@@ -67,6 +57,7 @@ function barPercent(current, target) {
   display: flex;
   flex-direction: column;
   gap: 16px;
+  height: 100%;
 }
 
 .ar__label {
@@ -157,29 +148,4 @@ function barPercent(current, target) {
 }
 
 /* ── Prediction ────────────────────────────────────────── */
-.ar__prediction {
-  background: var(--color-success-soft);
-  border: 1px solid var(--color-status-approved-border);
-  border-radius: var(--radius-md);
-  padding: 18px 20px;
-}
-
-.ar__prediction-title {
-  font-size: 13px;
-  font-weight: 600;
-  color: #166534;
-}
-
-.ar__prediction-normal {
-  font-size: 16px;
-  color: #14532d;
-  margin: 8px 0 4px;
-  line-height: 1.5;
-}
-
-.ar__prediction-fast {
-  font-size: 13px;
-  color: #16a34a;
-  margin: 0;
-}
 </style>

--- a/src/components/kms/worker/skill-gap/WorkerSkillGapChartAndStatus.vue
+++ b/src/components/kms/worker/skill-gap/WorkerSkillGapChartAndStatus.vue
@@ -3,6 +3,8 @@ import { computed, ref, onMounted } from 'vue'
 import BaseProgressBar from '@/components/common/base/data-display/BaseProgressBar.vue'
 
 const props = defineProps({
+  currentTier: { type: String, required: true },
+  targetTier: { type: String, required: true },
   skills: { type: Array, required: true },
   summary: { type: Object, required: true },
 })
@@ -84,13 +86,23 @@ const labelPositions = computed(() => {
 })
 
 const overallPercent = computed(() => {
+  if (!props.summary.targetOverall) return 0
   return Math.round((props.summary.currentOverall / props.summary.targetOverall) * 100)
+})
+
+const targetLabel = computed(() => `${props.targetTier} 등급 목표`)
+const comparisonLabel = computed(() => `현재 ${props.currentTier} 등급 VS ${props.targetTier} 등급 목표`)
+const gapSummaryLabel = computed(() => {
+  if (props.currentTier === props.targetTier) {
+    return '현재 최고 등급 유지 중'
+  }
+  return `평균 기준 ▲ ${props.summary.totalGap}점 필요`
 })
 </script>
 
 <template>
   <div class="sg">
-    <span class="sg__label">📊 현재 역량 VS S+ 목표</span>
+    <span class="sg__label">📊 {{ comparisonLabel }}</span>
 
     <!-- Radar Chart -->
     <div class="sg__chart-wrap">
@@ -110,7 +122,7 @@ const overallPercent = computed(() => {
           stroke="#E0DCFF"
           stroke-width="1"
         />
-        <!-- Target (S+) -->
+        <!-- Target -->
         <path
           :d="targetPath"
           fill="rgba(0, 191, 149, 0.08)"
@@ -144,21 +156,21 @@ const overallPercent = computed(() => {
         <span class="sg__legend-dot" style="background: #5B4FCF"></span> 현재 ● #5B4FCF
       </span>
       <span class="sg__legend-item">
-        <span class="sg__legend-line"></span> S+ 목표 -- #00BF95
+        <span class="sg__legend-line"></span> {{ targetLabel }} -- #00BF95
       </span>
     </div>
 
     <!-- Gap Summary -->
     <div class="sg__gap">
       <span class="sg__gap-label">종합 Gap</span>
-      <span class="sg__gap-value">▲ {{ summary.totalGap }}점 필요</span>
+      <span class="sg__gap-value">{{ gapSummaryLabel }}</span>
     </div>
 
     <!-- Overall Progress Bar -->
     <div class="sg__progress">
       <BaseProgressBar :value="animated ? overallPercent : 0" :show-percent="true" size="md" />
       <span class="sg__progress-text">
-        현재 {{ summary.currentOverall }}점 → 목표 {{ summary.targetOverall }}점
+        평균 현재 {{ summary.currentOverall }}점 → 평균 목표 {{ summary.targetOverall }}점
       </span>
     </div>
 

--- a/src/components/kms/worker/skill-gap/WorkerSkillGapChartAndStatus.vue
+++ b/src/components/kms/worker/skill-gap/WorkerSkillGapChartAndStatus.vue
@@ -199,6 +199,7 @@ const gapSummaryLabel = computed(() => {
   display: flex;
   flex-direction: column;
   gap: 16px;
+  height: 100%;
 }
 
 .sg__label {

--- a/src/services/knowledgeArticleApi.js
+++ b/src/services/knowledgeArticleApi.js
@@ -108,6 +108,10 @@ const knowledgeArticleApi = {
     return kmsApi.get('/api/kms/articles/recommendations')
   },
 
+  getWorkerSkillGap() {
+    return kmsApi.get('/api/kms/workers/me/skill-gap')
+  },
+
   getTags() {
     return kmsApi.get('/api/kms/tags')
   },
@@ -153,7 +157,7 @@ const knowledgeArticleApi = {
   },
 
   // ── Worker Command ────────────────────────────────────────────
-  // data: { authorId, title, category, equipmentId, content }
+  // data: { title, category, equipmentId, content }
   createArticle(data) {
     return kmsApi.post('/api/kms/articles', data)
   },
@@ -162,7 +166,7 @@ const knowledgeArticleApi = {
     return kmsApi.post('/api/kms/articles/drafts', data)
   },
 
-  // data: { authorId, title, category, equipmentId, content }
+  // data: { title, category, equipmentId, content }
   // DRAFT / PENDING / REJECTED 상태 문서만 허용 (임시저장용)
   updateArticle(articleId, data) {
     return kmsApi.put(`/api/kms/articles/${articleId}`, data)
@@ -179,7 +183,7 @@ const knowledgeArticleApi = {
   },
 
   // DRAFT / REJECTED → PENDING 제출
-  // data: { authorId, title, category, equipmentId, content }
+  // data: { title, category, equipmentId, content }
   submitDraft(articleId, data) {
     return kmsApi.put(`/api/kms/articles/${articleId}/submit`, data)
   },

--- a/src/services/knowledgeArticleApi.js
+++ b/src/services/knowledgeArticleApi.js
@@ -136,16 +136,20 @@ const knowledgeArticleApi = {
 
   // ── 승인 조회 ───────────────────────────────────────────────────
   getApprovalStats() {
-    return kmsApi.get('/api/kms/approval/stats')
+    return kmsApi.get('/api/kms/stats', { params: { stat: 'approval' } })
   },
 
   // params: { page, size }
   getApprovalList(params = {}) {
-    return kmsApi.get('/api/kms/approval', { params })
+    return kmsApi.get('/api/kms/articles', {
+      params: { ...params, stat: 'approval' },
+    })
   },
 
   getApprovalDetail(articleId) {
-    return kmsApi.get(`/api/kms/approval/${articleId}`)
+    return kmsApi.get(`/api/kms/articles/${articleId}`, {
+      params: { stat: 'approval' },
+    })
   },
 
   // ── Worker Command ────────────────────────────────────────────
@@ -207,11 +211,8 @@ const knowledgeArticleApi = {
   // role   : 'TL' | 'DL'
   // data   : { status: 'APPROVE'|'REJECT'|'PENDING', reviewComment }
   processApproval(role, articleId, data) {
-    const authStore = useAuthStore()
     const prefix = role === 'TL' ? 'tl' : 'dl'
-    return kmsApi.post(`/api/kms/${prefix}/articles/${articleId}/approval`, data, {
-      headers: { 'X-Employee-Id': authStore.userInfo?.employeeId },
-    })
+    return kmsApi.post(`/api/kms/${prefix}/articles/${articleId}/approval`, data)
   },
 
   // ── Admin Command ─────────────────────────────────────────────

--- a/src/services/knowledgeArticleApi.js
+++ b/src/services/knowledgeArticleApi.js
@@ -96,7 +96,7 @@ const knowledgeArticleApi = {
   },
 
   getHubStats() {
-    return kmsApi.get('/api/kms/stats', { params: { stat: 'hub' } })
+    return kmsApi.get('/api/kms/stats', { params: { status: 'hub' } })
   },
 
   // limit: 노출할 기여자 수 (기본 5)
@@ -135,20 +135,20 @@ const knowledgeArticleApi = {
   },
 
   // ── 승인 조회 ───────────────────────────────────────────────────
-  getApprovalStats() {
-    return kmsApi.get('/api/kms/stats', { params: { stat: 'approval' } })
+  getPendingStats() {
+    return kmsApi.get('/api/kms/stats', { params: { status: 'pending' } })
   },
 
   // params: { page, size }
-  getApprovalList(params = {}) {
+  getPendingList(params = {}) {
     return kmsApi.get('/api/kms/articles', {
-      params: { ...params, stat: 'approval' },
+      params: { ...params, status: 'pending' },
     })
   },
 
-  getApprovalDetail(articleId) {
+  getPendingDetail(articleId) {
     return kmsApi.get(`/api/kms/articles/${articleId}`, {
-      params: { stat: 'approval' },
+      params: { status: 'pending' },
     })
   },
 

--- a/src/services/knowledgeArticleApi.js
+++ b/src/services/knowledgeArticleApi.js
@@ -91,8 +91,8 @@ const knowledgeArticleApi = {
     return kmsApi.get('/api/kms/articles', { params })
   },
 
-  getArticleDetail(articleId, params = {}) {
-    return kmsApi.get(`/api/kms/articles/${articleId}`, { params })
+  getArticleDetail(articleId) {
+    return kmsApi.get(`/api/kms/articles/${articleId}`)
   },
 
   getHubStats() {
@@ -117,21 +117,21 @@ const knowledgeArticleApi = {
   },
 
   // ── 내 지식 관리 ────────────────────────────────────────────────
-  getMyArticleStats(authorId) {
-    return kmsApi.get('/api/kms/my/articles/stats', { params: { authorId } })
+  getMyArticleStats() {
+    return kmsApi.get('/api/kms/my/articles/stats')
   },
 
-  // params: { authorId, status, page, size }
+  // params: { status, page, size }
   getMyArticles(params = {}) {
     return kmsApi.get('/api/kms/my/articles', { params })
   },
 
-  getMyArticleHistory(authorId) {
-    return kmsApi.get('/api/kms/my/articles/history', { params: { authorId } })
+  getMyArticleHistory() {
+    return kmsApi.get('/api/kms/my/articles/history')
   },
 
-  getMyBookmarks(employeeId) {
-    return kmsApi.get('/api/kms/my/bookmarks', { params: { employeeId } })
+  getMyBookmarks() {
+    return kmsApi.get('/api/kms/my/bookmarks')
   },
 
   // ── 승인 조회 ───────────────────────────────────────────────────
@@ -174,9 +174,8 @@ const knowledgeArticleApi = {
   },
 
   // APPROVED 문서 수정 시작: 복사본(DRAFT) 생성 또는 기존 복사본 반환
-  // requesterId: Long
-  startRevision(articleId, requesterId) {
-    return kmsApi.put(`/api/kms/articles/${articleId}/revision`, { requesterId })
+  startRevision(articleId) {
+    return kmsApi.put(`/api/kms/articles/${articleId}/revision`, {})
   },
 
   // DRAFT / REJECTED → PENDING 제출
@@ -185,13 +184,12 @@ const knowledgeArticleApi = {
     return kmsApi.put(`/api/kms/articles/${articleId}/submit`, data)
   },
 
-  // data: { requesterId }
-  deleteArticle(articleId, data) {
-    return kmsApi.delete(`/api/kms/articles/${articleId}`, { data })
+  deleteArticle(articleId) {
+    return kmsApi.delete(`/api/kms/articles/${articleId}`)
   },
 
-  restoreArticle(articleId, data) {
-    return kmsApi.put(`/api/kms/articles/${articleId}/restore`, data)
+  restoreArticle(articleId) {
+    return kmsApi.put(`/api/kms/articles/${articleId}/restore`, {})
   },
 
   // tagIds: Long[]
@@ -199,12 +197,12 @@ const knowledgeArticleApi = {
     return kmsApi.put(`/api/kms/articles/${articleId}/tags`, { tagIds })
   },
 
-  addBookmark(articleId, employeeId) {
-    return kmsApi.post('/api/kms/bookmarks', { articleId, employeeId })
+  addBookmark(articleId) {
+    return kmsApi.post('/api/kms/bookmarks', { articleId })
   },
 
-  removeBookmark(articleId, employeeId) {
-    return kmsApi.delete('/api/kms/bookmarks', { params: { articleId, employeeId } })
+  removeBookmark(articleId) {
+    return kmsApi.delete('/api/kms/bookmarks', { params: { articleId } })
   },
 
   // ── 승인 처리 (TL / DL) ─────────────────────────────────────────

--- a/src/utils/kmsAuthorFilter.js
+++ b/src/utils/kmsAuthorFilter.js
@@ -1,9 +1,0 @@
-const EXCLUDED_KMS_AUTHORS = new Set(['Batch-Test-Worker', '최상위관리자'])
-
-export function isVisibleKmsAuthor(authorName) {
-  return !EXCLUDED_KMS_AUTHORS.has(authorName ?? '')
-}
-
-export function filterVisibleKmsAuthors(items, getAuthorName) {
-  return items.filter((item) => isVisibleKmsAuthor(getAuthorName(item)))
-}

--- a/src/views/admin/AdminKnowledgeHub.vue
+++ b/src/views/admin/AdminKnowledgeHub.vue
@@ -7,7 +7,6 @@ import TeamLeaderKnowledgeHubHeader from '@/components/kms/common/knowledge-hub/
 import TeamLeaderKnowledgeHubAiPanel from '@/components/kms/common/knowledge-hub/teamleader/TeamLeaderKnowledgeHubAiPanel.vue'
 import TeamLeaderKnowledgeDetailModal from '@/components/kms/common/knowledge-hub/teamleader/TeamLeaderKnowledgeDetailModal.vue'
 import knowledgeArticleApi from '@/services/knowledgeArticleApi'
-import { filterVisibleKmsAuthors } from '@/utils/kmsAuthorFilter'
 
 const tagFilters = ref([])
 
@@ -136,12 +135,9 @@ async function loadArticles() {
     const res = await knowledgeArticleApi.getArticles({
       page: 0,
       size: 20,
-      status: 'APPROVED',
+      articleStatus: 'APPROVED',
     })
-    articles.value = filterVisibleKmsAuthors(
-      (res.data.data ?? []).map(mapToFeedCard),
-      (item) => item.author.name,
-    )
+    articles.value = (res.data.data ?? []).map(mapToFeedCard)
   } catch (e) {
     console.error('[KMS] 문서 목록 로드 실패:', e)
   }
@@ -150,10 +146,8 @@ async function loadArticles() {
 async function loadBookmarks() {
   try {
     const res = await knowledgeArticleApi.getMyBookmarks()
-    bookmarkArticles.value = filterVisibleKmsAuthors(
-      (res.data.data ?? []).map(mapToFeedCard),
-      (item) => item.author.name,
-    ).map((item) => ({ ...item, bookmarked: true }))
+    bookmarkArticles.value = (res.data.data ?? []).map(mapToFeedCard)
+      .map((item) => ({ ...item, bookmarked: true }))
   } catch (e) {
     console.error('[KMS] 북마크 목록 로드 실패:', e)
   }
@@ -162,10 +156,7 @@ async function loadBookmarks() {
 async function loadContributors() {
   try {
     const res = await knowledgeArticleApi.getContributors(3)
-    contributors.value = filterVisibleKmsAuthors(
-      (res.data.data ?? []).map(mapToContributor),
-      (item) => item.name,
-    )
+    contributors.value = (res.data.data ?? []).map(mapToContributor)
   } catch (e) {
     console.error('[KMS] 기여자 랭킹 로드 실패:', e)
   }

--- a/src/views/admin/AdminKnowledgeHub.vue
+++ b/src/views/admin/AdminKnowledgeHub.vue
@@ -1,6 +1,5 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
-import { useAuthStore } from '@/stores/auth'
 import { ARTICLE_CATEGORY_LABEL } from '@/constants'
 import KmsFeed      from '@/components/admin/kms/KmsFeed.vue'
 import KmsSidePanel from '@/components/admin/kms/KmsSidePanel.vue'
@@ -10,8 +9,6 @@ import TeamLeaderKnowledgeDetailModal from '@/components/kms/common/knowledge-hu
 import knowledgeArticleApi from '@/services/knowledgeArticleApi'
 import { filterVisibleKmsAuthors } from '@/utils/kmsAuthorFilter'
 
-const authStore = useAuthStore()
-const authorId = computed(() => Number(authStore.userInfo?.employeeId))
 const tagFilters = ref([])
 
 function formatTrend(value, digits = 0) {
@@ -140,8 +137,6 @@ async function loadArticles() {
       page: 0,
       size: 20,
       status: 'APPROVED',
-      requesterId: authorId.value,
-      requesterRole: 'ADMIN',
     })
     articles.value = filterVisibleKmsAuthors(
       (res.data.data ?? []).map(mapToFeedCard),
@@ -154,7 +149,7 @@ async function loadArticles() {
 
 async function loadBookmarks() {
   try {
-    const res = await knowledgeArticleApi.getMyBookmarks(authorId.value)
+    const res = await knowledgeArticleApi.getMyBookmarks()
     bookmarkArticles.value = filterVisibleKmsAuthors(
       (res.data.data ?? []).map(mapToFeedCard),
       (item) => item.author.name,
@@ -220,7 +215,7 @@ async function openDetailModal(article) {
   }
 
   try {
-    const res = await knowledgeArticleApi.getArticleDetail(article.id, { requesterId: authorId.value })
+    const res = await knowledgeArticleApi.getArticleDetail(article.id)
     const dto = res.data.data ?? {}
     selectedArticle.value = {
       id: dto.articleId ?? article.id,
@@ -265,9 +260,9 @@ function openRecommendedArticle(item) {
 async function toggleBookmark(article) {
   try {
     if (article.bookmarked || article.isBookmarked) {
-      await knowledgeArticleApi.removeBookmark(article.id, authorId.value)
+      await knowledgeArticleApi.removeBookmark(article.id)
     } else {
-      await knowledgeArticleApi.addBookmark(article.id, authorId.value)
+      await knowledgeArticleApi.addBookmark(article.id)
     }
 
     await Promise.allSettled([loadArticles(), loadBookmarks()])

--- a/src/views/departmentleader/DepartmentLeaderKnowledgeApprovalView.vue
+++ b/src/views/departmentleader/DepartmentLeaderKnowledgeApprovalView.vue
@@ -5,7 +5,6 @@ import { BaseToast } from '@/components/common/base/overlay'
 import TeamLeaderKnowledgeApprovalQueue from '@/components/kms/teamleader/knowledge-approval/TeamLeaderKnowledgeApprovalQueue.vue'
 import TeamLeaderKnowledgeApprovalReviewPanel from '@/components/kms/teamleader/knowledge-approval/TeamLeaderKnowledgeApprovalReviewPanel.vue'
 import knowledgeArticleApi from '@/services/knowledgeArticleApi'
-import { filterVisibleKmsAuthors } from '@/utils/kmsAuthorFilter'
 
 // ── 날짜 포맷 헬퍼 ─────────────────────────────────────────────
 function formatDate(isoString) {
@@ -77,7 +76,7 @@ onMounted(async () => {
 
 async function loadStats() {
   try {
-    const res = await knowledgeArticleApi.getApprovalStats()
+    const res = await knowledgeArticleApi.getPendingStats()
     statsData.value = res.data.data ?? {}
   } catch (e) {
     console.error('[KMS] 승인 통계 로드 실패:', e)
@@ -86,11 +85,8 @@ async function loadStats() {
 
 async function loadList() {
   try {
-    const res = await knowledgeArticleApi.getApprovalList({ page: 0, size: 50 })
-    items.value = filterVisibleKmsAuthors(
-      (res.data.data ?? []).map(mapToQueueItem),
-      (item) => item.author,
-    )
+    const res = await knowledgeArticleApi.getPendingList({ page: 0, size: 50 })
+    items.value = (res.data.data ?? []).map(mapToQueueItem)
     if (items.value.length > 0) {
       const keepId = selectedId.value && items.value.some((i) => i.id === selectedId.value)
         ? selectedId.value
@@ -111,7 +107,7 @@ async function selectItem(id) {
   selectedDetail.value = null
   reviewError.value = ''
   try {
-    const res = await knowledgeArticleApi.getApprovalDetail(id)
+    const res = await knowledgeArticleApi.getPendingDetail(id)
     selectedDetail.value = mapToReviewItem(res.data.data ?? {})
     reviewNote.value = selectedDetail.value.reviewComment ?? ''
   } catch (e) {

--- a/src/views/departmentleader/DepartmentLeaderKnowledgeHubView.vue
+++ b/src/views/departmentleader/DepartmentLeaderKnowledgeHubView.vue
@@ -1,6 +1,5 @@
 <script setup>
 import { ref, reactive, computed, onMounted } from 'vue'
-import { useAuthStore } from '@/stores/auth'
 import { ARTICLE_CATEGORY_LABEL } from '@/constants'
 import TeamLeaderKnowledgeHubHeader from '@/components/kms/common/knowledge-hub/teamleader/TeamLeaderKnowledgeHubHeader.vue'
 import TeamLeaderKnowledgeHubFeed from '@/components/kms/common/knowledge-hub/teamleader/TeamLeaderKnowledgeHubFeed.vue'
@@ -22,9 +21,6 @@ import {
 import knowledgeArticleApi from '@/services/knowledgeArticleApi'
 import { filterVisibleKmsAuthors } from '@/utils/kmsAuthorFilter'
 
-const authStore = useAuthStore()
-const authorId = computed(() => Number(authStore.userInfo?.employeeId))
-const requesterRole = computed(() => 'DEPARTMENTLEADER')
 
 function formatTrend(value, digits = 0) {
   const numeric = Number(value ?? 0)
@@ -176,8 +172,6 @@ async function loadArticles() {
       page: 0,
       size: 20,
       status: 'APPROVED',
-      requesterId: authorId.value,
-      requesterRole: requesterRole.value,
     })
     articles.value = filterVisibleKmsAuthors(
       (res.data.data ?? [])
@@ -192,7 +186,7 @@ async function loadArticles() {
 
 async function loadBookmarks() {
   try {
-    const res = await knowledgeArticleApi.getMyBookmarks(authorId.value)
+    const res = await knowledgeArticleApi.getMyBookmarks()
     bookmarkArticles.value = filterVisibleKmsAuthors(
       (res.data.data ?? [])
         .filter((dto) => dto.articleStatus === 'APPROVED')
@@ -228,7 +222,6 @@ async function loadRecommendations() {
 async function handleAddArticle(data) {
   try {
     await knowledgeArticleApi.createArticle({
-      authorId: authorId.value,
       title: data.title,
       category: data.category,
       equipmentId: data.equipmentId,
@@ -244,7 +237,6 @@ async function handleAddArticle(data) {
 async function handleSaveDraft(data) {
   try {
     await knowledgeArticleApi.saveDraft({
-      authorId: authorId.value,
       title: data.title,
       category: data.category,
       equipmentId: data.equipmentId,
@@ -276,7 +268,7 @@ async function openDetailModal(article) {
     isBookmarked: Boolean(article.isBookmarked),
   }
   try {
-    const res = await knowledgeArticleApi.getArticleDetail(article.id, { requesterId: authorId.value })
+    const res = await knowledgeArticleApi.getArticleDetail(article.id)
     const dto = res.data.data ?? {}
     selectedArticle.value = {
       id: dto.articleId,
@@ -316,9 +308,9 @@ function openRecommendedArticle(item) {
 async function toggleBookmark(article) {
   try {
     if (article.isBookmarked) {
-      await knowledgeArticleApi.removeBookmark(article.id, authorId.value)
+      await knowledgeArticleApi.removeBookmark(article.id)
     } else {
-      await knowledgeArticleApi.addBookmark(article.id, authorId.value)
+      await knowledgeArticleApi.addBookmark(article.id)
     }
 
     await Promise.allSettled([loadArticles(), loadBookmarks()])

--- a/src/views/departmentleader/DepartmentLeaderKnowledgeHubView.vue
+++ b/src/views/departmentleader/DepartmentLeaderKnowledgeHubView.vue
@@ -19,7 +19,6 @@ import {
 } from '@/mocks/teamleader'
 
 import knowledgeArticleApi from '@/services/knowledgeArticleApi'
-import { filterVisibleKmsAuthors } from '@/utils/kmsAuthorFilter'
 
 
 function formatTrend(value, digits = 0) {
@@ -171,14 +170,11 @@ async function loadArticles() {
     const res = await knowledgeArticleApi.getArticles({
       page: 0,
       size: 20,
-      status: 'APPROVED',
+      articleStatus: 'APPROVED',
     })
-    articles.value = filterVisibleKmsAuthors(
-      (res.data.data ?? [])
+    articles.value = (res.data.data ?? [])
       .filter((dto) => dto.articleStatus === 'APPROVED')
-      .map(mapToFeedItem),
-      (item) => item.author,
-    )
+      .map(mapToFeedItem)
   } catch (e) {
     console.error('[KMS] 문서 목록 로드 실패:', e)
   }
@@ -187,12 +183,10 @@ async function loadArticles() {
 async function loadBookmarks() {
   try {
     const res = await knowledgeArticleApi.getMyBookmarks()
-    bookmarkArticles.value = filterVisibleKmsAuthors(
-      (res.data.data ?? [])
-        .filter((dto) => dto.articleStatus === 'APPROVED')
-        .map(mapToFeedItem),
-      (item) => item.author,
-    ).map((item) => ({ ...item, isBookmarked: true }))
+    bookmarkArticles.value = (res.data.data ?? [])
+      .filter((dto) => dto.articleStatus === 'APPROVED')
+      .map(mapToFeedItem)
+      .map((item) => ({ ...item, isBookmarked: true }))
   } catch (e) {
     console.error('[KMS] 북마크 목록 로드 실패:', e)
   }
@@ -201,10 +195,7 @@ async function loadBookmarks() {
 async function loadContributors() {
   try {
     const res = await knowledgeArticleApi.getContributors(5)
-    contributors.value = filterVisibleKmsAuthors(
-      (res.data.data ?? []).map(mapToContributor),
-      (item) => item.name,
-    )
+    contributors.value = (res.data.data ?? []).map(mapToContributor)
   } catch (e) {
     console.error('[KMS] 기여자 랭킹 로드 실패:', e)
   }

--- a/src/views/teamleader/TeamLeaderKnowledgeApprovalView.vue
+++ b/src/views/teamleader/TeamLeaderKnowledgeApprovalView.vue
@@ -6,7 +6,6 @@ import { BaseToast } from '@/components/common/base/overlay'
 import TeamLeaderKnowledgeApprovalQueue from '@/components/kms/teamleader/knowledge-approval/TeamLeaderKnowledgeApprovalQueue.vue'
 import TeamLeaderKnowledgeApprovalReviewPanel from '@/components/kms/teamleader/knowledge-approval/TeamLeaderKnowledgeApprovalReviewPanel.vue'
 import knowledgeArticleApi from '@/services/knowledgeArticleApi'
-import { filterVisibleKmsAuthors } from '@/utils/kmsAuthorFilter'
 
 // ── 날짜 포맷 헬퍼 ─────────────────────────────────────────────
 function formatDate(isoString) {
@@ -85,7 +84,7 @@ onMounted(async () => {
 
 async function loadStats() {
   try {
-    const res = await knowledgeArticleApi.getApprovalStats()
+    const res = await knowledgeArticleApi.getPendingStats()
     statsData.value = res.data.data ?? {}
   } catch (e) {
     console.error('[KMS] 승인 통계 로드 실패:', e)
@@ -94,11 +93,8 @@ async function loadStats() {
 
 async function loadList() {
   try {
-    const res = await knowledgeArticleApi.getApprovalList({ page: 0, size: 50 })
-    items.value = filterVisibleKmsAuthors(
-      (res.data.data ?? []).map(mapToQueueItem),
-      (item) => item.author,
-    )
+    const res = await knowledgeArticleApi.getPendingList({ page: 0, size: 50 })
+    items.value = (res.data.data ?? []).map(mapToQueueItem)
     if (items.value.length > 0) {
       const keepId = selectedId.value && items.value.some((i) => i.id === selectedId.value)
         ? selectedId.value
@@ -119,7 +115,7 @@ async function selectItem(id) {
   selectedDetail.value = null
   reviewError.value = ''
   try {
-    const res = await knowledgeArticleApi.getApprovalDetail(id)
+    const res = await knowledgeArticleApi.getPendingDetail(id)
     selectedDetail.value = mapToReviewItem(res.data.data ?? {})
     reviewNote.value = selectedDetail.value.reviewComment ?? ''
   } catch (e) {

--- a/src/views/teamleader/TeamLeaderKnowledgeHubView.vue
+++ b/src/views/teamleader/TeamLeaderKnowledgeHubView.vue
@@ -1,6 +1,5 @@
 <script setup>
 import { ref, reactive, computed, onMounted } from 'vue'
-import { useAuthStore } from '@/stores/auth'
 import { ARTICLE_CATEGORY_LABEL } from '@/constants'
 import TeamLeaderKnowledgeHubHeader from '@/components/kms/common/knowledge-hub/teamleader/TeamLeaderKnowledgeHubHeader.vue'
 import TeamLeaderKnowledgeHubFeed from '@/components/kms/common/knowledge-hub/teamleader/TeamLeaderKnowledgeHubFeed.vue'
@@ -22,9 +21,6 @@ import {
 import knowledgeArticleApi from '@/services/knowledgeArticleApi'
 import { filterVisibleKmsAuthors } from '@/utils/kmsAuthorFilter'
 
-const authStore = useAuthStore()
-const authorId = computed(() => Number(authStore.userInfo?.employeeId))
-const requesterRole = computed(() => 'TEAMLEADER')
 
 function formatTrend(value, digits = 0) {
   const numeric = Number(value ?? 0)
@@ -176,8 +172,6 @@ async function loadArticles() {
       page: 0,
       size: 20,
       status: 'APPROVED',
-      requesterId: authorId.value,
-      requesterRole: requesterRole.value,
     })
     articles.value = filterVisibleKmsAuthors(
       (res.data.data ?? [])
@@ -192,7 +186,7 @@ async function loadArticles() {
 
 async function loadBookmarks() {
   try {
-    const res = await knowledgeArticleApi.getMyBookmarks(authorId.value)
+    const res = await knowledgeArticleApi.getMyBookmarks()
     bookmarkArticles.value = filterVisibleKmsAuthors(
       (res.data.data ?? [])
         .filter((dto) => dto.articleStatus === 'APPROVED')
@@ -228,7 +222,6 @@ async function loadRecommendations() {
 async function handleAddArticle(data) {
   try {
     await knowledgeArticleApi.createArticle({
-      authorId: authorId.value,
       title: data.title,
       category: data.category,
       equipmentId: data.equipmentId,
@@ -244,7 +237,6 @@ async function handleAddArticle(data) {
 async function handleSaveDraft(data) {
   try {
     await knowledgeArticleApi.saveDraft({
-      authorId: authorId.value,
       title: data.title,
       category: data.category,
       equipmentId: data.equipmentId,
@@ -276,7 +268,7 @@ async function openDetailModal(article) {
     isBookmarked: Boolean(article.isBookmarked),
   }
   try {
-    const res = await knowledgeArticleApi.getArticleDetail(article.id, { requesterId: authorId.value })
+    const res = await knowledgeArticleApi.getArticleDetail(article.id)
     const dto = res.data.data ?? {}
     selectedArticle.value = {
       id: dto.articleId,
@@ -316,9 +308,9 @@ function openRecommendedArticle(item) {
 async function toggleBookmark(article) {
   try {
     if (article.isBookmarked) {
-      await knowledgeArticleApi.removeBookmark(article.id, authorId.value)
+      await knowledgeArticleApi.removeBookmark(article.id)
     } else {
-      await knowledgeArticleApi.addBookmark(article.id, authorId.value)
+      await knowledgeArticleApi.addBookmark(article.id)
     }
 
     await Promise.allSettled([loadArticles(), loadBookmarks()])

--- a/src/views/teamleader/TeamLeaderKnowledgeHubView.vue
+++ b/src/views/teamleader/TeamLeaderKnowledgeHubView.vue
@@ -19,7 +19,6 @@ import {
 } from '@/mocks/teamleader'
 
 import knowledgeArticleApi from '@/services/knowledgeArticleApi'
-import { filterVisibleKmsAuthors } from '@/utils/kmsAuthorFilter'
 
 
 function formatTrend(value, digits = 0) {
@@ -171,14 +170,11 @@ async function loadArticles() {
     const res = await knowledgeArticleApi.getArticles({
       page: 0,
       size: 20,
-      status: 'APPROVED',
+      articleStatus: 'APPROVED',
     })
-    articles.value = filterVisibleKmsAuthors(
-      (res.data.data ?? [])
+    articles.value = (res.data.data ?? [])
       .filter((dto) => dto.articleStatus === 'APPROVED')
-      .map(mapToFeedItem),
-      (item) => item.author,
-    )
+      .map(mapToFeedItem)
   } catch (e) {
     console.error('[KMS] 문서 목록 로드 실패:', e)
   }
@@ -187,12 +183,10 @@ async function loadArticles() {
 async function loadBookmarks() {
   try {
     const res = await knowledgeArticleApi.getMyBookmarks()
-    bookmarkArticles.value = filterVisibleKmsAuthors(
-      (res.data.data ?? [])
-        .filter((dto) => dto.articleStatus === 'APPROVED')
-        .map(mapToFeedItem),
-      (item) => item.author,
-    ).map((item) => ({ ...item, isBookmarked: true }))
+    bookmarkArticles.value = (res.data.data ?? [])
+      .filter((dto) => dto.articleStatus === 'APPROVED')
+      .map(mapToFeedItem)
+      .map((item) => ({ ...item, isBookmarked: true }))
   } catch (e) {
     console.error('[KMS] 북마크 목록 로드 실패:', e)
   }
@@ -201,10 +195,7 @@ async function loadBookmarks() {
 async function loadContributors() {
   try {
     const res = await knowledgeArticleApi.getContributors(5)
-    contributors.value = filterVisibleKmsAuthors(
-      (res.data.data ?? []).map(mapToContributor),
-      (item) => item.name,
-    )
+    contributors.value = (res.data.data ?? []).map(mapToContributor)
   } catch (e) {
     console.error('[KMS] 기여자 랭킹 로드 실패:', e)
   }

--- a/src/views/worker/WorkerKnowledgeHubView.vue
+++ b/src/views/worker/WorkerKnowledgeHubView.vue
@@ -1,6 +1,5 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
-import { useAuthStore } from '@/stores/auth'
 import TeamLeaderKnowledgeHubHeader from '@/components/kms/common/knowledge-hub/teamleader/TeamLeaderKnowledgeHubHeader.vue'
 import TeamLeaderKnowledgeHubFeed from '@/components/kms/common/knowledge-hub/teamleader/TeamLeaderKnowledgeHubFeed.vue'
 import TeamLeaderKnowledgeHubContributors from '@/components/kms/common/knowledge-hub/teamleader/TeamLeaderKnowledgeHubContributors.vue'
@@ -23,9 +22,6 @@ import {
 import knowledgeArticleApi from '@/services/knowledgeArticleApi'
 import { filterVisibleKmsAuthors } from '@/utils/kmsAuthorFilter'
 
-const authStore = useAuthStore()
-const authorId  = computed(() => Number(authStore.userInfo?.employeeId))
-const requesterRole = computed(() => 'WORKER')
 
 function formatTrend(value, digits = 0) {
   const numeric = Number(value ?? 0)
@@ -156,8 +152,6 @@ async function loadArticles() {
       page: 0,
       size: 20,
       status: 'APPROVED',
-      requesterId: authorId.value,
-      requesterRole: requesterRole.value,
     })
     knowledgeArticles.value = filterVisibleKmsAuthors(
       (res.data.data ?? [])
@@ -172,7 +166,7 @@ async function loadArticles() {
 
 async function loadBookmarks() {
   try {
-    const res = await knowledgeArticleApi.getMyBookmarks(authorId.value)
+    const res = await knowledgeArticleApi.getMyBookmarks()
     bookmarkArticles.value = filterVisibleKmsAuthors(
       (res.data.data ?? [])
         .filter((dto) => dto.articleStatus === 'APPROVED')
@@ -273,7 +267,6 @@ function submitRequest() {
 async function handleAddArticle(data) {
   try {
     await knowledgeArticleApi.createArticle({
-      authorId:    authorId.value,
       title:       data.title,
       category:    data.category,
       equipmentId: data.equipmentId,
@@ -289,7 +282,6 @@ async function handleAddArticle(data) {
 async function handleSaveDraft(data) {
   try {
     await knowledgeArticleApi.saveDraft({
-      authorId:    authorId.value,
       title:       data.title,
       category:    data.category,
       equipmentId: data.equipmentId,
@@ -321,7 +313,7 @@ async function openDetailModal(article) {
     isBookmarked:  Boolean(article.isBookmarked),
   }
   try {
-    const res = await knowledgeArticleApi.getArticleDetail(article.id, { requesterId: authorId.value })
+    const res = await knowledgeArticleApi.getArticleDetail(article.id)
     const dto = res.data.data ?? {}
     selectedArticle.value = {
       id:            dto.articleId,
@@ -363,9 +355,9 @@ function openRecommendedArticle(item) {
 async function toggleBookmark(article) {
   try {
     if (article.isBookmarked) {
-      await knowledgeArticleApi.removeBookmark(article.id, authorId.value)
+      await knowledgeArticleApi.removeBookmark(article.id)
     } else {
-      await knowledgeArticleApi.addBookmark(article.id, authorId.value)
+      await knowledgeArticleApi.addBookmark(article.id)
     }
 
     await Promise.allSettled([loadArticles(), loadBookmarks()])

--- a/src/views/worker/WorkerKnowledgeHubView.vue
+++ b/src/views/worker/WorkerKnowledgeHubView.vue
@@ -20,7 +20,6 @@ import {
 } from '@/mocks/worker/workerKnowledgeHubData'
 
 import knowledgeArticleApi from '@/services/knowledgeArticleApi'
-import { filterVisibleKmsAuthors } from '@/utils/kmsAuthorFilter'
 
 
 function formatTrend(value, digits = 0) {
@@ -151,14 +150,11 @@ async function loadArticles() {
     const res = await knowledgeArticleApi.getArticles({
       page: 0,
       size: 20,
-      status: 'APPROVED',
+      articleStatus: 'APPROVED',
     })
-    knowledgeArticles.value = filterVisibleKmsAuthors(
-      (res.data.data ?? [])
+    knowledgeArticles.value = (res.data.data ?? [])
       .filter((dto) => dto.articleStatus === 'APPROVED')
-      .map(mapToFeedItem),
-      (item) => item.author,
-    )
+      .map(mapToFeedItem)
   } catch (e) {
     console.error('[KMS] 문서 목록 로드 실패:', e)
   }
@@ -167,12 +163,10 @@ async function loadArticles() {
 async function loadBookmarks() {
   try {
     const res = await knowledgeArticleApi.getMyBookmarks()
-    bookmarkArticles.value = filterVisibleKmsAuthors(
-      (res.data.data ?? [])
-        .filter((dto) => dto.articleStatus === 'APPROVED')
-        .map(mapToFeedItem),
-      (item) => item.author,
-    ).map((item) => ({ ...item, isBookmarked: true }))
+    bookmarkArticles.value = (res.data.data ?? [])
+      .filter((dto) => dto.articleStatus === 'APPROVED')
+      .map(mapToFeedItem)
+      .map((item) => ({ ...item, isBookmarked: true }))
   } catch (e) {
     console.error('[KMS] 북마크 목록 로드 실패:', e)
   }
@@ -181,10 +175,7 @@ async function loadBookmarks() {
 async function loadContributors() {
   try {
     const res = await knowledgeArticleApi.getContributors(5)
-    monthlyRanking.value = filterVisibleKmsAuthors(
-      (res.data.data ?? []).map(mapToContributor),
-      (item) => item.name,
-    )
+    monthlyRanking.value = (res.data.data ?? []).map(mapToContributor)
   } catch (e) {
     console.error('[KMS] 기여자 랭킹 로드 실패:', e)
   }

--- a/src/views/worker/WorkerMyKnowledgeManagementView.vue
+++ b/src/views/worker/WorkerMyKnowledgeManagementView.vue
@@ -1,6 +1,5 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
-import { useAuthStore } from '@/stores/auth'
 import { ARTICLE_CATEGORY_LABEL, ARTICLE_STATUS_LABEL } from '@/constants'
 import WorkerKnowledgeManagementHeader from '@/components/kms/worker/my-knowledge-management/WorkerKnowledgeManagementHeader.vue'
 import WorkerKnowledgeManagementOverallCount from '@/components/kms/worker/my-knowledge-management/WorkerKnowledgeManagementOverallCount.vue'
@@ -11,8 +10,6 @@ import WorkerKnowledgeDetailModal from '@/components/kms/worker/my-knowledge-man
 import WorkerKnowledgeEditModal from '@/components/kms/worker/my-knowledge-management/WorkerKnowledgeEditModal.vue'
 import knowledgeArticleApi from '@/services/knowledgeArticleApi'
 
-const authStore = useAuthStore()
-const authorId = computed(() => Number(authStore.userInfo?.employeeId))
 
 // ── 날짜 포맷 헬퍼 ─────────────────────────────────────────────
 function formatDate(isoString) {
@@ -110,7 +107,7 @@ onMounted(async () => {
 
 async function loadStats() {
   try {
-    const res = await knowledgeArticleApi.getMyArticleStats(authorId.value)
+    const res = await knowledgeArticleApi.getMyArticleStats()
     const dto = res.data.data ?? {}
     overallCount.value = mapToOverallCount(dto)
   } catch (e) {
@@ -120,7 +117,7 @@ async function loadStats() {
 
 async function loadArticles() {
   try {
-    const res = await knowledgeArticleApi.getMyArticles({ authorId: authorId.value, page: 0, size: 50 })
+    const res = await knowledgeArticleApi.getMyArticles({ page: 0, size: 50 })
     myArticles.value = (res.data.data ?? []).map(mapToMyArticle)
   } catch (e) {
     console.error('[KMS] 내 문서 목록 로드 실패:', e)
@@ -129,7 +126,7 @@ async function loadArticles() {
 
 async function loadHistory() {
   try {
-    const res = await knowledgeArticleApi.getMyArticleHistory(authorId.value)
+    const res = await knowledgeArticleApi.getMyArticleHistory()
     editHistory.value = (res.data.data ?? []).map(mapToHistoryItem)
   } catch (e) {
     console.error('[KMS] 수정 이력 로드 실패:', e)
@@ -155,10 +152,10 @@ function openHistoryDetail(historyItem) {
 async function openEditModal(article) {
   if (article.status === '승인완료') {
     try {
-      const revRes = await knowledgeArticleApi.startRevision(article.id, authorId.value)
+      const revRes = await knowledgeArticleApi.startRevision(article.id)
       const revisionId = revRes.data.data   // Long revisionArticleId
 
-      const detailRes = await knowledgeArticleApi.getArticleDetail(revisionId, { requesterId: authorId.value })
+      const detailRes = await knowledgeArticleApi.getArticleDetail(revisionId)
       const dto = detailRes.data.data ?? {}
 
       selectedArticle.value = {
@@ -187,7 +184,6 @@ async function openEditModal(article) {
 async function handleAddArticle(data) {
   try {
     await knowledgeArticleApi.createArticle({
-      authorId:    authorId.value,
       title:       data.title,
       category:    data.category,
       equipmentId: data.equipmentId,
@@ -203,7 +199,6 @@ async function handleAddArticle(data) {
 async function handleSaveDraft(data) {
   try {
     await knowledgeArticleApi.saveDraft({
-      authorId:    authorId.value,
       title:       data.title,
       category:    data.category,
       equipmentId: data.equipmentId,
@@ -220,7 +215,6 @@ async function handleSaveDraft(data) {
 async function handleEditSubmit(data) {
   try {
     const submitPayload = {
-      authorId:    authorId.value,
       title:       data.title,
       category:    data.category,
       equipmentId: data.equipmentId,
@@ -244,7 +238,6 @@ async function handleEditSubmit(data) {
 async function handleEditSaveDraft(data) {
   try {
     await knowledgeArticleApi.saveArticleAsDraft(data.id, {
-      authorId:    authorId.value,
       title:       data.title,
       category:    data.category,
       equipmentId: data.equipmentId,
@@ -262,7 +255,7 @@ async function handleDeleteArticle(article) {
   if (!confirmed) return
 
   try {
-    await knowledgeArticleApi.deleteArticle(article.id, { requesterId: authorId.value })
+    await knowledgeArticleApi.deleteArticle(article.id)
     if (selectedArticle.value?.id === article.id) {
       showDetailModal.value = false
       selectedArticle.value = null
@@ -279,7 +272,7 @@ async function handleRestoreArticle(article) {
   if (!confirmed) return
 
   try {
-    await knowledgeArticleApi.restoreArticle(article.id, { requesterId: authorId.value })
+    await knowledgeArticleApi.restoreArticle(article.id)
     if (selectedArticle.value?.id === article.id) {
       showDetailModal.value = false
       selectedArticle.value = null

--- a/src/views/worker/WorkerSkillGapView.vue
+++ b/src/views/worker/WorkerSkillGapView.vue
@@ -152,7 +152,11 @@ async function toggleBookmark(article) {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 20px;
-  align-items: start;
+  align-items: stretch;
+}
+
+.sg-grid > * {
+  min-height: 100%;
 }
 
 .sg-loading {

--- a/src/views/worker/WorkerSkillGapView.vue
+++ b/src/views/worker/WorkerSkillGapView.vue
@@ -1,11 +1,13 @@
 <script setup>
 import { ref, onMounted } from 'vue'
-import { getWorkerSkillGap } from '@/services/workerHrApi'
+import knowledgeArticleApi from '@/services/knowledgeArticleApi'
 import WorkerSkillGapChartAndStatus from '@/components/kms/worker/skill-gap/WorkerSkillGapChartAndStatus.vue'
 import WorkerSkillGapAiAnalysisReport from '@/components/kms/worker/skill-gap/WorkerSkillGapAiAnalysisReport.vue'
 import WorkerCustomizedLearningRecommendations from '@/components/kms/worker/skill-gap/WorkerCustomizedLearningRecommendations.vue'
 
 const loading = ref(true)
+const currentTier = ref('C')
+const targetTier = ref('B')
 const skillGapSkills = ref([])
 const skillGapSummary = ref({ currentOverall: 0, targetOverall: 0, totalGap: 0 })
 const aiAnalysisReport = ref({
@@ -22,7 +24,10 @@ const relatedKmsArticles = ref([])
 
 onMounted(async () => {
   try {
-    const data = await getWorkerSkillGap()
+    const response = await knowledgeArticleApi.getWorkerSkillGap()
+    const data = response.data?.data ?? response.data
+    currentTier.value = data.currentTier ?? 'C'
+    targetTier.value = data.targetTier ?? currentTier.value
     skillGapSkills.value = data.skills
     skillGapSummary.value = data.summary
     aiAnalysisReport.value = data.report
@@ -43,6 +48,8 @@ onMounted(async () => {
     <div v-else class="sg-grid">
       <!-- Left: Radar Chart + Skill Status -->
       <WorkerSkillGapChartAndStatus
+        :current-tier="currentTier"
+        :target-tier="targetTier"
         :skills="skillGapSkills"
         :summary="skillGapSummary"
       />

--- a/src/views/worker/WorkerSkillGapView.vue
+++ b/src/views/worker/WorkerSkillGapView.vue
@@ -4,6 +4,9 @@ import knowledgeArticleApi from '@/services/knowledgeArticleApi'
 import WorkerSkillGapChartAndStatus from '@/components/kms/worker/skill-gap/WorkerSkillGapChartAndStatus.vue'
 import WorkerSkillGapAiAnalysisReport from '@/components/kms/worker/skill-gap/WorkerSkillGapAiAnalysisReport.vue'
 import WorkerCustomizedLearningRecommendations from '@/components/kms/worker/skill-gap/WorkerCustomizedLearningRecommendations.vue'
+import TeamLeaderKnowledgeDetailModal from '@/components/kms/common/knowledge-hub/teamleader/TeamLeaderKnowledgeDetailModal.vue'
+
+import { ARTICLE_CATEGORY_LABEL } from '@/constants'
 
 const loading = ref(true)
 const currentTier = ref('C')
@@ -21,6 +24,7 @@ const aiAnalysisReport = ref({
 })
 const learningRecommendations = ref([])
 const relatedKmsArticles = ref([])
+const selectedArticle = ref(null)
 
 onMounted(async () => {
   try {
@@ -39,6 +43,68 @@ onMounted(async () => {
     loading.value = false
   }
 })
+
+async function openArticleDetail(article) {
+  selectedArticle.value = {
+    id: article.id,
+    title: article.title,
+    category: article.category ?? '',
+    equipment: article.equipment ?? '',
+    date: article.date ?? '',
+    author: article.author ?? '',
+    authorInitial: article.authorInitial ?? '?',
+    authorTier: article.authorTier ?? 'C',
+    content: article.preview ?? '',
+    views: article.views ?? article.likes ?? 0,
+    isBookmarked: Boolean(article.isBookmarked),
+  }
+
+  try {
+    const response = await knowledgeArticleApi.getArticleDetail(article.id)
+    const dto = response.data?.data ?? {}
+    selectedArticle.value = {
+      id: dto.articleId ?? article.id,
+      title: dto.articleTitle ?? article.title,
+      category: ARTICLE_CATEGORY_LABEL[dto.articleCategory] ?? article.category ?? '',
+      equipment: dto.equipmentName ?? article.equipment ?? '',
+      date: article.date ?? '',
+      author: dto.authorName ?? article.author ?? '',
+      authorInitial: dto.authorName?.[0] ?? article.authorInitial ?? '?',
+      authorTier: dto.authorTier ?? article.authorTier ?? 'C',
+      content: dto.articleContent ?? article.preview ?? '',
+      views: dto.viewCount ?? article.views ?? article.likes ?? 0,
+      isBookmarked: Boolean(dto.bookmarked ?? article.isBookmarked),
+    }
+  } catch (error) {
+    console.error('Failed to load skill gap article detail:', error)
+  }
+}
+
+function closeArticleDetail() {
+  selectedArticle.value = null
+}
+
+async function toggleBookmark(article) {
+  try {
+    if (article.isBookmarked) {
+      await knowledgeArticleApi.removeBookmark(article.id)
+    } else {
+      await knowledgeArticleApi.addBookmark(article.id)
+    }
+
+    const bookmarked = !article.isBookmarked
+    relatedKmsArticles.value = relatedKmsArticles.value.map((item) => (
+      item.id === article.id ? { ...item, isBookmarked: bookmarked } : item
+    ))
+
+    if (selectedArticle.value?.id === article.id) {
+      selectedArticle.value = { ...selectedArticle.value, isBookmarked: bookmarked }
+    }
+  } catch (error) {
+    console.error('Failed to toggle bookmark from skill gap:', error)
+    window.alert('북마크 처리에 실패했습니다.')
+  }
+}
 </script>
 
 <template>
@@ -61,8 +127,16 @@ onMounted(async () => {
       <WorkerCustomizedLearningRecommendations
         :courses="learningRecommendations"
         :articles="relatedKmsArticles"
+        @open-article="openArticleDetail"
       />
     </div>
+
+    <TeamLeaderKnowledgeDetailModal
+      v-if="selectedArticle"
+      :article="selectedArticle"
+      @close="closeArticleDetail"
+      @toggle-bookmark="toggleBookmark"
+    />
   </div>
 </template>
 


### PR DESCRIPTION
  - KMS 승인 화면 API 호출 정리:
    승인 통계/목록/상세 조회 메서드를 Approval 기준에서 Pending 기준으로 변경
  - KMS 허브 목록 조회 파라미터 정리:
    Worker/TL/DL/Admin 허브에서 승인완료 글 조회 시 status 대신 articleStatus를 사용하도록 수정
  - 프론트 빌드 검증 완료:
    npm run build로 변경된 API 호출과 화면 코드까지 빌드 검증 완료