### PR TITLE
feat: 담당자 D 대시보드 및 SCM 화면 연동 개선

### DIFF
--- a/src/components/common/base/data-display/BaseNotificationList.vue
+++ b/src/components/common/base/data-display/BaseNotificationList.vue
@@ -20,7 +20,7 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(['click-item', 'click-action', 'change-page'])
+const emit = defineEmits(['click-item', 'click-action', 'dismiss-item', 'change-page'])
 
 const currentPage = ref(1)
 
@@ -49,6 +49,10 @@ function handleClickItem(item) {
 function handleClickAction(item) {
   emit('click-action', item)
 }
+
+function handleDismiss(item) {
+  emit('dismiss-item', item)
+}
 </script>
 
 <template>
@@ -73,6 +77,14 @@ function handleClickAction(item) {
       </div>
 
       <div class="base-notification-list__side">
+        <button
+          type="button"
+          class="base-notification-list__dismiss"
+          aria-label="알림 숨기기"
+          @click.stop="handleDismiss(item)"
+        >
+          ×
+        </button>
         <span class="base-notification-list__time">{{ item.time }}</span>
         <button
           type="button"
@@ -209,10 +221,32 @@ function handleClickAction(item) {
 }
 
 .base-notification-list__side {
+  position: relative;
   display: grid;
   justify-items: end;
   gap: 10px;
   flex-shrink: 0;
+  padding-top: 22px;
+}
+
+.base-notification-list__dismiss {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: #b1abd9;
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.base-notification-list__dismiss:hover {
+  background: #f5f2ff;
+  color: var(--color-primary-700);
 }
 
 .base-notification-list__time {

--- a/src/components/dashboard/common/TeamLeaderDashboardNoticeWrapper.vue
+++ b/src/components/dashboard/common/TeamLeaderDashboardNoticeWrapper.vue
@@ -15,6 +15,8 @@ defineProps({
     default: '',
   },
 })
+
+const emit = defineEmits(['click'])
 </script>
 
 <template>
@@ -25,5 +27,16 @@ defineProps({
     :description="description"
     tone="success"
     variant="soft"
+    role="button"
+    tabindex="0"
+    @click="emit('click')"
+    @keydown.enter.prevent="emit('click')"
+    @keydown.space.prevent="emit('click')"
   />
 </template>
+
+<style scoped>
+.notice {
+  cursor: pointer;
+}
+</style>

--- a/src/components/dashboard/common/WorkerNotificationBanner.vue
+++ b/src/components/dashboard/common/WorkerNotificationBanner.vue
@@ -3,10 +3,19 @@ defineProps({
   title: { type: String, required: true },
   description: { type: String, default: '' },
 })
+
+const emit = defineEmits(['click'])
 </script>
 
 <template>
-  <div class="notification">
+  <div
+    class="notification"
+    role="button"
+    tabindex="0"
+    @click="emit('click')"
+    @keydown.enter="emit('click')"
+    @keydown.space.prevent="emit('click')"
+  >
     <div class="notification__header">
       <span class="notification__icon">🔥</span>
       <span class="notification__badge">중요 공지</span>
@@ -23,6 +32,7 @@ defineProps({
   border-left: 4px solid var(--tier-c);
   border-radius: var(--radius-base);
   padding: 16px 20px;
+  cursor: pointer;
 }
 
 .notification__header {

--- a/src/components/dashboard/departmentleader/DepartmentLeaderGroupKpiCard.vue
+++ b/src/components/dashboard/departmentleader/DepartmentLeaderGroupKpiCard.vue
@@ -1,85 +1,23 @@
 <script setup>
-import { ref, onMounted, onBeforeUnmount, nextTick } from 'vue'
-import {
-  Chart,
-  BarController,
-  BarElement,
-  CategoryScale,
-  LinearScale,
-  Tooltip,
-} from 'chart.js'
+import { computed } from 'vue'
 
-Chart.register(BarController, BarElement, CategoryScale, LinearScale, Tooltip)
-
-defineProps({
-  groupAvg: { type: Number, default: 83.1 },
-  equipRate: { type: String, default: '91.4%' },
-  qualityRate: { type: String, default: '96.2%' },
+const props = defineProps({
+  groupAvg:    { type: Number, default: 0 },
+  equipRate:   { type: String, default: '0%' },
+  qualityRate: { type: String, default: '0명' },
+  tierStats:   { type: Object, default: () => ({ s: 0, a: 0, b: 0, c: 0 }) },
 })
 
-const canvasRef = ref(null)
-let chartInstance = null
-
-const kpiTrend = [
-  { quarter: '2024Q2', value: 72 },
-  { quarter: 'Q3',     value: 75 },
-  { quarter: 'Q4',     value: 80 },
-  { quarter: '2025Q1', value: 83.1 },
-]
-
-const barColors = ['#e0dcff', '#e0dcff', '#5b4fcf', '#18c3aa']
-
-function buildChart() {
-  if (chartInstance) chartInstance.destroy()
-  chartInstance = new Chart(canvasRef.value, {
-    type: 'bar',
-    data: {
-      labels: kpiTrend.map((d) => d.quarter),
-      datasets: [
-        {
-          data: kpiTrend.map((d) => d.value),
-          backgroundColor: barColors,
-          borderRadius: 6,
-          barThickness: 48,
-        },
-      ],
-    },
-    options: {
-      responsive: true,
-      maintainAspectRatio: false,
-      animation: { duration: 900, easing: 'easeOutQuart' },
-      scales: {
-        x: {
-          grid: { display: false },
-          ticks: {
-            color: getComputedStyle(document.documentElement)
-              .getPropertyValue('--color-text-muted').trim(),
-            font: { size: 12 },
-          },
-          border: { display: false },
-        },
-        y: {
-          display: false,
-          beginAtZero: true,
-          max: 100,
-        },
-      },
-      plugins: {
-        legend: { display: false },
-        tooltip: {
-          callbacks: {
-            label: (ctx) => ` 그룹 KPI: ${ctx.parsed.y}`,
-          },
-        },
-      },
-    },
-  })
-}
-
-onMounted(() => {
-  nextTick().then(() => requestAnimationFrame(buildChart))
+const tiers = computed(() => {
+  const { s, a, b, c } = props.tierStats
+  const total = s + a + b + c || 1
+  return [
+    { label: 'S', count: s, pct: Math.round((s / total) * 100), cls: 'tier--s' },
+    { label: 'A', count: a, pct: Math.round((a / total) * 100), cls: 'tier--a' },
+    { label: 'B', count: b, pct: Math.round((b / total) * 100), cls: 'tier--b' },
+    { label: 'C', count: c, pct: Math.round((c / total) * 100), cls: 'tier--c' },
+  ]
 })
-onBeforeUnmount(() => chartInstance?.destroy())
 </script>
 
 <template>
@@ -87,29 +25,40 @@ onBeforeUnmount(() => chartInstance?.destroy())
     <header class="dl-kpi-card__header">
       <div class="dl-kpi-card__title-row">
         <span class="dl-kpi-card__dot">●</span>
-        <span class="dl-kpi-card__title">그룹 통합 KPI</span>
-        <span class="dl-kpi-card__ai-badge">AI</span>
+        <span class="dl-kpi-card__title">부서 성과 현황</span>
       </div>
-      <button class="dl-kpi-card__detail-btn">상세 →</button>
     </header>
 
     <div class="dl-kpi-card__stats">
       <div class="dl-kpi-card__stat dl-kpi-card__stat--primary">
         <span class="dl-kpi-card__stat-value">{{ groupAvg }}</span>
-        <span class="dl-kpi-card__stat-label">그룹 평균</span>
+        <span class="dl-kpi-card__stat-label">부서 평균 점수</span>
       </div>
       <div class="dl-kpi-card__stat dl-kpi-card__stat--mint">
         <span class="dl-kpi-card__stat-value">{{ equipRate }}</span>
-        <span class="dl-kpi-card__stat-label">설비 가동률</span>
+        <span class="dl-kpi-card__stat-label">평가율</span>
       </div>
       <div class="dl-kpi-card__stat dl-kpi-card__stat--gold">
         <span class="dl-kpi-card__stat-value">{{ qualityRate }}</span>
-        <span class="dl-kpi-card__stat-label">품질 달성</span>
+        <span class="dl-kpi-card__stat-label">S/A Tier</span>
       </div>
     </div>
 
-    <div class="dl-kpi-card__chart">
-      <canvas ref="canvasRef" />
+    <div class="dl-kpi-card__tier-section">
+      <p class="dl-kpi-card__tier-title">Tier 분포</p>
+      <div class="dl-kpi-card__tier-list">
+        <div v-for="tier in tiers" :key="tier.label" class="dl-kpi-card__tier-row">
+          <span class="dl-kpi-card__tier-label" :class="tier.cls">{{ tier.label }}</span>
+          <div class="dl-kpi-card__tier-bar-track">
+            <div
+              class="dl-kpi-card__tier-bar-fill"
+              :class="tier.cls"
+              :style="{ width: tier.pct + '%' }"
+            />
+          </div>
+          <span class="dl-kpi-card__tier-count">{{ tier.count }}명</span>
+        </div>
+      </div>
     </div>
   </section>
 </template>
@@ -148,31 +97,6 @@ onBeforeUnmount(() => chartInstance?.destroy())
   color: var(--color-primary-800);
 }
 
-.dl-kpi-card__ai-badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  height: 22px;
-  padding: 0 10px;
-  border-radius: 999px;
-  background: var(--color-primary-700);
-  color: #fff;
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-bold);
-}
-
-.dl-kpi-card__detail-btn {
-  background: none;
-  border: none;
-  cursor: pointer;
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-primary-500);
-}
-.dl-kpi-card__detail-btn:hover {
-  color: var(--color-primary-700);
-}
-
 .dl-kpi-card__stats {
   display: flex;
   gap: 32px;
@@ -195,18 +119,74 @@ onBeforeUnmount(() => chartInstance?.destroy())
   color: var(--color-text-muted);
 }
 
-.dl-kpi-card__stat--primary .dl-kpi-card__stat-value {
-  color: var(--color-primary-700);
-}
-.dl-kpi-card__stat--mint .dl-kpi-card__stat-value {
-  color: var(--color-mint-500);
-}
-.dl-kpi-card__stat--gold .dl-kpi-card__stat-value {
-  color: #d97706;
+.dl-kpi-card__stat--primary .dl-kpi-card__stat-value { color: var(--color-primary-700); }
+.dl-kpi-card__stat--mint    .dl-kpi-card__stat-value { color: var(--color-mint-500, #18c3aa); }
+.dl-kpi-card__stat--gold    .dl-kpi-card__stat-value { color: #d97706; }
+
+/* Tier 분포 */
+.dl-kpi-card__tier-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
-.dl-kpi-card__chart {
-  height: 160px;
-  position: relative;
+.dl-kpi-card__tier-title {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-muted);
+  margin: 0;
 }
+
+.dl-kpi-card__tier-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.dl-kpi-card__tier-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.dl-kpi-card__tier-label {
+  width: 20px;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.dl-kpi-card__tier-bar-track {
+  flex: 1;
+  height: 10px;
+  border-radius: 999px;
+  background: var(--color-border-muted, #ede9ff);
+  overflow: hidden;
+}
+
+.dl-kpi-card__tier-bar-fill {
+  height: 100%;
+  border-radius: 999px;
+  transition: width 0.6s ease;
+}
+
+.dl-kpi-card__tier-count {
+  width: 36px;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  text-align: right;
+  flex-shrink: 0;
+}
+
+/* Tier 색상 */
+.tier--s { color: var(--tier-s, #9c27b0); }
+.tier--a { color: var(--tier-a, #e65100); }
+.tier--b { color: var(--tier-b, #1565c0); }
+.tier--c { color: var(--tier-c, #2e7d32); }
+
+.dl-kpi-card__tier-bar-fill.tier--s { background: var(--tier-s, #9c27b0); }
+.dl-kpi-card__tier-bar-fill.tier--a { background: var(--tier-a, #e65100); }
+.dl-kpi-card__tier-bar-fill.tier--b { background: var(--tier-b, #1565c0); }
+.dl-kpi-card__tier-bar-fill.tier--c { background: var(--tier-c, #2e7d32); }
 </style>

--- a/src/components/dashboard/departmentleader/DepartmentLeaderMemberTable.vue
+++ b/src/components/dashboard/departmentleader/DepartmentLeaderMemberTable.vue
@@ -1,0 +1,198 @@
+<script setup>
+defineProps({
+  members: {
+    type: Array,
+    default: () => [],
+  },
+})
+
+const tierClass = (tier) => {
+  if (tier === 'S') return 'tier--s'
+  if (tier === 'A') return 'tier--a'
+  if (tier === 'B') return 'tier--b'
+  if (tier === 'C') return 'tier--c'
+  return ''
+}
+
+const statusConfig = {
+  CONFIRMED: { label: '확정', cls: 'status--done' },
+  SUBMITTED:  { label: '제출완료', cls: 'status--review' },
+  DRAFT:      { label: '초안저장', cls: 'status--draft' },
+  NO_INPUT:   { label: '미작성', cls: 'status--pending' },
+}
+</script>
+
+<template>
+  <section class="dl-member-table">
+    <header class="dl-member-table__header">
+      <div class="dl-member-table__title-row">
+        <span class="dl-member-table__dot">●</span>
+        <span class="dl-member-table__title">팀원 역량 현황</span>
+      </div>
+      <span class="dl-member-table__count">{{ members.length }}명</span>
+    </header>
+
+    <div class="dl-member-table__wrap">
+      <table class="dl-member-table__table">
+        <thead>
+          <tr>
+            <th class="col-name">이름</th>
+            <th>현재 TIER</th>
+            <th>정성 점수</th>
+            <th>평가 등급</th>
+            <th>평가 상태</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="m in members" :key="m.id">
+            <td class="col-name">{{ m.name }}</td>
+            <td>
+              <span class="tier-badge" :class="tierClass(m.tier)">{{ m.tier }}</span>
+            </td>
+            <td class="col-score">{{ m.score }}</td>
+            <td>
+              <span class="tier-badge" :class="tierClass(m.grade)">{{ m.grade }}</span>
+            </td>
+            <td>
+              <span
+                class="status-chip"
+                :class="statusConfig[m.status]?.cls ?? 'status--pending'"
+              >
+                {{ statusConfig[m.status]?.label ?? m.status }}
+              </span>
+            </td>
+          </tr>
+          <tr v-if="members.length === 0">
+            <td colspan="5" class="col-empty">평가 기간 중 데이터가 없습니다.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.dl-member-table {
+  padding: 22px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 24px;
+  background: var(--color-bg-surface);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.dl-member-table__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.dl-member-table__title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.dl-member-table__dot {
+  font-size: var(--font-size-2xs);
+  color: var(--color-primary-500);
+}
+
+.dl-member-table__title {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary-800);
+}
+
+.dl-member-table__count {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.dl-member-table__wrap {
+  overflow-x: auto;
+}
+
+.dl-member-table__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--font-size-base);
+}
+
+.dl-member-table__table thead tr {
+  border-bottom: 1px solid var(--color-border-default);
+}
+
+.dl-member-table__table th {
+  padding: 10px 14px;
+  text-align: center;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-muted);
+}
+
+.dl-member-table__table th.col-name {
+  text-align: left;
+}
+
+.dl-member-table__table td {
+  padding: 13px 14px;
+  text-align: center;
+  color: var(--color-primary-800);
+  border-bottom: 1px solid var(--color-border-muted);
+}
+
+.dl-member-table__table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.col-name {
+  text-align: left !important;
+  font-weight: var(--font-weight-semibold);
+}
+
+.col-score {
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary-700) !important;
+}
+
+.col-empty {
+  text-align: center !important;
+  color: var(--color-text-muted);
+  padding: 24px 0 !important;
+}
+
+.tier-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+}
+
+.tier--s { background: #fdf3ff; color: var(--tier-s, #9c27b0); }
+.tier--a { background: #fff3e0; color: var(--tier-a, #e65100); }
+.tier--b { background: #e3f2fd; color: var(--tier-b, #1565c0); }
+.tier--c { background: #f1f8e9; color: var(--tier-c, #2e7d32); }
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 24px;
+  padding: 0 10px;
+  border-radius: 999px;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+  white-space: nowrap;
+}
+
+.status--done    { background: var(--color-success-soft); color: var(--color-success); }
+.status--review  { background: var(--color-warning-soft); color: var(--color-warning); }
+.status--draft   { background: #f0edff; color: var(--color-primary-700); }
+.status--pending { background: var(--color-danger-soft);  color: var(--color-danger); }
+</style>

--- a/src/components/dashboard/hrmanager/HRMTierDistCard.vue
+++ b/src/components/dashboard/hrmanager/HRMTierDistCard.vue
@@ -3,6 +3,7 @@ defineProps({
   tierS: { type: Number, default: 0 },
   tierA: { type: Number, default: 0 },
   tierB: { type: Number, default: 0 },
+  tierC: { type: Number, default: 0 },
   processLabel: { type: String, default: '' },
   processPercent: { type: Number, default: 0 },
 })
@@ -24,6 +25,10 @@ defineProps({
       <div class="tier-num tier-num--b">
         <span class="tier-num__value">{{ tierB }}</span>
         <span class="tier-num__label">B</span>
+      </div>
+      <div class="tier-num tier-num--c">
+        <span class="tier-num__value">{{ tierC }}</span>
+        <span class="tier-num__label">C</span>
       </div>
     </div>
 
@@ -82,6 +87,7 @@ defineProps({
 .tier-num--s .tier-num__value { color: var(--tier-s); }
 .tier-num--a .tier-num__value { color: var(--tier-a); }
 .tier-num--b .tier-num__value { color: var(--tier-b); }
+.tier-num--c .tier-num__value { color: var(--tier-c); }
 
 .tier-dist-card__process {
   display: flex;

--- a/src/components/dashboard/worker/WorkerMissionBoard.vue
+++ b/src/components/dashboard/worker/WorkerMissionBoard.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, onMounted } from 'vue'
+import { computed, ref, onMounted } from 'vue'
 
 const animated = ref(false)
 onMounted(() => {
@@ -8,18 +8,38 @@ onMounted(() => {
   })
 })
 
-defineProps({
+const props = defineProps({
   missions: {
     type: Array,
     default: () => [],
     // [{ title, points, current, target, icon }]
   },
+  currentTier: {
+    type: String,
+    default: '',
+  },
 })
+
+const tierOrder = ['C', 'B', 'A', 'S', 'S+']
+
+const nextTier = computed(() => {
+  const missionTargetTier = props.missions.find((mission) => mission.targetTier)?.targetTier
+  if (missionTargetTier) return missionTargetTier
+
+  const currentIndex = tierOrder.indexOf(props.currentTier)
+  return currentIndex >= 0 && currentIndex < tierOrder.length - 1
+    ? tierOrder[currentIndex + 1]
+    : ''
+})
+
+const title = computed(() =>
+  nextTier.value ? `${nextTier.value} 승급 미션 리스트` : '승급 미션 리스트'
+)
 </script>
 
 <template>
   <div class="missions">
-    <h3 class="missions__title">S+ 승급 미션 리스트</h3>
+    <h3 class="missions__title">{{ title }}</h3>
 
     <div class="missions__list">
       <div v-for="(m, i) in missions" :key="i" class="missions__card">

--- a/src/components/hr/departmentleader/perfomance/DepartmentLeaderPerformanceSummary.vue
+++ b/src/components/hr/departmentleader/perfomance/DepartmentLeaderPerformanceSummary.vue
@@ -10,7 +10,9 @@ const props = defineProps({
 const emit = defineEmits(['update:selectedTeam'])
 
 const progressPercent = computed(() =>
-  Math.round((props.summary.evalCompleted / props.summary.evalTotal) * 100),
+  props.summary.evalTotal > 0
+    ? Math.round((props.summary.evalCompleted / props.summary.evalTotal) * 100)
+    : 0,
 )
 
 const avgLabel   = computed(() => props.selectedTeam === '전체' ? '부서 평균 점수' : '팀 평균 점수')

--- a/src/components/hr/departmentleader/team-capability/DepartmentLeaderCapabilityDetailPanel.vue
+++ b/src/components/hr/departmentleader/team-capability/DepartmentLeaderCapabilityDetailPanel.vue
@@ -40,8 +40,8 @@ defineProps({
                 {{ member.tier }}-TIER
               </span>
             </div>
-            <span class="capability-detail__sub">
-              {{ member.line }} · {{ member.experience }}
+            <span v-if="member.line || member.experience" class="capability-detail__sub">
+              {{ [member.line, member.experience].filter(Boolean).join(' · ') }}
             </span>
           </div>
         </div>
@@ -52,27 +52,31 @@ defineProps({
 
       <!-- Score Summary -->
       <div class="capability-detail__scores">
-        <div class="capability-detail__score-item capability-detail__score-item--primary">
+        <div v-if="member.quantitative != null" class="capability-detail__score-item capability-detail__score-item--primary">
           <span class="capability-detail__score-value">{{ member.quantitative }}</span>
           <span class="capability-detail__score-label">정량</span>
         </div>
         <div class="capability-detail__score-item capability-detail__score-item--mint">
           <span class="capability-detail__score-value">{{ member.qualitative }}</span>
-          <span class="capability-detail__score-label">정성 (AI)</span>
+          <span class="capability-detail__score-label">정성</span>
         </div>
-        <div class="capability-detail__score-item capability-detail__score-item--dark">
+        <div v-if="member.composite != null" class="capability-detail__score-item capability-detail__score-item--dark">
           <span class="capability-detail__score-value">{{ member.composite }}</span>
           <span class="capability-detail__score-label">종합</span>
+        </div>
+        <div class="capability-detail__score-item">
+          <span class="capability-detail__score-value">{{ member.grade }}</span>
+          <span class="capability-detail__score-label">평가 등급</span>
         </div>
       </div>
 
       <div class="capability-detail__divider" />
 
       <!-- Radar + Skill Bars -->
-      <WorkerSkillsRadarChart :skills="member.skills" />
+      <WorkerSkillsRadarChart v-if="member.skills && member.skills.length > 0" :skills="member.skills" />
 
       <!-- Tier Timeline -->
-      <DepartmentLeaderTierTimeline :history="member.tierHistory" />
+      <DepartmentLeaderTierTimeline v-if="member.tierHistory && member.tierHistory.length > 0" :history="member.tierHistory" />
     </template>
   </section>
 </template>

--- a/src/components/hr/departmentleader/team-capability/DepartmentLeaderMemberListPanel.vue
+++ b/src/components/hr/departmentleader/team-capability/DepartmentLeaderMemberListPanel.vue
@@ -13,7 +13,10 @@ const search = ref('')
 const teamFilter = ref('전체')
 const dropdownOpen = ref(false)
 
-const teams = ['전체', '정밀가공 1팀', '정밀가공 2팀']
+const teams = computed(() => {
+  const names = [...new Set(props.members.map((m) => m.team).filter(Boolean))]
+  return ['전체', ...names]
+})
 
 const filtered = computed(() => {
   return props.members.filter((m) => {
@@ -92,7 +95,7 @@ function selectTeam(t) {
               {{ m.tier }}
             </span>
           </div>
-          <span class="member-list-panel__sub">{{ m.code }} · Overall {{ m.score }}</span>
+          <span class="member-list-panel__sub">{{ [m.code, `Overall ${m.score}`].filter(Boolean).join(' · ') }}</span>
         </div>
       </li>
     </ul>

--- a/src/components/hr/hrmanager/kpi-report/HRMKpiTeamTable.vue
+++ b/src/components/hr/hrmanager/kpi-report/HRMKpiTeamTable.vue
@@ -10,12 +10,12 @@ function rateColor(rate) {
 
 <template>
   <section class="kpi-team-table">
-    <p class="kpi-team-table__title">🧑‍💼 팀장별 평가 현황</p>
+    <p class="kpi-team-table__title">🧑‍💼 부서별 평가 현황</p>
     <table class="kpi-table">
       <thead>
         <tr>
-          <th>팀장</th>
-          <th>소속라인</th>
+          <th>부서</th>
+          <th>구분</th>
           <th>담당인원</th>
           <th>평가완료</th>
           <th>평균점수</th>

--- a/src/components/hr/hrmanager/organization-management/HRMGroupAddModal.vue
+++ b/src/components/hr/hrmanager/organization-management/HRMGroupAddModal.vue
@@ -1,26 +1,93 @@
 <script setup>
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { GROUP_COLORS } from '@/mocks/hrmanager/organization.js'
 import BaseFormModal from '@/components/common/base/overlay/BaseFormModal.vue'
 
 const props = defineProps({
   editMode:           { type: Boolean, default: false },
   initialName:        { type: String,  default: '' },
-  initialDescription: { type: String,  default: '' },
   initialColor:       { type: String,  default: '' },
+  allEmployees:       { type: Array,   default: () => [] },
+  initialMemberIds:   { type: Array,   default: () => [] },
 })
 const emit = defineEmits(['close', 'submit'])
 
 const name        = ref(props.initialName)
-const description = ref(props.initialDescription)
 const color       = ref(props.initialColor || GROUP_COLORS[0])
+const selected    = ref([...props.initialMemberIds])
+const tierFilter  = ref('')
+const posFilter   = ref('')
+const nameSearch  = ref('')
+
+const TIERS = ['S', 'A', 'B', 'C']
+const ROLE_LABELS = { WORKER: '사원', TL: '팀장', DL: '부서장', HRM: 'HR 매니저', ADMIN: '관리자' }
+const POSITIONS = Object.values(ROLE_LABELS)
+
+function employeeId(emp) {
+  return emp.employeeId ?? emp.employee_id
+}
+
+function employeeName(emp) {
+  return emp.name ?? emp.employeeName ?? emp.employee_name ?? ''
+}
+
+function employeeTier(emp) {
+  return emp.currentTier ?? emp.employeeCurrentTier ?? emp.employee_current_tier
+}
+
+function positionOf(emp) {
+  const departmentName = emp.departmentName ?? emp.department_name ?? ''
+  const teamName = emp.teamName ?? emp.team_name ?? ''
+  return {
+    position: ROLE_LABELS[emp.role] ?? emp.role ?? '사원',
+    dept: departmentName && teamName && departmentName !== teamName
+      ? `${departmentName} · ${teamName}`
+      : departmentName || teamName || '기타',
+  }
+}
+
+function tierColor(tier) {
+  const map = { S: 'var(--tier-s)', A: 'var(--tier-a)', B: 'var(--tier-b)', C: 'var(--tier-c)' }
+  return map[tier] ?? '#aaa'
+}
+
+function tierTextColor(tier) {
+  return tier === 'B' ? '#1a1000' : 'var(--color-white)'
+}
+
+const poolEmployees = computed(() => {
+  return props.allEmployees.filter(emp => {
+    if (!employeeId(emp)) return false
+    if (emp.role !== 'WORKER') return false
+    if (tierFilter.value && employeeTier(emp) !== tierFilter.value) return false
+    const { position } = positionOf(emp)
+    if (posFilter.value && position !== posFilter.value) return false
+    if (nameSearch.value && !employeeName(emp).includes(nameSearch.value)) return false
+    return true
+  })
+})
+
+const selectedEmployees = computed(() =>
+  props.allEmployees.filter(emp => selected.value.includes(employeeId(emp)))
+)
+
+function toggleSelect(emp) {
+  const id = employeeId(emp)
+  const idx = selected.value.indexOf(id)
+  if (idx === -1) selected.value.push(id)
+  else selected.value.splice(idx, 1)
+}
+
+function isSelected(emp) {
+  return selected.value.includes(employeeId(emp))
+}
 
 function handleSubmit() {
   if (!name.value.trim()) return
   emit('submit', {
     name:        name.value.trim(),
-    description: description.value.trim(),
     color:       color.value,
+    memberIds:   [...selected.value],
   })
 }
 </script>
@@ -30,38 +97,102 @@ function handleSubmit() {
     :title="editMode ? '그룹 편집' : '그룹 추가'"
     :confirmText="editMode ? '저장' : '추가'"
     :confirmDisabled="!name.trim()"
-    width="460px"
+    :width="editMode ? '820px' : '460px'"
     @confirm="handleSubmit"
     @cancel="$emit('close')"
     @close="$emit('close')"
   >
-    <div class="modal__form">
-    <label class="modal__label">그룹명 <span class="modal__required">*</span></label>
-    <input
-      v-model="name"
-      class="modal__input"
-      placeholder="예: 생산본부"
-      maxlength="30"
-    />
+    <div :class="editMode ? 'modal__body' : 'modal__form'">
+      <div class="modal__left">
+        <label class="modal__label">그룹명 <span class="modal__required">*</span></label>
+        <input
+          v-model="name"
+          class="modal__input"
+          placeholder="예: 생산본부"
+          maxlength="30"
+        />
 
-    <label class="modal__label">설명</label>
-    <textarea
-      v-model="description"
-      class="modal__textarea"
-      rows="4"
-    />
+        <label class="modal__label">그룹 색상</label>
+        <div class="modal__colors">
+          <button
+            v-for="c in GROUP_COLORS"
+            :key="c"
+            class="color-dot"
+            :class="{ 'color-dot--active': color === c }"
+            :style="{ background: c }"
+            @click="color = c"
+          />
+        </div>
 
-    <label class="modal__label">그룹 색상</label>
-    <div class="modal__colors">
-      <button
-        v-for="c in GROUP_COLORS"
-        :key="c"
-        class="color-dot"
-        :class="{ 'color-dot--active': color === c }"
-        :style="{ background: c }"
-        @click="color = c"
-      />
-    </div>
+        <template v-if="editMode">
+          <label class="modal__label">부서원</label>
+          <div class="selected-box">
+            <span v-if="selectedEmployees.length === 0" class="selected-box__empty">
+              인력 풀에서 추가할 직원을 선택해 주세요
+            </span>
+            <div v-else class="selected-tags">
+              <span
+                v-for="emp in selectedEmployees"
+                :key="employeeId(emp)"
+                class="selected-tag"
+                @click="toggleSelect(emp)"
+              >
+                {{ employeeName(emp) }}
+                <span class="selected-tag__tier"
+                  :style="{ background: tierColor(employeeTier(emp)), color: tierTextColor(employeeTier(emp)) }"
+                >{{ employeeTier(emp) }}</span>
+                <span class="selected-tag__remove">×</span>
+              </span>
+            </div>
+          </div>
+        </template>
+      </div>
+
+      <div v-if="editMode" class="modal__right">
+        <p class="modal__section-title">인력 풀</p>
+
+        <div class="pool__filters">
+          <select v-model="tierFilter" class="pool__select">
+            <option value="">전체 Tier</option>
+            <option v-for="t in TIERS" :key="t" :value="t">Tier {{ t }}</option>
+          </select>
+          <select v-model="posFilter" class="pool__select">
+            <option value="">전체 직위</option>
+            <option v-for="p in POSITIONS" :key="p" :value="p">{{ p }}</option>
+          </select>
+          <div class="pool__search-wrap">
+            <span class="pool__search-icon">&#128269;</span>
+            <input v-model="nameSearch" class="pool__search" placeholder="이름 검색" />
+          </div>
+        </div>
+
+        <div class="pool__list">
+          <div
+            v-for="emp in poolEmployees"
+            :key="employeeId(emp)"
+            class="pool-item"
+            :class="{ 'pool-item--selected': isSelected(emp) }"
+            @click="toggleSelect(emp)"
+          >
+            <div class="pool-item__avatar"
+              :style="{ background: tierColor(employeeTier(emp)) }"
+            >{{ employeeName(emp)[0] }}</div>
+            <div class="pool-item__info">
+              <div class="pool-item__row1">
+                <span class="pool-item__name">{{ employeeName(emp) }}</span>
+                <span class="pool-item__tier"
+                  :style="{ background: tierColor(employeeTier(emp)), color: tierTextColor(employeeTier(emp)) }"
+                >{{ employeeTier(emp) }}</span>
+              </div>
+              <p class="pool-item__sub">
+                {{ positionOf(emp).position }}·{{ positionOf(emp).dept }}
+              </p>
+            </div>
+            <div v-if="isSelected(emp)" class="pool-item__check">✓</div>
+          </div>
+          <div v-if="poolEmployees.length === 0" class="pool__empty">검색 결과가 없습니다.</div>
+        </div>
+      </div>
     </div>
   </BaseFormModal>
 </template>
@@ -71,6 +202,24 @@ function handleSubmit() {
   display: flex;
   flex-direction: column;
   gap: 10px;
+}
+.modal__body {
+  display: flex;
+  gap: 28px;
+  min-height: 0;
+}
+.modal__left {
+  flex: 0 0 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.modal__right {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 .modal__label {
   font-size: var(--font-size-xs); font-weight: var(--font-weight-bold);
@@ -88,18 +237,6 @@ function handleSubmit() {
   box-sizing: border-box;
 }
 .modal__input:focus { outline: none; border-color: var(--color-primary-400); }
-.modal__textarea {
-  width: 100%;
-  padding: 10px 14px;
-  border: 1.5px solid var(--color-border-default);
-  border-radius: 8px;
-  font-size: var(--font-size-sm); color: var(--color-primary-800);
-  background: var(--color-bg-app);
-  resize: none; box-sizing: border-box;
-  font-family: inherit;
-}
-.modal__textarea:focus { outline: none; border-color: var(--color-primary-400); }
-
 .modal__colors {
   display: flex; gap: 10px; flex-wrap: wrap;
   margin-top: 4px;
@@ -111,5 +248,138 @@ function handleSubmit() {
   transition: border-color .15s;
 }
 .color-dot--active { border-color: var(--color-primary-800); }
+
+.selected-box {
+  flex: 1;
+  min-height: 120px;
+  border: 1.5px solid var(--color-border-default);
+  border-radius: 8px;
+  padding: 10px 14px;
+  background: var(--color-bg-app);
+}
+.selected-box__empty {
+  font-size: var(--font-size-xs); color: #a89ed8;
+  display: flex; align-items: center; justify-content: center;
+  height: 100%;
+}
+.selected-tags { display: flex; flex-wrap: wrap; gap: 6px; }
+.selected-tag {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 8px;
+  border-radius: 999px;
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-default);
+  font-size: var(--font-size-xs);
+  color: var(--color-primary-800);
+  cursor: pointer;
+}
+.selected-tag__tier {
+  padding: 2px 5px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: var(--font-weight-bold);
+}
+.selected-tag__remove {
+  color: var(--color-danger);
+  font-weight: var(--font-weight-bold);
+}
+.modal__section-title {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary-800);
+}
+.pool__filters {
+  display: flex;
+  gap: 8px;
+}
+.pool__select, .pool__search {
+  height: 36px;
+  border: 1.5px solid var(--color-border-default);
+  border-radius: 8px;
+  background: var(--color-bg-app);
+  color: var(--color-primary-800);
+  font-size: var(--font-size-xs);
+}
+.pool__select {
+  padding: 0 10px;
+}
+.pool__search-wrap {
+  position: relative;
+  flex: 1;
+}
+.pool__search {
+  width: 100%;
+  padding: 0 12px 0 30px;
+  box-sizing: border-box;
+}
+.pool__search-icon {
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 12px;
+  color: var(--color-primary-400);
+}
+.pool__list {
+  flex: 1;
+  min-height: 330px;
+  max-height: 430px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-right: 4px;
+}
+.pool-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1.5px solid var(--color-border-default);
+  border-radius: 10px;
+  background: var(--color-bg-app);
+  cursor: pointer;
+}
+.pool-item--selected {
+  border-color: var(--color-primary-500);
+  background: var(--color-primary-50);
+}
+.pool-item__avatar {
+  width: 34px; height: 34px; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  color: var(--color-white);
+  font-weight: var(--font-weight-bold);
+}
+.pool-item__info { flex: 1; min-width: 0; }
+.pool-item__row1 {
+  display: flex; align-items: center; gap: 6px;
+}
+.pool-item__name {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary-800);
+}
+.pool-item__tier {
+  padding: 2px 6px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: var(--font-weight-bold);
+}
+.pool-item__sub {
+  margin: 2px 0 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-primary-500);
+}
+.pool-item__check {
+  color: var(--color-primary-700);
+  font-weight: var(--font-weight-bold);
+}
+.pool__empty {
+  padding: 40px 0;
+  text-align: center;
+  font-size: var(--font-size-sm);
+  color: var(--color-primary-400);
+}
 
 </style>

--- a/src/components/hr/hrmanager/organization-management/HRMTeamAddModalForm.vue
+++ b/src/components/hr/hrmanager/organization-management/HRMTeamAddModalForm.vue
@@ -1,19 +1,16 @@
 <script setup>
 import { ref, computed } from 'vue'
-import { POSITIONS, POSITION_MAP } from '@/mocks/hrmanager/organization.js'
 import BaseFormModal from '@/components/common/base/overlay/BaseFormModal.vue'
 
 const props = defineProps({
   allEmployees: { type: Array, required: true },
   initialName:        { type: String,  default: '' },
-  initialDescription: { type: String,  default: '' },
   initialMemberIds:   { type: Array,   default: () => [] },
   editMode:           { type: Boolean, default: false },
 })
 const emit = defineEmits(['close', 'submit'])
 
 const name        = ref(props.initialName)
-const description = ref(props.initialDescription)
 const selected    = ref([...props.initialMemberIds])
 
 const tierFilter  = ref('')
@@ -21,9 +18,30 @@ const posFilter   = ref('')
 const nameSearch  = ref('')
 
 const TIERS = ['S', 'A', 'B', 'C']
+const ROLE_LABELS = { WORKER: '사원', TL: '팀장', DL: '부서장', HRM: 'HR 매니저', ADMIN: '관리자' }
+const POSITIONS = Object.values(ROLE_LABELS)
+
+function employeeId(emp) {
+  return emp.employeeId ?? emp.employee_id
+}
+
+function employeeName(emp) {
+  return emp.name ?? emp.employeeName ?? emp.employee_name ?? ''
+}
+
+function employeeTier(emp) {
+  return emp.currentTier ?? emp.employeeCurrentTier ?? emp.employee_current_tier
+}
 
 function positionOf(emp) {
-  return POSITION_MAP[emp.employee_id] ?? { position: '사원', dept: '기타' }
+  const departmentName = emp.departmentName ?? emp.department_name ?? ''
+  const teamName = emp.teamName ?? emp.team_name ?? ''
+  return {
+    position: ROLE_LABELS[emp.role] ?? emp.role ?? '사원',
+    dept: departmentName && teamName && departmentName !== teamName
+      ? `${departmentName} · ${teamName}`
+      : departmentName || teamName || '기타',
+  }
 }
 
 function tierColor(tier) {
@@ -36,33 +54,33 @@ function tierTextColor(tier) {
 
 const poolEmployees = computed(() => {
   return props.allEmployees.filter(emp => {
-    if (tierFilter.value && emp.employee_current_tier !== tierFilter.value) return false
+    if (tierFilter.value && employeeTier(emp) !== tierFilter.value) return false
     const { position } = positionOf(emp)
     if (posFilter.value && position !== posFilter.value) return false
-    if (nameSearch.value && !emp.employee_name.includes(nameSearch.value)) return false
+    if (nameSearch.value && !employeeName(emp).includes(nameSearch.value)) return false
     return true
   })
 })
 
 function toggleSelect(emp) {
-  const idx = selected.value.indexOf(emp.employee_id)
-  if (idx === -1) selected.value.push(emp.employee_id)
+  const id = employeeId(emp)
+  const idx = selected.value.indexOf(id)
+  if (idx === -1) selected.value.push(id)
   else            selected.value.splice(idx, 1)
 }
 
 function isSelected(emp) {
-  return selected.value.includes(emp.employee_id)
+  return selected.value.includes(employeeId(emp))
 }
 
 const selectedEmployees = computed(() =>
-  props.allEmployees.filter(e => selected.value.includes(e.employee_id))
+  props.allEmployees.filter(e => selected.value.includes(employeeId(e)))
 )
 
 function handleSubmit() {
   if (!name.value.trim()) return
   emit('submit', {
     name:        name.value.trim(),
-    description: description.value.trim(),
     memberIds:   [...selected.value],
   })
 }
@@ -89,13 +107,6 @@ function handleSubmit() {
           maxlength="30"
         />
 
-        <label class="modal__label">설명</label>
-        <textarea
-          v-model="description"
-          class="modal__textarea"
-          rows="4"
-        />
-
         <label class="modal__label">선택된 팀원</label>
         <div class="selected-box">
           <span v-if="selectedEmployees.length === 0" class="selected-box__empty">
@@ -104,14 +115,14 @@ function handleSubmit() {
           <div v-else class="selected-tags">
             <span
               v-for="emp in selectedEmployees"
-              :key="emp.employee_id"
+              :key="employeeId(emp)"
               class="selected-tag"
               @click="toggleSelect(emp)"
             >
-              {{ emp.employee_name }}
+              {{ employeeName(emp) }}
               <span class="selected-tag__tier"
-                :style="{ background: tierColor(emp.employee_current_tier), color: tierTextColor(emp.employee_current_tier) }"
-              >{{ emp.employee_current_tier }}</span>
+                :style="{ background: tierColor(employeeTier(emp)), color: tierTextColor(employeeTier(emp)) }"
+              >{{ employeeTier(emp) }}</span>
               <span class="selected-tag__remove">×</span>
             </span>
           </div>
@@ -140,20 +151,20 @@ function handleSubmit() {
         <div class="pool__list">
           <div
             v-for="emp in poolEmployees"
-            :key="emp.employee_id"
+            :key="employeeId(emp)"
             class="pool-item"
             :class="{ 'pool-item--selected': isSelected(emp) }"
             @click="toggleSelect(emp)"
           >
             <div class="pool-item__avatar"
-              :style="{ background: tierColor(emp.employee_current_tier) }"
-            >{{ emp.employee_name[0] }}</div>
+              :style="{ background: tierColor(employeeTier(emp)) }"
+            >{{ employeeName(emp)[0] }}</div>
             <div class="pool-item__info">
               <div class="pool-item__row1">
-                <span class="pool-item__name">{{ emp.employee_name }}</span>
+                <span class="pool-item__name">{{ employeeName(emp) }}</span>
                 <span class="pool-item__tier"
-                  :style="{ background: tierColor(emp.employee_current_tier), color: tierTextColor(emp.employee_current_tier) }"
-                >{{ emp.employee_current_tier }}</span>
+                  :style="{ background: tierColor(employeeTier(emp)), color: tierTextColor(employeeTier(emp)) }"
+                >{{ employeeTier(emp) }}</span>
               </div>
               <p class="pool-item__sub">
                 {{ positionOf(emp).position }}·{{ positionOf(emp).dept }}
@@ -214,18 +225,6 @@ function handleSubmit() {
   box-sizing: border-box;
 }
 .modal__input:focus { outline: none; border-color: var(--color-primary-400); }
-.modal__textarea {
-  width: 100%;
-  padding: 10px 14px;
-  border: 1.5px solid var(--color-border-default);
-  border-radius: 8px;
-  font-size: var(--font-size-sm); color: var(--color-primary-800);
-  background: var(--color-bg-app);
-  resize: none; box-sizing: border-box;
-  font-family: inherit;
-}
-.modal__textarea:focus { outline: none; border-color: var(--color-primary-400); }
-
 .selected-box {
   flex: 1;
   min-height: 80px;

--- a/src/components/hr/teamleader/kpi-report/TeamLeaderKpiMemberTableWrapper.vue
+++ b/src/components/hr/teamleader/kpi-report/TeamLeaderKpiMemberTableWrapper.vue
@@ -102,9 +102,6 @@ function handlePageChange(page) {
       </template>
   </BaseDataTable>
 
-    <div class="kpi-table-panel__warning">
-      정미래 팀원의 낮은 점수는 WLD-01 FAULT(E_idx 0.71) 영향입니다. 설비 보정 적용 중.
-    </div>
   </section>
 </template>
 
@@ -196,17 +193,6 @@ function handlePageChange(page) {
   color: #6b5de0;
   font-weight: 800;
   cursor: pointer;
-}
-
-.kpi-table-panel__warning {
-  margin-top: 0;
-  padding: 12px 14px;
-  border-radius: 12px;
-  background: #fff1f4;
-  color: #e05373;
-  font-size: 13px;
-  font-weight: 700;
-  flex-shrink: 0;
 }
 
 :deep(.base-data-table) {

--- a/src/components/hr/teamleader/notification/TeamLeaderNotificationListWrapper.vue
+++ b/src/components/hr/teamleader/notification/TeamLeaderNotificationListWrapper.vue
@@ -16,7 +16,7 @@ defineProps({
   },
 })
 
-defineEmits(['click-item', 'click-action', 'change-page'])
+defineEmits(['click-item', 'click-action', 'dismiss-item', 'change-page'])
 </script>
 
 <template>
@@ -26,6 +26,7 @@ defineEmits(['click-item', 'click-action', 'change-page'])
     :page-size="pageSize"
     @click-item="$emit('click-item', $event)"
     @click-action="$emit('click-action', $event)"
+    @dismiss-item="$emit('dismiss-item', $event)"
     @change-page="$emit('change-page', $event)"
   />
 </template>

--- a/src/components/hr/worker/point-mission/WorkerPointPerMission.vue
+++ b/src/components/hr/worker/point-mission/WorkerPointPerMission.vue
@@ -9,6 +9,7 @@ const props = defineProps({
   },
   overallCurrent: { type: Number, default: 91 },
   overallTarget: { type: Number, default: 95 },
+  currentTier: { type: String, default: '' },
 })
 
 const animated = ref(false)
@@ -19,11 +20,29 @@ onMounted(() => {
 })
 
 const overallPercent = computed(() => {
+  if (props.missions.length === 0) return 0
   const completed = props.missions.filter((m) => m.completed).length
   return Math.round((completed / props.missions.length) * 100)
 })
 
+const tierOrder = ['C', 'B', 'A', 'S', 'S+']
+
+const nextTier = computed(() => {
+  const missionTargetTier = props.missions.find((mission) => mission.targetTier)?.targetTier
+  if (missionTargetTier) return missionTargetTier
+
+  const currentIndex = tierOrder.indexOf(props.currentTier)
+  return currentIndex >= 0 && currentIndex < tierOrder.length - 1
+    ? tierOrder[currentIndex + 1]
+    : ''
+})
+
+const title = computed(() =>
+  nextTier.value ? `${nextTier.value} 승급 미션` : '승급 미션'
+)
+
 function missionPercent(m) {
+  if (!m.target) return 0
   return Math.min(Math.round((m.current / m.target) * 100), 100)
 }
 
@@ -38,7 +57,7 @@ function progressLabel(m) {
   <div class="pm">
     <div class="pm__header">
       <span class="pm__header-icon">🎯</span>
-      <span class="pm__header-title">S+ 승급 미션</span>
+      <span class="pm__header-title">{{ title }}</span>
     </div>
 
     <div class="pm__overall">

--- a/src/components/scm/teamleader/facility-status/TeamLeaderFacilityHistoryPanel.vue
+++ b/src/components/scm/teamleader/facility-status/TeamLeaderFacilityHistoryPanel.vue
@@ -4,19 +4,28 @@ defineProps({
     type: Array,
     default: () => [],
   },
+  facilityName: {
+    type: String,
+    default: '',
+  },
 })
 </script>
 
 <template>
   <article class="history-panel">
-    <p class="history-panel__eyebrow">최근 장비 이력</p>
+    <div class="history-panel__head">
+      <p class="history-panel__eyebrow">최근 장비 이력</p>
+      <strong v-if="facilityName" class="history-panel__facility">{{ facilityName }}</strong>
+    </div>
 
-    <div class="history-panel__list">
+    <div v-if="items.length" class="history-panel__list">
       <article v-for="item in items" :key="item.id" class="history-panel__item">
         <span class="history-panel__time">{{ item.time }}</span>
         <strong class="history-panel__title">{{ item.title }}</strong>
       </article>
     </div>
+
+    <p v-else class="history-panel__empty">선택한 설비의 최근 이력이 없습니다.</p>
   </article>
 </template>
 
@@ -34,6 +43,16 @@ defineProps({
   font-size: 12px;
   font-weight: 700;
   color: var(--color-primary-300);
+}
+
+.history-panel__head {
+  display: grid;
+  gap: 6px;
+}
+
+.history-panel__facility {
+  font-size: 16px;
+  color: var(--color-primary-800);
 }
 
 .history-panel__list {
@@ -55,5 +74,12 @@ defineProps({
   font-size: 18px;
   line-height: 1.35;
   color: var(--color-primary-800);
+}
+
+.history-panel__empty {
+  padding: 18px 0;
+  color: var(--color-primary-200);
+  font-size: 14px;
+  font-weight: 700;
 }
 </style>

--- a/src/components/scm/teamleader/facility-status/TeamLeaderFacilityStatusCard.vue
+++ b/src/components/scm/teamleader/facility-status/TeamLeaderFacilityStatusCard.vue
@@ -4,7 +4,13 @@ const props = defineProps({
     type: Object,
     required: true,
   },
+  selected: {
+    type: Boolean,
+    default: false,
+  },
 })
+
+const emit = defineEmits(['select'])
 
 function cardValue(value) {
   if (value == null) return '-'
@@ -18,7 +24,15 @@ function progressWidth(value) {
 </script>
 
 <template>
-  <article class="facility-card" :class="`facility-card--${card.tone}`">
+  <article
+    class="facility-card"
+    :class="[`facility-card--${card.tone}`, { 'facility-card--selected': selected }]"
+    role="button"
+    tabindex="0"
+    @click="emit('select', card.id)"
+    @keydown.enter.prevent="emit('select', card.id)"
+    @keydown.space.prevent="emit('select', card.id)"
+  >
     <div class="facility-card__top">
       <div class="facility-card__heading">
         <p class="facility-card__code">{{ card.code }}</p>
@@ -63,6 +77,22 @@ function progressWidth(value) {
   border: 1px solid var(--color-border-default);
   border-radius: 18px;
   background: var(--color-bg-surface);
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.facility-card:hover,
+.facility-card:focus-visible {
+  border-color: var(--color-primary-300);
+  box-shadow: 0 10px 24px rgba(73, 57, 157, 0.12);
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.facility-card--selected {
+  border-color: var(--color-primary-700);
+  background: linear-gradient(135deg, #f3f0ff 0%, #ffffff 62%, #e8fbf7 100%);
+  box-shadow: 0 14px 32px rgba(73, 57, 157, 0.22);
 }
 
 .facility-card__top,

--- a/src/components/scm/teamleader/order-status/OrderAssignmentModal.vue
+++ b/src/components/scm/teamleader/order-status/OrderAssignmentModal.vue
@@ -13,6 +13,10 @@ const props = defineProps({
 const emit = defineEmits(['close', 'submit'])
 
 const selectedTechnicianId = ref(null)
+const MATCHING_MODE_LABELS = {
+  EFFICIENCY_TYPE: '최적형 배정',
+  GROWTH_TYPE: '도전형 배정',
+}
 
 watch(
   () => props.open,
@@ -36,6 +40,10 @@ watch(
 const selectedCandidate = computed(() =>
   props.candidates.find((candidate) => candidate.employeeId === selectedTechnicianId.value) ?? null
 )
+
+function matchingModeLabel(candidate) {
+  return MATCHING_MODE_LABELS[candidate?.matchingMode] ?? '배정 유형 미정'
+}
 
 function handleSubmit() {
   if (!props.order?.orderId || !selectedTechnicianId.value) return
@@ -103,6 +111,7 @@ function handleSubmit() {
           <div class="assignment-modal__candidate-row assignment-modal__candidate-row--meta">
             <span>OCSA {{ candidate.score ?? '-' }}</span>
             <span>적합도 {{ candidate.suitabilityScore ?? '-' }}</span>
+            <span class="assignment-modal__mode">{{ matchingModeLabel(candidate) }}</span>
           </div>
         </div>
       </label>
@@ -172,6 +181,14 @@ function handleSubmit() {
   color: var(--color-primary-700);
   font-size: 12px;
   font-weight: 700;
+}
+.assignment-modal__mode {
+  display: inline-flex;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: #f6f3ff;
+  color: var(--color-primary-700);
+  font-weight: 800;
 }
 .assignment-modal__summary {
   display: flex;

--- a/src/components/scm/teamleader/order-status/TeamLeaderScmPipelineBoard.vue
+++ b/src/components/scm/teamleader/order-status/TeamLeaderScmPipelineBoard.vue
@@ -184,6 +184,7 @@ function formatCount(count) {
   display: grid;
   align-content: start;
   gap: 6px;
+  box-sizing: border-box;
   min-height: 156px;
   padding: 14px 12px;
   border: 2px solid var(--color-border-default);
@@ -211,13 +212,19 @@ function formatCount(count) {
 
 .pipeline-card__action {
   margin-top: auto;
+  width: 100%;
+  min-width: 0;
   height: 34px;
+  padding: 0 10px;
   border: none;
   border-radius: 10px;
   background: var(--color-primary-600);
   color: var(--color-text-inverse);
   font-size: 12px;
   font-weight: 700;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   cursor: pointer;
 }
 

--- a/src/components/scm/teamleader/task-matching/TeamLeaderTaskMatchingAssignmentPanel.vue
+++ b/src/components/scm/teamleader/task-matching/TeamLeaderTaskMatchingAssignmentPanel.vue
@@ -36,12 +36,12 @@ function candidateToneClass(tone) {
 }
 
 const displayedCandidates = computed(() => {
-  const list = [...props.candidates]
+  const list = props.candidates.filter((candidate) => candidate.assignmentType === strategy.value)
   if (strategy.value === 'optimal') {
-    return list.sort((a, b) => Number(b.fit.replace('%', '')) - Number(a.fit.replace('%', '')))
+    return [...list].sort((a, b) => Number(b.fit.replace('%', '')) - Number(a.fit.replace('%', '')))
   }
 
-  return list.sort((a, b) => {
+  return [...list].sort((a, b) => {
     const fitGap = Number(a.fit.replace('%', '')) - Number(b.fit.replace('%', ''))
     if (Math.abs(fitGap) > 12) return fitGap
     return a.score - b.score
@@ -180,7 +180,7 @@ function confirmAssignment() {
                     <strong>{{ candidate.name }}</strong>
                     <span>{{ candidate.tier }}</span>
                   </div>
-                  <p>{{ candidate.line }}</p>
+                  <p>{{ candidate.line }} · {{ candidate.matchingModeLabel }}</p>
                 </div>
               </div>
               <div class="candidate-card__action">
@@ -219,7 +219,7 @@ function confirmAssignment() {
       <p class="assignment-panel__eyebrow">배정 확인</p>
       <h3>{{ selectedOrder.code }} 주문을 배정하시겠습니까?</h3>
       <p class="assignment-confirm-modal__copy">
-        {{ confirmTarget.name }} · {{ confirmTarget.tier }} · 적합도 {{ confirmTarget.fit }}
+        {{ confirmTarget.name }} · {{ confirmTarget.tier }} · {{ confirmTarget.matchingModeLabel }} · 적합도 {{ confirmTarget.fit }}
       </p>
       <div class="assignment-confirm-modal__actions">
         <button type="button" class="assignment-confirm-modal__button assignment-confirm-modal__button--ghost" @click="closeConfirm">취소</button>

--- a/src/components/scm/teamleader/task-matching/TeamLeaderTaskMatchingDashboardPanel.vue
+++ b/src/components/scm/teamleader/task-matching/TeamLeaderTaskMatchingDashboardPanel.vue
@@ -164,10 +164,18 @@ function tierClass(tier) {
   gap: 10px;
 }
 
-.line-card__head h3,
-.alerts-card strong {
+.line-card__head h3 {
   font-size: 18px;
   color: var(--color-primary-800);
+}
+
+.alerts-card strong {
+  overflow: hidden;
+  color: var(--color-primary-800);
+  font-size: 14px;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .line-card__percent {
@@ -471,7 +479,8 @@ function tierClass(tier) {
 
 .alerts-card__list {
   display: grid;
-  gap: 12px;
+  align-content: start;
+  gap: 8px;
   min-height: 0;
   overflow-y: auto;
   padding-right: 4px;
@@ -479,11 +488,11 @@ function tierClass(tier) {
 
 .alerts-card__item {
   display: grid;
-  gap: 10px;
+  gap: 6px;
   width: 100%;
-  padding: 14px 16px;
+  padding: 9px 12px;
   border: 1px solid #ff9db0;
-  border-radius: 16px;
+  border-radius: 12px;
   background: #fff7f9;
   cursor: pointer;
   text-align: left;

--- a/src/components/scm/worker/today-task/WorkerJobFinishModal.vue
+++ b/src/components/scm/worker/today-task/WorkerJobFinishModal.vue
@@ -8,25 +8,11 @@ const props = defineProps({
 
 const emit = defineEmits(['close', 'save-draft', 'submit'])
 
-const completedQty = ref('')
-const defectQty = ref('')
 const memo = ref('')
-
-const qualityChecks = ref([
-  { label: '치수 측정 결과 입력', btnLabel: '등록 완료', done: false },
-  { label: '불량 사유 코드 선택', btnLabel: '등록 완료', done: false },
-  { label: '사진 첨부', btnLabel: '1장 대기', done: false },
-])
-
-function toggleQuality(index) {
-  qualityChecks.value[index].done = !qualityChecks.value[index].done
-}
 
 function handleSubmit() {
   emit('submit', {
     jobId: props.job.id,
-    completedQty: completedQty.value,
-    defectQty: defectQty.value,
     memo: memo.value,
   })
 }
@@ -56,7 +42,7 @@ function handleDraft() {
       <div class="fm__header">
         <h2 class="fm__title">작업 완료 보고</h2>
         <p class="fm__desc">
-          완료 수량, 작업 이슈, 품질 체크 결과를 입력하면 작업 이력이 저장되고 TL/GL에게 즉시 공유됩니다.
+          작업 이슈나 특이사항을 입력하면 작업 이력이 저장되고 TL/GL에게 즉시 공유됩니다.
         </p>
       </div>
     </template>
@@ -79,22 +65,6 @@ function handleDraft() {
       </div>
     </div>
 
-    <!-- Quantity -->
-    <div class="fm__section">
-      <span class="fm__section-label">완료 수량 / 불량 수량</span>
-      <div class="fm__qty-row">
-        <div class="fm__qty-field">
-          <span class="fm__qty-prefix">완료</span>
-          <input v-model="completedQty" type="text" class="fm__input" placeholder="24EA" />
-        </div>
-        <span class="fm__qty-sep">/</span>
-        <div class="fm__qty-field">
-          <span class="fm__qty-prefix">불량</span>
-          <input v-model="defectQty" type="text" class="fm__input" placeholder="1EA" />
-        </div>
-      </div>
-    </div>
-
     <!-- Memo -->
     <div class="fm__section">
       <span class="fm__section-label">작업 메모</span>
@@ -104,23 +74,6 @@ function handleDraft() {
         rows="3"
         placeholder="작업 중 발생한 이슈나 특이사항을 기록해 주세요."
       ></textarea>
-    </div>
-
-    <!-- Quality checks -->
-    <div class="fm__section">
-      <span class="fm__section-label">품질 체크</span>
-      <div class="fm__checks">
-        <div v-for="(item, i) in qualityChecks" :key="i" class="fm__check">
-          <span class="fm__check-text">{{ item.label }}</span>
-          <button
-            class="fm__check-btn"
-            :class="{ 'fm__check-btn--done': item.done }"
-            @click="toggleQuality(i)"
-          >
-            {{ item.btnLabel }}
-          </button>
-        </div>
-      </div>
     </div>
   </BaseFormModal>
 </template>
@@ -199,47 +152,6 @@ function handleDraft() {
   color: var(--color-text-muted);
 }
 
-/* ── Quantity ───────────────────────────────────────────── */
-.fm__qty-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-top: 8px;
-}
-
-.fm__qty-field {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.fm__qty-prefix {
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--color-text-default);
-}
-
-.fm__qty-sep {
-  font-size: 16px;
-  color: var(--color-text-muted);
-}
-
-.fm__input {
-  width: 80px;
-  padding: 6px 10px;
-  border: 1px solid var(--color-border-default);
-  border-radius: var(--radius-xs);
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--color-text-strong);
-  font-family: inherit;
-}
-
-.fm__input:focus {
-  outline: none;
-  border-color: var(--color-primary-300);
-}
-
 /* ── Textarea ───────────────────────────────────────────── */
 .fm__textarea {
   width: 100%;
@@ -254,45 +166,5 @@ function handleDraft() {
 
 .fm__textarea:focus {
   outline: none;
-}
-
-/* ── Quality checks ─────────────────────────────────────── */
-.fm__checks {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  margin-top: 10px;
-}
-
-.fm__check {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px 16px;
-  border: 1px solid var(--color-border-muted);
-  border-radius: var(--radius-sm);
-}
-
-.fm__check-text {
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--color-text-default);
-}
-
-.fm__check-btn {
-  padding: 5px 14px;
-  border: 1px solid var(--color-border-default);
-  border-radius: var(--radius-2xs);
-  background: var(--color-bg-surface);
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--color-primary-700);
-  cursor: pointer;
-}
-
-.fm__check-btn--done {
-  background: var(--color-success-soft);
-  border-color: #bbf7d0;
-  color: #166534;
 }
 </style>

--- a/src/services/departmentleader/capabilityApi.js
+++ b/src/services/departmentleader/capabilityApi.js
@@ -1,0 +1,42 @@
+import hrApi from '@/services/hrApi'
+
+const AVATAR_COLORS = ['#5f50d6', '#269063', '#c08b00', '#d04060', '#2288cc']
+
+function avatarColor(name) {
+  let hash = 0
+  for (const ch of (name ?? '')) hash = (hash * 31 + ch.charCodeAt(0)) & 0xffffffff
+  return AVATAR_COLORS[Math.abs(hash) % AVATAR_COLORS.length]
+}
+
+function toNumber(v, fallback = 0) {
+  const n = Number(v)
+  return Number.isFinite(n) ? n : fallback
+}
+
+function mapMember(item) {
+  return {
+    id: item.employeeId,
+    name: item.employeeName ?? '-',
+    avatar: item.employeeName?.charAt(0) ?? '?',
+    avatarColor: avatarColor(item.employeeName),
+    tier: item.employeeTier ?? '-',
+    code: '',
+    team: item.teamName ?? '',
+    line: '',
+    experience: '',
+    score: toNumber(item.qualitativeScore),
+    qualitative: toNumber(item.qualitativeScore),
+    quantitative: null,
+    composite: null,
+    grade: item.grade ?? '-',
+    evalStatus: item.evalStatus ?? '-',
+    skills: [],
+    tierHistory: [],
+  }
+}
+
+export async function fetchDlCapabilityMembers({ page = 0, size = 50 } = {}) {
+  const res = await hrApi.get('/api/v1/hr/department-leader/members', { params: { page, size } })
+  const items = res.data?.data ?? []
+  return items.map(mapMember)
+}

--- a/src/services/departmentleader/performanceApi.js
+++ b/src/services/departmentleader/performanceApi.js
@@ -1,0 +1,76 @@
+import hrApi from '@/services/hrApi'
+
+function toNumber(v, fallback = 0) {
+  const n = Number(v)
+  return Number.isFinite(n) ? n : fallback
+}
+
+function tierCount(source = {}, tier) {
+  const upper = tier.toUpperCase()
+  const lower = tier.toLowerCase()
+  return toNumber(
+    source[`tier${upper}Count`] ??
+    source[`${lower}TierCount`] ??
+    source[`${lower}tierCount`] ??
+    source[`${upper}TierCount`] ??
+    source[`${upper}tierCount`]
+  )
+}
+
+function evalStatusToKo(status) {
+  if (status === 'CONFIRMED') return '완료'
+  if (status === 'SUBMITTED' || status === 'DRAFT') return '진행중'
+  return '미완료'
+}
+
+function mapMember(item) {
+  const tier = item.employeeTier ?? '-'
+  return {
+    empId: String(item.employeeCode ?? item.employeeId ?? '-'),
+    name: item.employeeName ?? '-',
+    position: '',
+    team: item.teamName ?? '',
+    quantitative: null,
+    qualitative: toNumber(item.qualitativeScore),
+    total: toNumber(item.qualitativeScore),
+    grade: item.grade ?? tier,
+    status: evalStatusToKo(item.evalStatus),
+    _evalStatus: item.evalStatus,
+  }
+}
+
+export async function fetchDlPerformance() {
+  const [summaryRes, teamsRes, membersRes] = await Promise.all([
+    hrApi.get('/api/v1/hr/department-leader/dashboard'),
+    hrApi.get('/api/v1/hr/department-leader/dashboard/teams'),
+    hrApi.get('/api/v1/hr/department-leader/members', { params: { page: 0, size: 100 } }),
+  ])
+
+  const summary = summaryRes.data?.data ?? {}
+  const teams   = teamsRes.data?.data   ?? []
+  const items   = membersRes.data?.data ?? []
+
+  const members = items.map(mapMember)
+  const tierTotal = tierCount(summary, 'S') + tierCount(summary, 'A') + tierCount(summary, 'B') + tierCount(summary, 'C')
+  const totalMembers = tierTotal > 0 ? tierTotal : members.length
+  const evalCompleted = Math.max(0, Math.min(totalMembers, totalMembers - toNumber(summary.unevaluatedCount)))
+
+  const performanceSummary = {
+    deptName: '',
+    totalMembers,
+    totalTeams: teams.length,
+    evalCompleted,
+    evalTotal: totalMembers,
+    deptAvg: toNumber(summary.deptAvgScore),
+    deptAvgDelta: 0,
+    period: '',
+  }
+
+  const teamNames = [...new Set(teams.map((t) => t.teamName).filter(Boolean))]
+  const teamOptions = ['전체', ...teamNames]
+
+  const gradeOptions  = ['전체', 'S', 'A', 'B', 'C']
+  const periodOptions = [performanceSummary.period || '현재 기간']
+
+  return { performanceSummary, members, teamOptions, gradeOptions, periodOptions, teams }
+}

--- a/src/services/hrDashboardApi.js
+++ b/src/services/hrDashboardApi.js
@@ -1,0 +1,515 @@
+import hrApi from '@/services/hrApi'
+
+function unwrap(response) {
+  return response.data?.data ?? response.data
+}
+
+function toNumber(value, fallback = 0) {
+  const number = Number(value)
+  return Number.isFinite(number) ? number : fallback
+}
+
+function tierCount(source = {}, tier) {
+  const upper = tier.toUpperCase()
+  const lower = tier.toLowerCase()
+  return toNumber(
+    source[`tier${upper}Count`] ??
+    source[`${lower}TierCount`] ??
+    source[`${lower}tierCount`] ??
+    source[`${upper}TierCount`] ??
+    source[`${upper}tierCount`]
+  )
+}
+
+function formatScore(value) {
+  return toNumber(value).toFixed(1)
+}
+
+function formatPercent(value) {
+  return `${formatScore(value)}%`
+}
+
+function tierTone(tier) {
+  return tier === 'B' ? 'gold' : 'purple'
+}
+
+function statusTone(status) {
+  if (status === 'CONFIRMED' || status === 'COMPLETE') return 'success'
+  if (status === 'NO_INPUT' || status === 'REJECTED') return 'danger'
+  return 'warning'
+}
+
+function gradeFromTierCounts(summary = {}) {
+  const s = tierCount(summary, 'S')
+  const a = tierCount(summary, 'A')
+  const b = tierCount(summary, 'B')
+  const c = tierCount(summary, 'C')
+  const total = s + a + b + c
+  if (total === 0) return '-'
+  const avg = (s * 4 + a * 3 + b * 2 + c * 1) / total
+  if (avg >= 3.5) return 'S'
+  if (avg >= 2.5) return 'A'
+  if (avg >= 1.5) return 'B'
+  return 'C'
+}
+
+function gradeFromMembers(members = []) {
+  const scoreByTier = { S: 4, A: 3, B: 2, C: 1 }
+  const scores = members
+    .map((member) => scoreByTier[member.tier ?? member.employeeTier ?? member.grade])
+    .filter((score) => Number.isFinite(score))
+  if (!scores.length) return '-'
+  const avg = scores.reduce((sum, score) => sum + score, 0) / scores.length
+  if (avg >= 3.5) return 'S'
+  if (avg >= 2.5) return 'A'
+  if (avg >= 1.5) return 'B'
+  return 'C'
+}
+
+function mapNotice(notice) {
+  return {
+    id: notice?.noticeId ?? null,
+    badge: '중요 공지',
+    title: notice?.noticeTitle ?? '중요 공지가 없습니다',
+    description: notice?.noticeContent ?? '',
+  }
+}
+
+function mapTlDashboardMember(member) {
+  const qualitative = toNumber(member.qualitativeScore)
+  const tier = member.tier ?? member.grade ?? '-'
+  return {
+    id: member.employeeId,
+    avatar: member.employeeName?.charAt(0) ?? '?',
+    avatarTone: tier === 'B' ? 'gold' : tier === 'C' ? 'green' : 'purple',
+    name: member.employeeName ?? '-',
+    code: member.employeeCode ?? '',
+    tier,
+    tierTone: tierTone(tier),
+    quantitative: '-',
+    qualitative: formatPercent(qualitative),
+    tasks: member.evalStatus ?? '-',
+    score: Math.round(qualitative),
+    delta: member.grade ?? '',
+    statusTone: statusTone(member.evalStatus),
+  }
+}
+
+function formatDecimal(value) {
+  return toNumber(value).toFixed(2)
+}
+
+function mapTlKpiRow(item) {
+  const score = toNumber(item.tScore)
+  return {
+    id: item.employeeId,
+    avatar: item.employeeName?.charAt(0) ?? '?',
+    avatarTone: 'purple',
+    name: item.employeeName ?? '-',
+    tier: item.employeeTier ?? '-',
+    actualOutput: formatDecimal(item.uphScore),
+    eIdx: formatDecimal(item.yieldScore),
+    adjustedRate: `${formatDecimal(item.leadTimeScore)}%`,
+    score: formatScore(score),
+    trend: '-',
+    trendTone: 'success',
+    detailLabel: '보기',
+    status: item.status,
+  }
+}
+
+function buildTlKpiPanel(member, details = []) {
+  const rows = details.length > 0 ? details : []
+  const avg = (key) => {
+    if (!rows.length) return member?.[key] ?? 0
+    return rows.reduce((sum, row) => sum + toNumber(row[key]), 0) / rows.length
+  }
+
+  const uphScore = avg('uphScore')
+  const yieldScore = avg('yieldScore')
+  const leadTimeScore = avg('leadTimeScore')
+  const sQuant = avg('sQuant')
+  const tScore = avg('tScore')
+  const error = avg('actualError')
+
+  return {
+    title: `산출 상세 - ${member?.name ?? '팀원'}`,
+    steps: [
+      {
+        step: 1,
+        title: 'UPH',
+        description: '단위 시간 생산성 점수',
+        value: formatDecimal(uphScore),
+      },
+      {
+        step: 2,
+        title: 'Yield',
+        description: '수율 기반 점수',
+        value: formatDecimal(yieldScore),
+      },
+      {
+        step: 3,
+        title: 'Lead Time',
+        description: '리드타임 보정 점수',
+        value: formatDecimal(leadTimeScore),
+      },
+      {
+        step: 4,
+        title: '최종 정량',
+        description: '설비별 정량 지표를 종합한 최종 점수',
+        value: formatDecimal(tScore),
+      },
+    ],
+    chartTitle: '설비별 정량 점수 흐름',
+    benchmarkTitle: '평가 지표',
+    benchmarkItems: [
+      { label: 'S_QUANT', value: formatDecimal(sQuant), delta: '종합' },
+      { label: 'T_SCORE', value: formatDecimal(tScore), delta: '최종' },
+      { label: 'ACTUAL ERROR', value: formatDecimal(error), delta: '보정' },
+    ],
+  }
+}
+
+export async function getTeamLeaderDashboard() {
+  const [summaryResponse, membersResponse, noticeResponse] = await Promise.all([
+    hrApi.get('/api/v1/hr/team-leader/dashboard'),
+    hrApi.get('/api/v1/hr/team-leader/dashboard/members', { params: { page: 0, size: 50 } }),
+    hrApi.get('/api/v1/hr/notices/pinned').catch(() => null),
+  ])
+
+  const summary = unwrap(summaryResponse) ?? {}
+  const members = unwrap(membersResponse) ?? []
+  const notice = noticeResponse ? unwrap(noticeResponse) : null
+  const summaryTierAverage = gradeFromTierCounts(summary)
+  const tierAverage = summaryTierAverage === '-' ? gradeFromMembers(members) : summaryTierAverage
+
+  return {
+    notice: mapNotice(notice),
+    metrics: [
+      { label: '팀 평균 점수', value: formatScore(summary.teamAvgScore), tone: 'primary' },
+      { label: '평가율', value: formatPercent(summary.evaluationRate), tone: 'success' },
+      { label: '평가 완료', value: `${toNumber(summary.completedCount)}건`, tone: 'success' },
+      { label: '팀 TIER 평균', value: tierAverage, helper: `S ${tierCount(summary, 'S')} / A ${tierCount(summary, 'A')}`, tone: 'primary' },
+    ],
+    members: members.map(mapTlDashboardMember),
+  }
+}
+
+export async function getTeamLeaderKpiReport({ year = 2026, evalSequence = 1 } = {}) {
+  const response = await hrApi.get('/api/v1/hr/team-leader/kpi', {
+    params: { year, evalSequence },
+  })
+  const rows = unwrap(response) ?? []
+  const mappedRows = rows.map(mapTlKpiRow)
+  const avgScore = mappedRows.length
+    ? mappedRows.reduce((sum, row) => sum + toNumber(row.score), 0) / mappedRows.length
+    : 0
+
+  return {
+    rows: mappedRows,
+    summaryCards: [
+      { label: '팀원 수', value: `${mappedRows.length}명`, tone: 'primary' },
+      { label: '평균 정량점수', value: formatScore(avgScore), tone: 'success' },
+      { label: '확정 건수', value: `${rows.filter((row) => row.status === 'CONFIRMED').length}건`, tone: 'success' },
+      { label: '평가 기간', value: `${year}-${evalSequence}`, tone: 'primary' },
+    ],
+  }
+}
+
+export async function getTeamLeaderKpiMemberDetail(employeeId, { year = 2026, evalSequence = 1 } = {}, member = null) {
+  if (!employeeId) return buildTlKpiPanel(member)
+  const response = await hrApi.get(`/api/v1/hr/team-leader/kpi/${employeeId}`, {
+    params: { year, evalSequence },
+  })
+  return buildTlKpiPanel(member, unwrap(response) ?? [])
+}
+
+function mapDlMember(item) {
+  return {
+    id: item.employeeId,
+    name: item.employeeName ?? '-',
+    tier: item.employeeTier ?? '-',
+    score: formatScore(item.qualitativeScore),
+    grade: item.grade ?? '-',
+    status: item.evalStatus ?? '-',
+    statusTone: statusTone(item.evalStatus),
+  }
+}
+
+export async function getDepartmentLeaderDashboard() {
+  const [summaryResponse, teamsResponse, membersResponse, noticeResponse] = await Promise.all([
+    hrApi.get('/api/v1/hr/department-leader/dashboard'),
+    hrApi.get('/api/v1/hr/department-leader/dashboard/teams'),
+    hrApi.get('/api/v1/hr/department-leader/members', { params: { page: 0, size: 50 } }),
+    hrApi.get('/api/v1/hr/notices/pinned').catch(() => null),
+  ])
+
+  const summary = unwrap(summaryResponse) ?? {}
+  const teams = unwrap(teamsResponse) ?? []
+  const members = unwrap(membersResponse) ?? []
+  const notice = noticeResponse ? unwrap(noticeResponse) : null
+
+  return {
+    notice: mapNotice(notice),
+    metrics: [
+      { label: '부서 평균 점수', value: formatScore(summary.deptAvgScore), tone: 'primary' },
+      { label: '평가율', value: formatPercent(summary.evaluationRate), tone: 'success' },
+      { label: '미평가 직원', value: `${toNumber(summary.unevaluatedCount)}명`, tone: toNumber(summary.unevaluatedCount) > 0 ? 'danger' : 'success' },
+      { label: 'S/A Tier', value: `${tierCount(summary, 'S') + tierCount(summary, 'A')}명`, tone: 'primary' },
+    ],
+    groupKpi: {
+      groupAvg: toNumber(summary.deptAvgScore),
+      equipRate: formatPercent(summary.evaluationRate),
+      qualityRate: `${tierCount(summary, 'S') + tierCount(summary, 'A')}명`,
+      tierStats: {
+        s: tierCount(summary, 'S'),
+        a: tierCount(summary, 'A'),
+        b: tierCount(summary, 'B'),
+        c: tierCount(summary, 'C'),
+      },
+    },
+    members: members.map(mapDlMember),
+    teams: teams.map((team) => ({
+      id: team.tlId,
+      name: team.teamName ?? `${team.tlName ?? '-'} 팀`,
+      tl: team.tlName ?? '-',
+      count: toNumber(team.memberCount),
+      avg: formatScore(team.teamAvgScore),
+      status: team.evaluationStatus ?? '-',
+    })),
+  }
+}
+
+function tierDistribution(summary = {}) {
+  return tierDistributionFromCounts({
+    S: tierCount(summary, 'S'),
+    A: tierCount(summary, 'A'),
+    B: tierCount(summary, 'B'),
+    C: tierCount(summary, 'C'),
+  })
+}
+
+function tierDistributionFromCounts(counts = {}) {
+  const total = toNumber(counts.S) + toNumber(counts.A) + toNumber(counts.B) + toNumber(counts.C)
+  const toItem = (tier, count) => ({
+    tier,
+    count,
+    percent: total ? Math.round((count / total) * 100) : 0,
+  })
+  return [
+    toItem('S', toNumber(counts.S)),
+    toItem('A', toNumber(counts.A)),
+    toItem('B', toNumber(counts.B)),
+    toItem('C', toNumber(counts.C)),
+  ]
+}
+
+function mapHrmTrend(trend) {
+  return {
+    month: `${trend.year}-Q${trend.evalSequence}`,
+    quarter: `${trend.year}-Q${trend.evalSequence}`,
+    S: tierCount(trend, 'S'),
+    A: tierCount(trend, 'A'),
+    B: tierCount(trend, 'B'),
+    C: tierCount(trend, 'C'),
+    avgScore: toNumber(trend.avgScore),
+  }
+}
+
+function mapHrmDetailRow(item) {
+  return {
+    id: item.employeeId,
+    team: item.employeeName ?? '-',
+    count: 1,
+    avg: formatScore(item.qualitativeScore),
+    S: item.employeeTier === 'S' ? 1 : 0,
+    A: item.employeeTier === 'A' ? 1 : 0,
+    B: item.employeeTier === 'B' ? 1 : 0,
+    C: item.employeeTier === 'C' ? 1 : 0,
+  }
+}
+
+function mapHrmTeamStatsRow(item) {
+  return {
+    id: item.departmentId,
+    team: item.departmentName ?? '-',
+    count: toNumber(item.memberCount),
+    avg: formatScore(item.avgScore),
+    S: tierCount(item, 'S'),
+    A: tierCount(item, 'A'),
+    B: tierCount(item, 'B'),
+    C: tierCount(item, 'C'),
+  }
+}
+
+function sumTierCounts(rows = []) {
+  return rows.reduce(
+    (acc, row) => ({
+      S: acc.S + toNumber(row.S),
+      A: acc.A + toNumber(row.A),
+      B: acc.B + toNumber(row.B),
+      C: acc.C + toNumber(row.C),
+    }),
+    { S: 0, A: 0, B: 0, C: 0 }
+  )
+}
+
+function mapHrmKpiLeaderRow(item, index) {
+  const status = item.evalStatus ?? ''
+  const completionRate = status === 'CONFIRMED' ? 100 : status === 'NO_INPUT' ? 0 : 50
+  return {
+    id: item.employeeId,
+    name: item.employeeName ?? '-',
+    line: item.employeeTier ? `${item.employeeTier}-Tier` : '-',
+    members: 1,
+    evaluated: status === 'NO_INPUT' ? 0 : 1,
+    total: 1,
+    avgScore: formatScore(item.qualitativeScore),
+    tierDist: item.grade ?? item.employeeTier ?? '-',
+    completionRate,
+    avatarColor: ['#5b4fcf', '#00bf95', '#f59e0b', '#ef476f'][index % 4],
+  }
+}
+
+function mapHrmTeamStatsReportRow(item, index, completionRate = 0) {
+  const total = toNumber(item.count)
+  const evaluated = Math.round((total * toNumber(completionRate)) / 100)
+  return {
+    id: item.id,
+    name: item.team,
+    line: '부서',
+    members: total,
+    evaluated,
+    total,
+    avgScore: item.avg,
+    tierDist: `S ${item.S} / A ${item.A} / B ${item.B} / C ${item.C}`,
+    completionRate: toNumber(completionRate),
+    avatarColor: ['#5b4fcf', '#00bf95', '#f59e0b', '#ef476f'][index % 4],
+  }
+}
+
+async function resolveHrmKpiPeriod(period = {}) {
+  if (period.year && period.evalSequence) return period
+  try {
+    const response = await hrApi.get('/api/v1/hr/evaluation-periods', {
+      params: { status: 'IN_PROGRESS', page: 0, size: 1 },
+    })
+    const latest = unwrap(response)?.content?.[0]
+    if (latest?.evalYear && latest?.evalSequence) {
+      return { year: latest.evalYear, evalSequence: latest.evalSequence }
+    }
+  } catch {
+    // KPI 화면은 평가기간 조회 실패 시 기존 기본 기간으로 fallback한다.
+  }
+  return { year: 2026, evalSequence: 1 }
+}
+
+export async function getHrmDashboard(period = {}) {
+  const { year, evalSequence } = await resolveHrmKpiPeriod(period)
+  const [summaryResponse, trendsResponse, teamStatsResponse, noticeResponse] = await Promise.all([
+    hrApi.get('/api/v1/hr/kpi/summary', { params: { year, evalSequence } }),
+    hrApi.get('/api/v1/hr/kpi/trends', { params: { year } }),
+    hrApi.get('/api/v1/hr/kpi/team-stats', { params: { year, evalSequence } }),
+    hrApi.get('/api/v1/hr/notices/pinned').catch(() => null),
+  ])
+
+  const summary = unwrap(summaryResponse) ?? {}
+  const trends = unwrap(trendsResponse) ?? []
+  const teamStats = (unwrap(teamStatsResponse) ?? []).map(mapHrmTeamStatsRow)
+  const notice = noticeResponse ? unwrap(noticeResponse) : null
+  const summaryTierCounts = {
+    S: tierCount(summary, 'S'),
+    A: tierCount(summary, 'A'),
+    B: tierCount(summary, 'B'),
+    C: tierCount(summary, 'C'),
+  }
+  const teamTierCounts = sumTierCounts(teamStats)
+  const tierCounts =
+    summaryTierCounts.S + summaryTierCounts.A + summaryTierCounts.B + summaryTierCounts.C > 0
+      ? summaryTierCounts
+      : teamTierCounts
+
+  return {
+    notification: mapNotice(notice),
+    dashboard: {
+      avgScore: formatScore(summary.avgScore),
+      totalEmployees: toNumber(summary.totalEmployees),
+      evaluationRate: formatScore(summary.evaluationRate),
+      unevaluatedCount: toNumber(summary.unevaluatedCount),
+      tierDelta: `현재 평가기간 ${year}-Q${evalSequence}`,
+    },
+    tierDistribution: tierDistributionFromCounts(tierCounts),
+    tierTrend: trends.map(mapHrmTrend),
+    teamStats,
+    tierSummary: {
+      S: tierCounts.S,
+      A: tierCounts.A,
+      B: tierCounts.B,
+      C: tierCounts.C,
+      processLabel: '평가 완료율',
+      processPercent: toNumber(summary.evaluationRate),
+    },
+  }
+}
+
+export async function getHrmKpiReport(period = {}) {
+  const { year, evalSequence } = await resolveHrmKpiPeriod(period)
+  const [summaryResponse, trendsResponse, detailsResponse, teamStatsResponse] = await Promise.all([
+    hrApi.get('/api/v1/hr/kpi/summary', { params: { year, evalSequence } }),
+    hrApi.get('/api/v1/hr/kpi/trends', { params: { year } }),
+    hrApi.get('/api/v1/hr/kpi/details', { params: { year, evalSequence, page: 0, size: 50 } }),
+    hrApi.get('/api/v1/hr/kpi/team-stats', { params: { year, evalSequence } }),
+  ])
+
+  const summary = unwrap(summaryResponse) ?? {}
+  const trends = unwrap(trendsResponse) ?? []
+  const details = unwrap(detailsResponse) ?? []
+  const teamStats = (unwrap(teamStatsResponse) ?? []).map(mapHrmTeamStatsRow)
+  const completionRate = toNumber(summary.evaluationRate)
+
+  return {
+    report: {
+      quarter: `${year}년 ${evalSequence}분기`,
+      avgScore: formatScore(summary.avgScore),
+      avgScoreDelta: '-',
+      saRatio: toNumber(summary.totalEmployees)
+        ? Math.round(((tierCount(summary, 'S') + tierCount(summary, 'A')) / toNumber(summary.totalEmployees)) * 100)
+        : 0,
+      saRatioDelta: 0,
+      completedTasks: details.filter((item) => item.evalStatus === 'CONFIRMED').length,
+      completedTasksDelta: '-',
+      avgMtbf: '-',
+      avgMtbfDelta: '-',
+      completionRate,
+      inProgressRate: 0,
+      pendingRate: Math.max(0, 100 - completionRate),
+    },
+    teamScores: teamStats.map((item) => ({
+      team: item.team,
+      score: toNumber(item.avg),
+      quarter: `${year}년 ${evalSequence}분기`,
+    })),
+    tierTrend: trends.map(mapHrmTrend),
+    teamLeaders: teamStats.map((item, index) => mapHrmTeamStatsReportRow(item, index, completionRate)),
+  }
+}
+
+export async function downloadHrmKpiReport(period = {}) {
+  const { year, evalSequence } = await resolveHrmKpiPeriod(period)
+  const response = await hrApi.get('/api/v1/hr/kpi/report/download', {
+    params: { year, evalSequence },
+    responseType: 'blob',
+  })
+
+  const blob = new Blob([response.data], {
+    type: response.headers['content-type'] ?? 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = `전사_KPI_보고서_${year}_Q${evalSequence}.xlsx`
+  document.body.appendChild(link)
+  link.click()
+  link.remove()
+  URL.revokeObjectURL(url)
+}

--- a/src/services/teamLeaderScmApi.js
+++ b/src/services/teamLeaderScmApi.js
@@ -19,8 +19,13 @@ export async function getUrgentOrders() {
   return unwrap(response)
 }
 
-export async function getAssignmentCandidates() {
-  const response = await scmApi.get('/api/v1/scm/assignments/candidates')
+export async function getUnassignedOrders() {
+  const response = await scmApi.get('/api/v1/scm/orders/unassigned')
+  return unwrap(response)
+}
+
+export async function getAssignmentCandidates(params = {}) {
+  const response = await scmApi.get('/api/v1/scm/assignments/candidates', { params })
   return unwrap(response)
 }
 
@@ -84,5 +89,10 @@ export async function getLinesSummary() {
 
 export async function getMyTeamLinesSummary() {
   const response = await scmApi.get('/api/v1/scm/lines/my-team/summary')
+  return unwrap(response)
+}
+
+export async function getLineWorkers(lineId) {
+  const response = await scmApi.get(`/api/v1/scm/lines/${lineId}/workers`)
   return unwrap(response)
 }

--- a/src/services/workerHrApi.js
+++ b/src/services/workerHrApi.js
@@ -70,6 +70,24 @@ function toSkillViewModel(skill) {
   }
 }
 
+function calculateOverallSkillScore(skills) {
+  const scoreTargetSkillNames = new Set([
+    'EQUIPMENT_RESPONSE',
+    'TECHNICAL_TRANSFER',
+    'INNOVATION_PROPOSAL',
+    'SAFETY_COMPLIANCE',
+    'QUALITY_MANAGEMENT',
+    'PRODUCTIVITY',
+  ])
+  const scores = (skills ?? [])
+    .filter((skill) => scoreTargetSkillNames.has(skill.skillName))
+    .map((skill) => Number(skill.skillScore))
+    .filter(Number.isFinite)
+
+  if (!scores.length) return 0
+  return Math.round(scores.reduce((sum, score) => sum + score, 0) / scores.length)
+}
+
 function toTierHistoryMilestone(item) {
   const tier = normalizeTier(item.toTier)
   const isInitial = item.eventType === 'INITIAL'
@@ -248,16 +266,17 @@ export async function getWorkerProfileDashboard() {
   ])
 
   const tier = normalizeTier(profile.currentTier)
+  const skillGrid = skills.map(toSkillViewModel).slice(0, 6)
 
   return {
     worker: {
       id: profile.employeeId,
       name: profile.employeeName ?? '-',
       nameEn: profile.employeeCode ?? '',
-      score: Math.round(toNumber(profile.totalScore)),
+      score: calculateOverallSkillScore(skills),
       type: 'TECH',
       tier,
-      skillGrid: skills.map(toSkillViewModel).slice(0, 6),
+      skillGrid,
       historyPeriod: formatCareerPeriod(profile.hireDate),
       worksDone: '-',
       finishRate: 0,

--- a/src/services/workerHrApi.js
+++ b/src/services/workerHrApi.js
@@ -278,10 +278,11 @@ export async function getWorkerProfileDashboard() {
 }
 
 export async function getWorkerPointMission() {
-  const [summaryResponse, historyResponse, missionsResponse] = await Promise.all([
+  const [summaryResponse, historyResponse, missionsResponse, profile] = await Promise.all([
     hrApi.get('/api/v1/hr/workers/me/point-summary'),
     hrApi.get('/api/v1/hr/workers/me/point-history'),
     hrApi.get('/api/v1/hr/workers/me/missions/upgrade'),
+    optionalGet('/api/v1/hr/workers/me/profile', {}, {}),
   ])
 
   const summary = unwrap(summaryResponse) ?? {}
@@ -298,6 +299,7 @@ export async function getWorkerPointMission() {
     },
     history,
     missions,
+    currentTier: normalizeTier(profile.currentTier),
   }
 }
 

--- a/src/views/departmentleader/DepartmentLeaderDashboardView.vue
+++ b/src/views/departmentleader/DepartmentLeaderDashboardView.vue
@@ -1,45 +1,87 @@
 <script setup>
+import { onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
 import { BaseNoticeBanner, BaseStatCard } from '@/components/common/base'
-import DepartmentLeaderGroupKpiCard           from '@/components/dashboard/departmentleader/DepartmentLeaderGroupKpiCard.vue'
-import DepartmentLeaderTeamStatusCard         from '@/components/dashboard/departmentleader/DepartmentLeaderTeamStatusCard.vue'
-import {
-  dashboardNotice  as notice,
-  dashboardMetrics as metrics,
-  dashboardTeams   as teams,
-  dashboardGroupKpi,
-} from '@/mocks/departmentleader/dashboard.js'
+import DepartmentLeaderGroupKpiCard  from '@/components/dashboard/departmentleader/DepartmentLeaderGroupKpiCard.vue'
+import DepartmentLeaderTeamStatusCard from '@/components/dashboard/departmentleader/DepartmentLeaderTeamStatusCard.vue'
+import DepartmentLeaderMemberTable   from '@/components/dashboard/departmentleader/DepartmentLeaderMemberTable.vue'
+import { getDepartmentLeaderDashboard } from '@/services/hrDashboardApi'
+
+const loading = ref(true)
+const notice = ref(null)
+const metrics = ref([])
+const teams = ref([])
+const members = ref([])
+const dashboardGroupKpi = ref({ groupAvg: 0, equipRate: '0%', qualityRate: '0명' })
+const router = useRouter()
+
+onMounted(async () => {
+  try {
+    const dashboard = await getDepartmentLeaderDashboard()
+    notice.value = dashboard.notice
+    metrics.value = dashboard.metrics
+    teams.value = dashboard.teams
+    members.value = dashboard.members
+    dashboardGroupKpi.value = dashboard.groupKpi
+  } catch (error) {
+    console.error('Failed to load department leader dashboard:', error)
+  } finally {
+    loading.value = false
+  }
+})
+
+function goNoticeBoard() {
+  router.push({
+    name: 'DLNoticeBoard',
+    query: notice.value?.id ? { noticeId: notice.value.id } : {},
+  })
+}
 </script>
 
 <template>
   <section class="department-leader-dashboard">
-    <BaseNoticeBanner
-      :badge="notice.badge"
-      :title="notice.title"
-      :description="notice.description"
-      tone="success"
-      variant="soft"
-    />
+    <div v-if="loading" class="department-leader-dashboard__loading">데이터를 불러오는 중...</div>
 
-    <section class="department-leader-dashboard__metrics">
-      <BaseStatCard
-        v-for="m in metrics"
-        :key="m.label"
-        :label="m.label"
-        :value="m.value"
-        :delta="m.delta ?? ''"
-        :tone="m.tone"
-        :variant="m.isTier ? 'tier' : 'default'"
+    <template v-else>
+      <BaseNoticeBanner
+        v-if="notice"
+        :badge="notice.badge"
+        :title="notice.title"
+        :description="notice.description"
+        tone="success"
+        variant="soft"
+        class="department-leader-dashboard__notice"
+        role="button"
+        tabindex="0"
+        @click="goNoticeBoard"
+        @keydown.enter="goNoticeBoard"
+        @keydown.space.prevent="goNoticeBoard"
       />
-    </section>
 
-    <section class="department-leader-dashboard__bottom">
-      <DepartmentLeaderGroupKpiCard
-        :group-avg="dashboardGroupKpi.groupAvg"
-        :equip-rate="dashboardGroupKpi.equipRate"
-        :quality-rate="dashboardGroupKpi.qualityRate"
-      />
-      <DepartmentLeaderTeamStatusCard :teams="teams" />
-    </section>
+      <section class="department-leader-dashboard__metrics">
+        <BaseStatCard
+          v-for="m in metrics"
+          :key="m.label"
+          :label="m.label"
+          :value="m.value"
+          :delta="m.delta ?? ''"
+          :tone="m.tone"
+          :variant="m.isTier ? 'tier' : 'default'"
+        />
+      </section>
+
+      <section class="department-leader-dashboard__bottom">
+        <DepartmentLeaderGroupKpiCard
+          :group-avg="dashboardGroupKpi.groupAvg"
+          :equip-rate="dashboardGroupKpi.equipRate"
+          :quality-rate="dashboardGroupKpi.qualityRate"
+          :tier-stats="dashboardGroupKpi.tierStats"
+        />
+        <DepartmentLeaderTeamStatusCard :teams="teams" />
+      </section>
+
+      <DepartmentLeaderMemberTable :members="members" />
+    </template>
   </section>
 </template>
 
@@ -66,5 +108,16 @@ import {
   display: grid;
   grid-template-columns: 1.4fr 1fr;
   gap: 20px;
+}
+
+.department-leader-dashboard__loading {
+  padding: 60px;
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-base);
+}
+
+.department-leader-dashboard__notice {
+  cursor: pointer;
 }
 </style>

--- a/src/views/departmentleader/DepartmentLeaderNoticeBoardView.vue
+++ b/src/views/departmentleader/DepartmentLeaderNoticeBoardView.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, watch, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
 import hrApi from '@/services/hrApi'
 import HRMNoticeListPanel  from '@/components/hr/common/notices/HRMNoticeListPanel.vue'
 import HRMNoticeDetailPanel from '@/components/hr/common/notices/HRMNoticeDetailPanel.vue'
@@ -36,12 +37,18 @@ function normalizeDetail(n) {
 const notices        = ref([])
 const selectedId     = ref(null)
 const selectedNotice = ref(null)
+const route = useRoute()
 
 async function fetchNotices() {
   try {
     const res = await hrApi.get('/api/v1/hr/notices')
     const list = res.data?.success ? res.data.data : res.data
     notices.value = (Array.isArray(list) ? list : []).map(normalizeList)
+    const queryNoticeId = route.query.noticeId ? Number(route.query.noticeId) : null
+    if (queryNoticeId && notices.value.some(notice => notice.id === queryNoticeId)) {
+      selectedId.value = queryNoticeId
+      return
+    }
     if (!selectedId.value && notices.value.length) {
       selectedId.value = notices.value[0].id
     }

--- a/src/views/departmentleader/DepartmentLeaderNotificationView.vue
+++ b/src/views/departmentleader/DepartmentLeaderNotificationView.vue
@@ -8,7 +8,6 @@ const TYPE_MAP = {
   RESULTS:        { label: '평가결과', category: 'results',     tone: 'info' },
   OBJECTIONS:     { label: '이의신청', category: 'objections',  tone: 'warn' },
   PROMOTION:      { label: '승급',    category: 'promotion',   tone: 'success' },
-  ARRANGEMENT:    { label: '배정',    category: 'arrangement', tone: 'info' },
   BIAS_DETECTION: { label: '편향감지', category: 'bias',        tone: 'fault' },
 }
 
@@ -17,7 +16,6 @@ const notificationFilters = [
   { key: 'results',     label: '평가결과', categoryKey: 'results' },
   { key: 'objections',  label: '이의신청', categoryKey: 'objections' },
   { key: 'promotion',   label: '승급',    categoryKey: 'promotion' },
-  { key: 'arrangement', label: '배정',    categoryKey: 'arrangement' },
   { key: 'bias',        label: '편향감지', categoryKey: 'bias' },
 ]
 
@@ -62,8 +60,14 @@ async function fetchNotifications() {
       hrApi.get('/api/v1/hr/notifications/summary'),
     ])
     const list = listRes.data?.success ? listRes.data.data : listRes.data
-    notifications.value = (Array.isArray(list) ? list : []).map(normalize)
-    summary.value = summaryRes.data?.success ? summaryRes.data.data : summaryRes.data
+    notifications.value = (Array.isArray(list) ? list : [])
+      .filter((item) => item.notificationType !== 'ARRANGEMENT')
+      .map(normalize)
+    summary.value = {
+      ...(summaryRes.data?.success ? summaryRes.data.data : summaryRes.data),
+      totalCount: notifications.value.length,
+      unreadCount: notifications.value.filter((item) => item.unread).length,
+    }
   } catch (err) {
     console.error('알림 조회 실패:', err)
   }
@@ -78,6 +82,17 @@ async function ackNotification(item) {
     if (summary.value.unreadCount > 0) summary.value.unreadCount--
   } catch (err) {
     console.error('알림 확인 실패:', err)
+  }
+}
+
+async function hideNotification(item) {
+  try {
+    await hrApi.patch(`/api/v1/hr/notifications/${item.notificationId}/hide`)
+    notifications.value = notifications.value.filter((n) => n.id !== item.id)
+    if (summary.value.totalCount > 0) summary.value.totalCount--
+    if (item.unread && summary.value.unreadCount > 0) summary.value.unreadCount--
+  } catch (err) {
+    console.error('알림 숨김 실패:', err)
   }
 }
 
@@ -136,6 +151,7 @@ function handleClickAction(item) {
       :page-size="6"
       @click-item="handleClickAction"
       @click-action="handleClickAction"
+      @dismiss-item="hideNotification"
     />
   </section>
 </template>

--- a/src/views/departmentleader/DepartmentLeaderPerformanceView.vue
+++ b/src/views/departmentleader/DepartmentLeaderPerformanceView.vue
@@ -1,39 +1,67 @@
-﻿<script setup>
-import { ref, computed } from 'vue'
+<script setup>
+import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import DepartmentLeaderPerformanceSummary from '@/components/hr/departmentleader/perfomance/DepartmentLeaderPerformanceSummary.vue'
 import DepartmentLeaderPerformanceTable from '@/components/hr/departmentleader/perfomance/DepartmentLeaderPerformanceTable.vue'
-import {
-  performanceSummary,
-  performanceMembers,
-  teamOptions,
-  gradeOptions,
-  periodOptions,
-} from '@/mocks/departmentleader/performance.js'
+import { fetchDlPerformance } from '@/services/departmentleader/performanceApi'
 
 const router = useRouter()
 
+const loading = ref(true)
+const performanceSummary = ref({
+  deptName: '',
+  totalMembers: 0,
+  totalTeams: 0,
+  evalCompleted: 0,
+  evalTotal: 0,
+  deptAvg: 0,
+  deptAvgDelta: 0,
+  period: '',
+})
+const performanceMembers = ref([])
+const teamOptions  = ref(['전체'])
+const gradeOptions = ref(['전체', 'S', 'A', 'B', 'C'])
+const periodOptions = ref(['현재 기간'])
+const rawTeams = ref([])
+
 const selectedTeam = ref('전체')
-const teamTabs = teamOptions
 
+onMounted(async () => {
+  try {
+    const data = await fetchDlPerformance()
+    performanceSummary.value  = data.performanceSummary
+    performanceMembers.value  = data.members
+    teamOptions.value         = data.teamOptions
+    gradeOptions.value        = data.gradeOptions
+    periodOptions.value       = data.periodOptions
+    rawTeams.value            = data.teams
+  } catch (error) {
+    console.error('Failed to load performance data:', error)
+  } finally {
+    loading.value = false
+  }
+})
+
+// 팀 탭 선택 시 해당 팀 이름 기준으로 팀 요약 계산
 const activeSummary = computed(() => {
-  if (selectedTeam.value === '전체') return performanceSummary
+  if (selectedTeam.value === '전체') return performanceSummary.value
 
-  const members = performanceMembers.filter((member) => member.team === selectedTeam.value)
-  const completed = members.filter((member) => member.status === '완료').length
-  const avg = members.length
-    ? +(members.reduce((sum, member) => sum + member.total, 0) / members.length).toFixed(1)
-    : 0
-  const delta = +(avg - performanceSummary.deptAvg).toFixed(1)
+  const teamData = rawTeams.value.find((t) => t.teamName === selectedTeam.value)
+  if (!teamData) return performanceSummary.value
+
+  const memberCount = Number(teamData.memberCount) || 0
+  const avg = Number(teamData.teamAvgScore) || 0
+  const delta = +(avg - performanceSummary.value.deptAvg).toFixed(1)
+  const completed = teamData.evaluationStatus === '평가완료' ? memberCount : 0
 
   return {
-    totalMembers: members.length,
+    totalMembers: memberCount,
     totalTeams: 1,
     evalCompleted: completed,
-    evalTotal: members.length,
+    evalTotal: memberCount,
     deptAvg: avg,
     deptAvgDelta: delta,
-    period: performanceSummary.period,
+    period: performanceSummary.value.period,
   }
 })
 
@@ -50,24 +78,32 @@ function handleGoEvaluation() {
   <div class="dl-performance">
     <header class="dl-performance__header">
       <h2 class="dl-performance__title">부서 성과 현황</h2>
-      <span class="dl-performance__dept-name">{{ performanceSummary.deptName }}</span>
-      <span class="dl-performance__period">{{ performanceSummary.period }}</span>
+      <span v-if="performanceSummary.deptName" class="dl-performance__dept-name">
+        {{ performanceSummary.deptName }}
+      </span>
+      <span v-if="performanceSummary.period" class="dl-performance__period">
+        {{ performanceSummary.period }}
+      </span>
     </header>
 
-    <DepartmentLeaderPerformanceSummary
-      :summary="activeSummary"
-      :team-tabs="teamTabs"
-      v-model:selectedTeam="selectedTeam"
-    />
+    <div v-if="loading" class="dl-performance__loading">데이터를 불러오는 중...</div>
 
-    <DepartmentLeaderPerformanceTable
-      :members="performanceMembers"
-      :team-options="teamOptions"
-      :grade-options="gradeOptions"
-      :period-options="periodOptions"
-      @view-capability="handleViewCapability"
-      @go-evaluation="handleGoEvaluation"
-    />
+    <template v-else>
+      <DepartmentLeaderPerformanceSummary
+        :summary="activeSummary"
+        :team-tabs="teamOptions"
+        v-model:selectedTeam="selectedTeam"
+      />
+
+      <DepartmentLeaderPerformanceTable
+        :members="performanceMembers"
+        :team-options="teamOptions"
+        :grade-options="gradeOptions"
+        :period-options="periodOptions"
+        @view-capability="handleViewCapability"
+        @go-evaluation="handleGoEvaluation"
+      />
+    </template>
   </div>
 </template>
 
@@ -115,6 +151,13 @@ function handleGoEvaluation() {
   border: 1px solid var(--color-border-default);
   border-radius: 99px;
   padding: 3px 12px;
+}
+
+.dl-performance__loading {
+  padding: 60px;
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-base);
 }
 
 @media (max-width: 960px) {

--- a/src/views/departmentleader/DepartmentLeaderTeamCapabilityView.vue
+++ b/src/views/departmentleader/DepartmentLeaderTeamCapabilityView.vue
@@ -1,20 +1,39 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import DepartmentLeaderMemberListPanel from '@/components/hr/departmentleader/team-capability/DepartmentLeaderMemberListPanel.vue'
 import DepartmentLeaderCapabilityDetailPanel from '@/components/hr/departmentleader/team-capability/DepartmentLeaderCapabilityDetailPanel.vue'
-import { capabilityMembers as members } from '@/mocks/departmentleader/teamCapability.js'
+import { fetchDlCapabilityMembers } from '@/services/departmentleader/capabilityApi'
 
-const selectedMember = ref(members[0])
+const members = ref([])
+const selectedMember = ref(null)
+const loading = ref(true)
+
+onMounted(async () => {
+  try {
+    members.value = await fetchDlCapabilityMembers()
+    if (members.value.length > 0) {
+      selectedMember.value = members.value[0]
+    }
+  } catch (error) {
+    console.error('Failed to load capability members:', error)
+  } finally {
+    loading.value = false
+  }
+})
 </script>
 
 <template>
   <section class="dl-capability-view">
-    <DepartmentLeaderMemberListPanel
-      :members="members"
-      :selected-id="selectedMember?.id ?? null"
-      @select="selectedMember = $event"
-    />
-    <DepartmentLeaderCapabilityDetailPanel :member="selectedMember" />
+    <div v-if="loading" class="dl-capability-view__loading">데이터를 불러오는 중...</div>
+
+    <template v-else>
+      <DepartmentLeaderMemberListPanel
+        :members="members"
+        :selected-id="selectedMember?.id ?? null"
+        @select="selectedMember = $event"
+      />
+      <DepartmentLeaderCapabilityDetailPanel :member="selectedMember" />
+    </template>
   </section>
 </template>
 
@@ -30,5 +49,13 @@ const selectedMember = ref(members[0])
   padding: 20px 28px 28px;
   background: var(--color-bg-app);
   align-items: start;
+}
+
+.dl-capability-view__loading {
+  grid-column: 1 / -1;
+  padding: 60px;
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-base);
 }
 </style>

--- a/src/views/hrmanager/HRMDashboardView.vue
+++ b/src/views/hrmanager/HRMDashboardView.vue
@@ -1,12 +1,13 @@
 <script setup>
 import { ref, onMounted } from 'vue'
-import { API_BASE } from '@/constants'
+import { useRouter } from 'vue-router'
 import BaseNoticeBanner from '@/components/common/base/display/BaseNoticeBanner.vue'
 import BaseStatCard from '@/components/common/base/display/BaseStatCard.vue'
 import HRMTierDonutChart from '@/components/dashboard/hrmanager/HRMTierDonutChart.vue'
 import HRMTierTrendChart from '@/components/dashboard/hrmanager/HRMTierTrendChart.vue'
 import HRMTeamStatsTable from '@/components/dashboard/hrmanager/HRMTeamStatsTable.vue'
 import HRMTierDistCard from '@/components/dashboard/hrmanager/HRMTierDistCard.vue'
+import { getHrmDashboard } from '@/services/hrDashboardApi'
 
 const loading = ref(true)
 const dashboard = ref(null)
@@ -15,29 +16,17 @@ const tierTrend = ref([])
 const teamStats = ref([])
 const tierSummary = ref(null)
 const notification = ref(null)
-
-async function fetchJson(url) {
-  const res = await fetch(url)
-  return res.json()
-}
+const router = useRouter()
 
 onMounted(async () => {
   try {
-    const [dash, dist, trend, stats, summary, notifs] = await Promise.all([
-      fetchJson(`${API_BASE}/hrmDashboard`),
-      fetchJson(`${API_BASE}/tierDistribution`),
-      fetchJson(`${API_BASE}/tierTrend`),
-      fetchJson(`${API_BASE}/teamStats`),
-      fetchJson(`${API_BASE}/tierSummary`),
-      fetchJson(`${API_BASE}/notifications?active=true`),
-    ])
-
-    dashboard.value = dash[0] ?? null
-    tierDistribution.value = dist
-    tierTrend.value = trend
-    teamStats.value = stats
-    tierSummary.value = summary[0] ?? null
-    notification.value = notifs[0] ?? null
+    const data = await getHrmDashboard()
+    dashboard.value = data.dashboard
+    tierDistribution.value = data.tierDistribution
+    tierTrend.value = data.tierTrend
+    teamStats.value = data.teamStats
+    tierSummary.value = data.tierSummary
+    notification.value = data.notification
   } catch (e) {
     console.error('Failed to load HRM dashboard data:', e)
   } finally {
@@ -56,6 +45,13 @@ function metricValue(key, suffix) {
   if (!dashboard.value) return '-'
   return `${dashboard.value[key]}${suffix ?? ''}`
 }
+
+function goNoticeBoard() {
+  router.push({
+    name: 'HRMNoticeBoard',
+    query: notification.value?.id ? { noticeId: notification.value.id } : {},
+  })
+}
 </script>
 
 <template>
@@ -65,10 +61,16 @@ function metricValue(key, suffix) {
     <template v-else>
       <BaseNoticeBanner
         badge="📌 중요 공지"
-        :title="notification?.notification_title ?? ''"
-        :description="notification?.notification_content ?? ''"
+        :title="notification?.title ?? ''"
+        :description="notification?.description ?? ''"
         tone="success"
         variant="soft"
+        class="hrm-dashboard__notice"
+        role="button"
+        tabindex="0"
+        @click="goNoticeBoard"
+        @keydown.enter="goNoticeBoard"
+        @keydown.space.prevent="goNoticeBoard"
       />
 
       <section class="hrm-dashboard__metrics">
@@ -99,6 +101,7 @@ function metricValue(key, suffix) {
           :tier-s="tierSummary.S"
           :tier-a="tierSummary.A"
           :tier-b="tierSummary.B"
+          :tier-c="tierSummary.C"
           :process-label="tierSummary.processLabel"
           :process-percent="tierSummary.processPercent"
         />
@@ -152,5 +155,9 @@ function metricValue(key, suffix) {
 
 :deep(.base-stat-card) {
   align-items: center;
+}
+
+.hrm-dashboard__notice {
+  cursor: pointer;
 }
 </style>

--- a/src/views/hrmanager/HRMKpiReportView.vue
+++ b/src/views/hrmanager/HRMKpiReportView.vue
@@ -1,11 +1,11 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
-import { API_BASE } from '@/constants'
 import BaseStatCard         from '@/components/common/base/display/BaseStatCard.vue'
 import HRMKpiTeamBarChart   from '@/components/hr/hrmanager/kpi-report/HRMKpiTeamBarChart.vue'
 import HRMKpiTierTrendChart from '@/components/hr/hrmanager/kpi-report/HRMKpiTierTrendChart.vue'
 import HRMKpiCompletionDonut from '@/components/hr/hrmanager/kpi-report/HRMKpiCompletionDonut.vue'
 import HRMKpiTeamTable      from '@/components/hr/hrmanager/kpi-report/HRMKpiTeamTable.vue'
+import { downloadHrmKpiReport, getHrmKpiReport } from '@/services/hrDashboardApi'
 
 const loading         = ref(true)
 const allReports      = ref([])
@@ -17,30 +17,34 @@ const selectedQuarter = ref('2026년 1분기')
 const report      = computed(() => allReports.value.find(r => r.quarter === selectedQuarter.value) ?? null)
 const teamScores  = computed(() => allTeamScores.value.filter(s => s.quarter === selectedQuarter.value))
 const teamLeaders = computed(() => allTeamLeaders.value.filter(l => l.quarter === selectedQuarter.value))
-
-async function fetchJson(url) {
-  const res = await fetch(url)
-  return res.json()
-}
+const quarterOptions = computed(() => {
+  const defaults = ['2026년 1분기', '2025년 4분기', '2025년 3분기']
+  return [...new Set([selectedQuarter.value, ...defaults].filter(Boolean))]
+})
 
 onMounted(async () => {
   try {
-    const [kpi, scores, trend, leaders] = await Promise.all([
-      fetchJson(`${API_BASE}/kpiReport`),
-      fetchJson(`${API_BASE}/kpiTeamScores`),
-      fetchJson(`${API_BASE}/kpiTierTrend`),
-      fetchJson(`${API_BASE}/kpiTeamLeaders`),
-    ])
-    allReports.value     = kpi
-    allTeamScores.value  = scores
-    tierTrend.value      = trend
-    allTeamLeaders.value = leaders
+    const data = await getHrmKpiReport()
+    allReports.value = [data.report]
+    selectedQuarter.value = data.report.quarter
+    allTeamScores.value = data.teamScores
+    tierTrend.value = data.tierTrend
+    allTeamLeaders.value = data.teamLeaders
   } catch (e) {
     console.error('KPI 데이터 로딩 실패:', e)
   } finally {
     loading.value = false
   }
 })
+
+async function handleDownloadReport() {
+  try {
+    await downloadHrmKpiReport()
+  } catch (e) {
+    console.error('KPI 보고서 다운로드 실패:', e)
+    alert('보고서 다운로드에 실패했습니다.')
+  }
+}
 </script>
 
 <template>
@@ -51,12 +55,10 @@ onMounted(async () => {
       <!-- 툴바 -->
       <div class="kpi-view__toolbar">
         <select class="kpi-view__quarter-select" v-model="selectedQuarter">
-          <option>2026년 1분기</option>
-          <option>2025년 4분기</option>
-          <option>2025년 3분기</option>
+          <option v-for="quarter in quarterOptions" :key="quarter">{{ quarter }}</option>
         </select>
         <div class="kpi-view__toolbar-actions">
-          <button class="kpi-view__btn kpi-view__btn--primary">📥 전체 보고서 다운로드</button>
+          <button class="kpi-view__btn kpi-view__btn--primary" @click="handleDownloadReport">📥 전체 보고서 다운로드</button>
         </div>
       </div>
 

--- a/src/views/hrmanager/HRMNoticeBoardView.vue
+++ b/src/views/hrmanager/HRMNoticeBoardView.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, watch, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
 import hrApi from '@/services/hrApi'
 import HRMNoticeListPanel  from '@/components/hr/common/notices/HRMNoticeListPanel.vue'
 import HRMNoticeDetailPanel from '@/components/hr/common/notices/HRMNoticeDetailPanel.vue'
@@ -12,6 +13,7 @@ const selectedId     = ref(null)
 const selectedNotice = ref(null)
 const showFormModal  = ref(false)
 const editTarget     = ref(null)
+const route = useRoute()
 
 // ── 필드 변환 헬퍼 ────────────────────────────────
 const STATUS_MAP = { POSTING: '게시중', RESERVATION: '예약', TEMPORARY: '임시' }
@@ -62,6 +64,11 @@ async function fetchNotices() {
     const res = await hrApi.get('/api/v1/hr/notices')
     const list = res.data?.success ? res.data.data : res.data
     notices.value = (Array.isArray(list) ? list : []).map(normalizeList)
+    const queryNoticeId = route.query.noticeId ? Number(route.query.noticeId) : null
+    if (queryNoticeId && notices.value.some(notice => notice.id === queryNoticeId)) {
+      selectedId.value = queryNoticeId
+      return
+    }
     if (!selectedId.value && notices.value.length) {
       selectedId.value = notices.value[0].id
     }

--- a/src/views/hrmanager/HRMOrganizationView.vue
+++ b/src/views/hrmanager/HRMOrganizationView.vue
@@ -12,14 +12,17 @@ const DEPT_COLORS = [
 ]
 
 // ── 상태 ─────────────────────────────────────────────────────────
-const groups      = ref([])   // [{id, name, color, description, teams:[{id, name, memberCount, leader}]}]
+const groups      = ref([])   // [{id, name, color, teams:[{id, name, memberCount, leader}]}]
 const employees   = ref([])   // 전체 직원 목록 (모달 인력풀용)
 const teamMembers = ref([])   // 선택된 팀의 멤버 목록
+const departmentMembers = ref([]) // 선택된 그룹의 부서원 목록
+const departmentDirectMembers = ref([]) // 선택된 그룹에 직접 소속된 부서원 목록
 
 const treeSearch   = ref('')
 const selectedTeam = ref(null)        // { groupId, team }
 const selectedGroup = ref(null)       // 팀 추가 모달용 그룹
 const selectedGroupDetail = ref(null) // 그룹 상세 패널
+const selectedDepartmentLeaderId = ref(null)
 
 const showGroupModal      = ref(false)
 const showGroupEditModal  = ref(false)
@@ -76,7 +79,6 @@ async function loadOrgTree() {
       id:          dept.unitId,
       name:        dept.unitName,
       color:       DEPT_COLORS[i % DEPT_COLORS.length],
-      description: '',
       teams: (dept.children ?? []).map(team => ({
         id:          team.unitId,
         name:        team.unitName,
@@ -87,9 +89,24 @@ async function loadOrgTree() {
         memberIds:   [],
       })),
     }))
+    await hydrateGroupDetails(groups.value)
   } catch (e) {
     console.error('조직도 로딩 실패', e)
   }
+}
+
+async function hydrateGroupDetails(targetGroups) {
+  await Promise.all(targetGroups.map(async (group) => {
+    try {
+      const res = await hrApi.get(`/api/v1/hr/org/departments/${group.id}`)
+      const detail = res.data?.data
+      if (!detail?.teams) return
+      detail.teams.forEach(t => {
+        const team = group.teams.find(gt => gt.id === t.teamId)
+        if (team) team.memberCount = t.memberCount
+      })
+    } catch { /* ignore */ }
+  }))
 }
 
 async function loadEmployees() {
@@ -103,6 +120,9 @@ async function loadEmployees() {
 
 onMounted(async () => {
   await Promise.all([loadOrgTree(), loadEmployees()])
+  if (!selectedGroupDetail.value && groups.value.length > 0) {
+    await selectGroup(groups.value[0])
+  }
 })
 
 // ── 유틸 ─────────────────────────────────────────────────────────
@@ -114,13 +134,22 @@ function tierTextColor(tier) {
   return tier === 'B' ? '#1a1000' : 'var(--color-white)'
 }
 function positionOf(emp) {
-  return { position: ROLE_LABELS[emp.role] ?? emp.role ?? '사원', dept: emp.departmentName ?? '기타' }
+  return { position: ROLE_LABELS[emp.role] ?? emp.role ?? '사원', dept: departmentPath(emp) }
 }
 function isLeader(team, emp) {
   return emp.role === 'TL'
 }
 function leaderOf(team) {
   return team?.leader ?? null
+}
+
+function departmentPath(emp) {
+  const departmentName = emp.departmentName ?? emp.department_name ?? ''
+  const teamName = emp.teamName ?? emp.team_name ?? ''
+  if (departmentName && teamName && departmentName !== teamName) {
+    return `${departmentName} · ${teamName}`
+  }
+  return departmentName || teamName || '기타'
 }
 
 const COLOR_NAMES = {
@@ -165,23 +194,37 @@ const selectedGroup$ = computed(() =>
 // ── 그룹 전체 인원 수 ─────────────────────────────────────────────
 const groupTotalMemberCount = computed(() => {
   if (!selectedGroupDetail.value) return 0
-  return selectedGroupDetail.value.teams.reduce((s, t) => s + (t.memberCount ?? 0), 0)
+  return departmentMembers.value.length
 })
+
+const departmentLeader = computed(() =>
+  departmentMembers.value.find(emp => emp.role === 'DL') ?? null
+)
+
+const sortedDepartmentDirectMembers = computed(() =>
+  [...departmentDirectMembers.value].sort((a, b) => {
+    if (a.role === 'DL' && b.role !== 'DL') return -1
+    if (a.role !== 'DL' && b.role === 'DL') return 1
+    return String(a.name ?? '').localeCompare(String(b.name ?? ''), 'ko')
+  })
+)
+
+const departmentLeaderCandidates = computed(() =>
+  employees.value.filter(emp => emp.role === 'DL')
+)
 
 // ── 인력풀 (모달용) ───────────────────────────────────────────────
 const availableEmployees = computed(() => {
-  const currentTeamId = isEditMode.value ? selectedTeam.value?.team?.id : null
-  const usedIds = new Set()
-  groups.value.forEach(g => g.teams.forEach(t => {
-    if (t.id !== currentTeamId) (t.memberIds ?? []).forEach(id => usedIds.add(id))
-  }))
-  return employees.value.filter(e => e.employeeId && !usedIds.has(e.employeeId))
+  return employees.value.filter(e => e.employeeId)
 })
 
 // ── 이벤트 핸들러 ─────────────────────────────────────────────────
 async function selectGroup(group) {
   selectedGroupDetail.value = group
   selectedTeam.value = null
+  departmentMembers.value = []
+  departmentDirectMembers.value = []
+  selectedDepartmentLeaderId.value = null
   // 팀별 멤버 수 갱신
   try {
     const res = await hrApi.get(`/api/v1/hr/org/departments/${group.id}`)
@@ -193,6 +236,25 @@ async function selectGroup(group) {
       })
     }
   } catch { /* ignore */ }
+
+  try {
+    const res = await hrApi.get('/api/v1/hr/org/employees', {
+      params: { departmentId: group.id, page: 0, size: 200 },
+    })
+    departmentMembers.value = res.data?.data ?? []
+    selectedDepartmentLeaderId.value = departmentLeader.value?.employeeId ?? null
+  } catch {
+    departmentMembers.value = []
+  }
+
+  try {
+    const res = await hrApi.get('/api/v1/hr/org/employees', {
+      params: { teamId: group.id, page: 0, size: 200 },
+    })
+    departmentDirectMembers.value = res.data?.data ?? []
+  } catch {
+    departmentDirectMembers.value = []
+  }
 }
 
 async function selectTeam(group, team) {
@@ -247,11 +309,11 @@ async function handleGroupSubmit(data) {
   try {
     const res = await hrApi.post('/api/v1/hr/org/departments', {
       departmentName: data.name,
-      depth: 'DEPARTMENT',
+      depth: 'L0',
     })
     const newId = res.data?.data
     const color = DEPT_COLORS[groups.value.length % DEPT_COLORS.length]
-    groups.value.push({ id: newId, name: data.name, color, description: data.description ?? '', teams: [] })
+    groups.value.push({ id: newId, name: data.name, color, teams: [] })
     showGroupModal.value = false
     showToast(`'${data.name}' 그룹이 추가되었습니다.`)
   } catch {
@@ -264,11 +326,20 @@ async function handleGroupEditSubmit(data) {
   try {
     await hrApi.put(`/api/v1/hr/org/departments/${group.id}`, {
       departmentName: data.name,
-      depth: 'DEPARTMENT',
+      depth: 'L0',
     })
+    if (data.memberIds?.length > 0) {
+      const currentIds = new Set(departmentDirectMembers.value.map(emp => emp.employeeId))
+      const toAdd = data.memberIds.filter(id => !currentIds.has(id))
+      if (toAdd.length > 0) {
+        await hrApi.post(`/api/v1/hr/org/teams/${group.id}/members`, {
+          employeeIds: toAdd,
+        })
+      }
+    }
     group.name        = data.name
-    group.description = data.description ?? ''
     group.color       = data.color
+    await Promise.all([loadEmployees(), selectGroup(group)])
     showGroupEditModal.value = false
     showToast(`'${data.name}' 그룹이 수정되었습니다.`)
   } catch {
@@ -294,7 +365,12 @@ async function handleTeamSubmit(data) {
 
       team.name = data.name
       // 팀원 목록 재로딩
-      await selectTeam(selectedGroup$?.value ?? groups.value.find(g => g.id === selectedTeam.value.groupId), team)
+      await Promise.all([loadOrgTree(), loadEmployees()])
+      const refreshedGroup = groups.value.find(g => g.id === selectedTeam.value.groupId)
+      const refreshedTeam = refreshedGroup?.teams.find(t => t.id === team.id) ?? team
+      if (refreshedGroup) {
+        await selectTeam(refreshedGroup, refreshedTeam)
+      }
       showToast(`'${data.name}' 팀 정보가 수정되었습니다.`)
     } catch {
       showToast('팀 수정에 실패했습니다.', 'error')
@@ -320,6 +396,7 @@ async function handleTeamSubmit(data) {
         leaderId:    null,
         memberIds:   data.memberIds ?? [],
       })
+      await Promise.all([loadOrgTree(), loadEmployees()])
       showToast(`'${data.name}' 팀이 추가되었습니다.`)
     } catch {
       showToast('팀 추가에 실패했습니다.', 'error')
@@ -330,6 +407,29 @@ async function handleTeamSubmit(data) {
 
 function setLeader(team, emp) {
   showToast('팀장 지정은 역할 변경 메뉴에서 처리합니다.')
+}
+
+async function assignDepartmentLeader() {
+  if (!selectedGroupDetail.value || !selectedDepartmentLeaderId.value) return
+  const selectedLeader = employees.value.find(emp => emp.employeeId === selectedDepartmentLeaderId.value)
+  if (isDifferentDepartmentDl(selectedLeader)) {
+    const confirmed = window.confirm('다른 부서의 부서장입니다. 변경하시겠습니까?')
+    if (!confirmed) return
+  }
+  try {
+    await hrApi.patch(`/api/v1/hr/org/departments/${selectedGroupDetail.value.id}/leader`, {
+      employeeId: selectedDepartmentLeaderId.value,
+    })
+    await Promise.all([loadEmployees(), selectGroup(selectedGroupDetail.value)])
+    showToast('부서장이 지정되었습니다.')
+  } catch {
+    showToast('부서장 지정에 실패했습니다.', 'error')
+  }
+}
+
+function isDifferentDepartmentDl(emp) {
+  if (!emp || emp.role !== 'DL' || !selectedGroupDetail.value) return false
+  return emp.departmentName && emp.departmentName !== selectedGroupDetail.value.name
 }
 
 function removeMember(team, emp) {
@@ -561,8 +661,6 @@ function deleteGroup(group) {
           <button class="team-detail__delete-btn" @click="deleteGroup(selectedGroupDetail); selectedGroupDetail = null">삭제</button>
         </div>
       </div>
-      <p class="team-detail__desc">{{ selectedGroupDetail.description || '설명 없음' }}</p>
-
       <!-- 통계 카드 -->
       <div class="group-detail__stats">
         <div class="group-detail__stat-card">
@@ -591,6 +689,60 @@ function deleteGroup(group) {
               <span class="group-detail__stat-num">{{ groupTotalMemberCount }}</span>
               <span class="group-detail__stat-unit">명</span>
             </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="department-leader-card">
+        <div class="department-leader-card__info">
+          <span class="team-detail__member-title">부서장</span>
+          <p class="department-leader-card__desc">
+            {{ departmentLeader ? `${departmentLeader.name}님이 현재 부서장입니다.` : '지정된 부서장이 없습니다.' }}
+          </p>
+        </div>
+        <div class="department-leader-card__actions">
+          <select v-model="selectedDepartmentLeaderId" class="team-detail__select">
+            <option :value="null">부서장 선택</option>
+            <option
+              v-for="emp in departmentLeaderCandidates"
+              :key="emp.employeeId"
+              :value="emp.employeeId"
+            >
+              {{ emp.name }} · {{ emp.departmentName ?? '소속 없음' }} · Tier {{ emp.currentTier ?? '-' }}
+            </option>
+          </select>
+          <button
+            class="team-detail__edit-btn"
+            :disabled="!selectedDepartmentLeaderId"
+            @click="assignDepartmentLeader"
+          >
+            부서장 지정
+          </button>
+        </div>
+      </div>
+
+      <div class="team-detail__member-header">
+        <span class="team-detail__member-title">부서원 목록</span>
+      </div>
+      <div class="member-list">
+        <div v-if="departmentDirectMembers.length === 0" class="member-list__empty">
+          직접 소속된 부서원이 없습니다.
+        </div>
+        <div v-for="emp in sortedDepartmentDirectMembers" :key="emp.employeeId" class="member-card">
+          <div class="member-card__avatar"
+            :style="{ background: tierColor(emp.currentTier) }"
+          >{{ emp.name[0] }}</div>
+          <div class="member-card__info">
+            <div class="member-card__row1">
+              <span class="member-card__name">{{ emp.name }}</span>
+              <span class="member-card__tier"
+                :style="{ background: tierColor(emp.currentTier), color: tierTextColor(emp.currentTier) }"
+              >{{ emp.currentTier }}</span>
+              <span v-if="emp.role === 'DL'" class="member-card__leader-badge">부서장</span>
+            </div>
+            <p class="member-card__sub">
+              {{ positionOf(emp).position }}·{{ positionOf(emp).dept }}
+            </p>
           </div>
         </div>
       </div>
@@ -653,8 +805,9 @@ function deleteGroup(group) {
       v-if="showGroupEditModal && selectedGroupDetail"
       :edit-mode="true"
       :initial-name="selectedGroupDetail.name"
-      :initial-description="selectedGroupDetail.description"
       :initial-color="selectedGroupDetail.color"
+      :all-employees="availableEmployees"
+      :initial-member-ids="departmentDirectMembers.map(emp => emp.employeeId)"
       @close="showGroupEditModal = false"
       @submit="handleGroupEditSubmit"
     />
@@ -663,7 +816,6 @@ function deleteGroup(group) {
       :all-employees="availableEmployees"
       :edit-mode="isEditMode"
       :initial-name="isEditMode ? selectedTeam?.team?.name : ''"
-      :initial-description="isEditMode ? selectedTeam?.team?.description : ''"
       :initial-member-ids="isEditMode ? [...(selectedTeam?.team?.memberIds ?? [])] : []"
       @close="showTeamModal = false"
       @submit="handleTeamSubmit"
@@ -1002,6 +1154,32 @@ function deleteGroup(group) {
   background: var(--color-danger); color: var(--color-white);
   border: none; border-radius: 8px; font-size: var(--font-size-xs); font-weight: var(--font-weight-bold);
   cursor: pointer;
+}
+
+.department-leader-card {
+  display: flex; align-items: center; justify-content: space-between; gap: 16px;
+  padding: 18px 20px;
+  background: var(--color-bg-app);
+  border: 1.5px solid var(--color-border-default);
+  border-radius: 12px;
+}
+.department-leader-card__info {
+  display: flex; flex-direction: column; gap: 4px;
+}
+.department-leader-card__desc {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+.department-leader-card__actions {
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap; justify-content: flex-end;
+}
+.department-leader-card__actions .team-detail__select {
+  min-width: 240px;
+}
+.department-leader-card__actions .team-detail__edit-btn:disabled {
+  opacity: .5;
+  cursor: not-allowed;
 }
 
 /* ── 그룹 상세 ── */

--- a/src/views/teamleader/TeamLeaderDashboardView.vue
+++ b/src/views/teamleader/TeamLeaderDashboardView.vue
@@ -1,39 +1,72 @@
 ﻿<script setup>
-import { computed } from 'vue'
+import { computed, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
 import TeamLeaderDashboardNotice from '@/components/dashboard/common/TeamLeaderDashboardNoticeWrapper.vue'
 import TeamLeaderMetricCard from '@/components/dashboard/teamleader/TeamLeaderMetricCardWrapper.vue'
 import TeamLeaderMemberGrid from '@/components/dashboard/teamleader/TeamLeaderMemberGrid.vue'
-import { dashboardNotice, dashboardMetrics, dashboardMembers } from '@/mocks/teamleader/dashboard'
+import { getTeamLeaderDashboard } from '@/services/hrDashboardApi'
+
+const loading = ref(true)
+const router = useRouter()
+const notice = ref(null)
+const metrics = ref([])
+const members = ref([])
 
 const evaluationRate = computed(() => {
-  const rateMetric = dashboardMetrics.find((metric) => metric.label === '평가율')
+  const rateMetric = metrics.value.find((metric) => metric.label === '평가율')
   return Number.parseFloat(String(rateMetric?.value ?? '0').replace('%', '')) || 0
 })
+
+onMounted(async () => {
+  try {
+    const dashboard = await getTeamLeaderDashboard()
+    notice.value = dashboard.notice
+    metrics.value = dashboard.metrics
+    members.value = dashboard.members
+  } catch (error) {
+    console.error('Failed to load team leader dashboard:', error)
+  } finally {
+    loading.value = false
+  }
+})
+
+function goNoticeBoard() {
+  router.push({
+    name: 'TLNoticeBoard',
+    query: notice.value?.id ? { noticeId: notice.value.id } : {},
+  })
+}
 </script>
 
 <template>
   <section class="teamleader-dashboard-view">
-    <TeamLeaderDashboardNotice
-      :badge="dashboardNotice.badge"
-      :title="dashboardNotice.title"
-      :description="dashboardNotice.description"
-    />
+    <div v-if="loading" class="teamleader-dashboard-view__loading">데이터를 불러오는 중...</div>
 
-    <section class="teamleader-dashboard-view__metrics">
-      <TeamLeaderMetricCard
-        v-for="metric in dashboardMetrics"
-        :key="metric.label"
-        :label="metric.label"
-        :value="metric.value"
-        :delta="metric.delta"
-        :helper="metric.helper"
-        :tone="metric.tone"
-        :progress-value="metric.label === '평가율' ? evaluationRate : null"
-        progress-tone="success"
+    <template v-else>
+      <TeamLeaderDashboardNotice
+        v-if="notice"
+        :badge="notice.badge"
+        :title="notice.title"
+        :description="notice.description"
+        @click="goNoticeBoard"
       />
-    </section>
 
-    <TeamLeaderMemberGrid :members="dashboardMembers" />
+      <section class="teamleader-dashboard-view__metrics">
+        <TeamLeaderMetricCard
+          v-for="metric in metrics"
+          :key="metric.label"
+          :label="metric.label"
+          :value="metric.value"
+          :delta="metric.delta"
+          :helper="metric.helper"
+          :tone="metric.tone"
+          :progress-value="metric.label === '평가율' ? evaluationRate : null"
+          progress-tone="success"
+        />
+      </section>
+
+      <TeamLeaderMemberGrid :members="members" />
+    </template>
   </section>
 </template>
 
@@ -64,5 +97,12 @@ const evaluationRate = computed(() => {
 :deep(.notice) {
   width: 100%;
   box-sizing: border-box;
+}
+
+.teamleader-dashboard-view__loading {
+  padding: 60px;
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-base);
 }
 </style>

--- a/src/views/teamleader/TeamLeaderFacilityStatusView.vue
+++ b/src/views/teamleader/TeamLeaderFacilityStatusView.vue
@@ -4,7 +4,7 @@ import { BaseFilterTabs } from '@/components/common/base'
 import TeamLeaderFacilityStatusCard from '@/components/scm/teamleader/facility-status/TeamLeaderFacilityStatusCard.vue'
 import TeamLeaderFacilityTrendPanel from '@/components/scm/teamleader/facility-status/TeamLeaderFacilityTrendPanel.vue'
 import TeamLeaderFacilityHistoryPanel from '@/components/scm/teamleader/facility-status/TeamLeaderFacilityHistoryPanel.vue'
-import { getMyTeamFacilities, getFacilityHistory, getFacilityTrends } from '@/services/teamLeaderScmApi'
+import { getFacilities, getFacilityHistory, getFacilityTrends } from '@/services/teamLeaderScmApi'
 
 const STATUS_TONE  = { OPERATING: 'mint', UNDER_INSPECTION: 'warning', STOPPED: 'danger', DISPOSED: 'soft' }
 const STATUS_LABEL = { OPERATING: '가동중', UNDER_INSPECTION: '점검중', STOPPED: '정지', DISPOSED: '폐기' }
@@ -19,8 +19,10 @@ const facilityTrends  = ref({})   // { [equipmentId]: FacilityTrendsDto[] }
 const facilityHistories = ref([]) // flat merged array with .facilityName added
 const activeFilter    = ref('all')
 const activeTrendFilter = ref('all')
+const selectedFacilityId = ref(null)
 const currentPage     = ref(1)
 const pageSize        = 4
+const visiblePageCount = 5
 
 // ── Filter tabs (derived from real category data) ─────────────────
 const facilityFilters = computed(() => {
@@ -88,10 +90,31 @@ const filteredCards = computed(() =>
 
 const totalPages  = computed(() => Math.max(1, Math.ceil(filteredCards.value.length / pageSize)))
 const pagedCards  = computed(() => filteredCards.value.slice((currentPage.value - 1) * pageSize, currentPage.value * pageSize))
-const pageNumbers = computed(() => Array.from({ length: totalPages.value }, (_, i) => i + 1))
+const pageNumbers = computed(() => {
+  if (totalPages.value <= visiblePageCount) {
+    return Array.from({ length: totalPages.value }, (_, i) => i + 1)
+  }
+
+  const half = Math.floor(visiblePageCount / 2)
+  let start = Math.max(1, currentPage.value - half)
+  const endLimit = totalPages.value - visiblePageCount + 1
+  start = Math.min(start, endLimit)
+
+  return Array.from({ length: visiblePageCount }, (_, i) => start + i)
+})
 
 watch(activeFilter,   () => { currentPage.value = 1 })
 watch(filteredCards,  () => { if (currentPage.value > totalPages.value) currentPage.value = totalPages.value })
+watch(filteredCards,  (cards) => {
+  if (cards.length === 0) {
+    selectedFacilityId.value = null
+    return
+  }
+
+  if (!cards.some((card) => card.id === selectedFacilityId.value)) {
+    selectedFacilityId.value = cards[0].id
+  }
+})
 
 // ── Trend panel ───────────────────────────────────────────────────
 const trendChartData = computed(() => {
@@ -135,8 +158,13 @@ const filteredTrend = computed(() => {
 })
 
 // ── History panel ─────────────────────────────────────────────────
+const selectedFacility = computed(() =>
+  facilities.value.find((facility) => String(facility.equipmentId) === selectedFacilityId.value)
+)
+
 const historyItems = computed(() =>
   facilityHistories.value
+    .filter((history) => !selectedFacilityId.value || String(history.equipmentId) === selectedFacilityId.value)
     .slice()
     .sort((a, b) => new Date(b.occurredAt) - new Date(a.occurredAt))
     .slice(0, 6)
@@ -149,9 +177,10 @@ const historyItems = computed(() =>
 
 // ── Data loading ──────────────────────────────────────────────────
 onMounted(async () => {
-  const raw = await getMyTeamFacilities().catch(() => [])
+  const raw = await getFacilities().catch(() => [])
   facilities.value = Array.isArray(raw) ? raw : []
   if (facilities.value.length === 0) return
+  selectedFacilityId.value = String(facilities.value[0].equipmentId)
 
   const ids = facilities.value.map((f) => f.equipmentId)
 
@@ -167,7 +196,7 @@ onMounted(async () => {
       ids.map((id) => {
         const f = facilities.value.find((f) => f.equipmentId === id)
         return getFacilityHistory(id)
-          .then((data) => (Array.isArray(data) ? data : []).map((h) => ({ ...h, facilityName: f?.equipmentName ?? '' })))
+          .then((data) => (Array.isArray(data) ? data : []).map((h) => ({ ...h, equipmentId: id, facilityName: f?.equipmentName ?? '' })))
           .catch(() => [])
       })
     ),
@@ -196,11 +225,21 @@ onMounted(async () => {
             v-for="card in pagedCards"
             :key="card.id"
             :card="card"
+            :selected="card.id === selectedFacilityId"
+            @select="selectedFacilityId = $event"
           />
         </div>
 
         <div class="teamleader-facility-view__pagination-slot">
           <div v-if="filteredCards.length > 0" class="teamleader-facility-view__pagination">
+            <button
+              type="button"
+              class="teamleader-facility-view__page-button"
+              :disabled="currentPage === 1"
+              @click="currentPage = Math.max(1, currentPage - 1)"
+            >
+              이전
+            </button>
             <button
               v-for="page in pageNumbers"
               :key="page"
@@ -210,6 +249,14 @@ onMounted(async () => {
               @click="currentPage = page"
             >
               {{ page }}
+            </button>
+            <button
+              type="button"
+              class="teamleader-facility-view__page-button"
+              :disabled="currentPage === totalPages"
+              @click="currentPage = Math.min(totalPages, currentPage + 1)"
+            >
+              다음
             </button>
           </div>
         </div>
@@ -223,7 +270,10 @@ onMounted(async () => {
           @change-filter="activeTrendFilter = $event"
         />
 
-        <TeamLeaderFacilityHistoryPanel :items="historyItems" />
+        <TeamLeaderFacilityHistoryPanel
+          :items="historyItems"
+          :facility-name="selectedFacility?.equipmentName ?? ''"
+        />
       </section>
     </section>
   </section>
@@ -283,14 +333,18 @@ onMounted(async () => {
 
 .teamleader-facility-view__pagination-slot {
   display: grid;
-  align-items: end;
+  place-items: end center;
+  min-width: 0;
 }
 
 .teamleader-facility-view__pagination {
   display: flex;
+  align-items: center;
   justify-content: center;
   gap: 8px;
+  max-width: 100%;
   min-height: 34px;
+  overflow: hidden;
 }
 
 .teamleader-facility-view__page-button {
@@ -303,6 +357,11 @@ onMounted(async () => {
   font-size: 13px;
   font-weight: 800;
   cursor: pointer;
+}
+
+.teamleader-facility-view__page-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
 }
 
 .teamleader-facility-view__page-button--active {

--- a/src/views/teamleader/TeamLeaderKpiReportView.vue
+++ b/src/views/teamleader/TeamLeaderKpiReportView.vue
@@ -1,72 +1,81 @@
 ﻿<script setup>
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { BaseStatCardGrid } from '@/components/common/base'
 import TeamLeaderKpiMemberTable from '@/components/hr/teamleader/kpi-report/TeamLeaderKpiMemberTableWrapper.vue'
 import TeamLeaderKpiTrendPanel from '@/components/hr/teamleader/kpi-report/TeamLeaderKpiTrendPanel.vue'
-import { kpiSummaryCards, kpiRows, kpiTrendPanelMap } from '@/mocks/teamleader/kpiReport'
+import { getTeamLeaderKpiMemberDetail, getTeamLeaderKpiReport } from '@/services/hrDashboardApi'
 
-const selectedMemberId = ref(1)
+const loading = ref(true)
+const detailLoading = ref(false)
+const summaryCards = ref([])
+const rows = ref([])
+const selectedMemberId = ref(null)
+const trendPanel = ref(null)
+const period = { year: 2026, evalSequence: 1 }
 
 const selectedMember = computed(() => {
-  return kpiRows.find((row) => row.id === selectedMemberId.value) ?? kpiRows[0]
-})
-
-const trendPanel = computed(() => {
-  const member = selectedMember.value
-  const basePanel = kpiTrendPanelMap.default
-
-  const steps = basePanel.stepTemplates.map((step) => ({
-    step: step.step,
-    title: step.title,
-    description: step.descriptionTemplate
-      .replace('{actualOutput}', member.actualOutput)
-      .replace('{actualBase}', member.actualOutput.replace('개', ''))
-      .replace('{eIdx}', member.eIdx)
-      .replace('{name}', member.name)
-      .replace('{adjustedRate}', member.adjustedRate)
-      .replace('{score}', member.score),
-    value: step.valueTemplate
-      .replace('{actualOutput}', member.actualOutput)
-      .replace('{eRate}', `${Number(member.eIdx) * 100}`)
-      .replace('{eIdx}', member.eIdx)
-      .replace('{adjustedRate}', member.adjustedRate)
-      .replace('{score}', member.score),
-  }))
-
-  const benchmarkItems = basePanel.benchmarkTemplates.map((item) => ({
-    label: item.labelTemplate.replace('{name}', member.name),
-    value: item.valueTemplate.replace('{score}', member.score),
-    delta: item.deltaTemplate.replace('{trend}', member.trend),
-  }))
-
-  return {
-    title: `산출 상세 — ${member.name}`,
-    steps,
-    chartTitle: basePanel.chartTitleTemplate.replace('{name}', member.name),
-    chartMeta: basePanel.chartMetaTemplate.replace('{name}', member.name),
-    benchmarkTitle: basePanel.benchmarkTitle,
-    benchmarkItems,
-  }
+  return rows.value.find((row) => row.id === selectedMemberId.value) ?? rows.value[0] ?? null
 })
 
 function handleSelectMember(memberId) {
   selectedMemberId.value = memberId
 }
+
+async function loadMemberDetail() {
+  if (!selectedMember.value) {
+    trendPanel.value = null
+    return
+  }
+  detailLoading.value = true
+  try {
+    trendPanel.value = await getTeamLeaderKpiMemberDetail(
+      selectedMember.value.id,
+      period,
+      selectedMember.value
+    )
+  } catch (error) {
+    console.error('Failed to load team leader KPI member detail:', error)
+  } finally {
+    detailLoading.value = false
+  }
+}
+
+onMounted(async () => {
+  try {
+    const report = await getTeamLeaderKpiReport(period)
+    summaryCards.value = report.summaryCards
+    rows.value = report.rows
+    selectedMemberId.value = report.rows[0]?.id ?? null
+  } catch (error) {
+    console.error('Failed to load team leader KPI report:', error)
+  } finally {
+    loading.value = false
+  }
+})
+
+watch(selectedMemberId, loadMemberDetail)
 </script>
 
 <template>
   <section class="teamleader-kpi-report-view">
-    <BaseStatCardGrid class="teamleader-kpi-report-view__summary" :cards="kpiSummaryCards" />
+    <div v-if="loading" class="teamleader-kpi-report-view__loading">데이터를 불러오는 중...</div>
 
-    <section class="teamleader-kpi-report-view__content">
-      <TeamLeaderKpiMemberTable
-        :rows="kpiRows"
-        :page-size="8"
-        :selected-id="selectedMemberId"
-        @select-row="handleSelectMember"
-      />
-      <TeamLeaderKpiTrendPanel :panel="trendPanel" />
-    </section>
+    <template v-else>
+      <BaseStatCardGrid class="teamleader-kpi-report-view__summary" :cards="summaryCards" />
+
+      <section class="teamleader-kpi-report-view__content">
+        <TeamLeaderKpiMemberTable
+          :rows="rows"
+          :page-size="8"
+          :selected-id="selectedMemberId"
+          @select-row="handleSelectMember"
+        />
+        <div v-if="detailLoading || !trendPanel" class="teamleader-kpi-report-view__loading">
+          상세 데이터를 불러오는 중...
+        </div>
+        <TeamLeaderKpiTrendPanel v-else :panel="trendPanel" />
+      </section>
+    </template>
   </section>
 </template>
 
@@ -98,6 +107,13 @@ function handleSelectMember(memberId) {
   gap: 16px;
   align-items: stretch;
   min-height: 0;
+}
+
+.teamleader-kpi-report-view__loading {
+  padding: 60px;
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-base);
 }
 
 @media (max-width: 1180px) {

--- a/src/views/teamleader/TeamLeaderNoticeBoardView.vue
+++ b/src/views/teamleader/TeamLeaderNoticeBoardView.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, watch, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
 import hrApi from '@/services/hrApi'
 import HRMNoticeListPanel  from '@/components/hr/common/notices/HRMNoticeListPanel.vue'
 import HRMNoticeDetailPanel from '@/components/hr/common/notices/HRMNoticeDetailPanel.vue'
@@ -36,12 +37,18 @@ function normalizeDetail(n) {
 const notices        = ref([])
 const selectedId     = ref(null)
 const selectedNotice = ref(null)
+const route = useRoute()
 
 async function fetchNotices() {
   try {
     const res = await hrApi.get('/api/v1/hr/notices')
     const list = res.data?.success ? res.data.data : res.data
     notices.value = (Array.isArray(list) ? list : []).map(normalizeList)
+    const queryNoticeId = route.query.noticeId ? Number(route.query.noticeId) : null
+    if (queryNoticeId && notices.value.some(notice => notice.id === queryNoticeId)) {
+      selectedId.value = queryNoticeId
+      return
+    }
     if (!selectedId.value && notices.value.length) {
       selectedId.value = notices.value[0].id
     }

--- a/src/views/teamleader/TeamLeaderNotificationView.vue
+++ b/src/views/teamleader/TeamLeaderNotificationView.vue
@@ -3,13 +3,11 @@ import { computed, ref, onMounted } from 'vue'
 import hrApi from '@/services/hrApi'
 import TeamLeaderNotificationFilterBar from '@/components/hr/teamleader/notification/TeamLeaderNotificationFilterBarWrapper.vue'
 import TeamLeaderNotificationList from '@/components/hr/teamleader/notification/TeamLeaderNotificationListWrapper.vue'
-import TeamLeaderNotificationAssistPanel from '@/components/hr/teamleader/notification/TeamLeaderNotificationAssistPanel.vue'
-import { notificationAssistPanels } from '@/mocks/teamleader/notification'
 
 // ── 상수 ──────────────────────────────────────────
 const notificationFilters = [
   { key: 'all',     label: '전체' },
-  { key: 'info',    label: '평가/배정' },
+  { key: 'info',    label: '평가' },
   { key: 'warn',    label: '이의신청' },
   { key: 'success', label: '승급' },
   { key: 'fault',   label: '편향감지' },
@@ -19,7 +17,6 @@ const TYPE_MAP = {
   RESULTS:        { label: '평가결과', tone: 'info' },
   OBJECTIONS:     { label: '이의신청', tone: 'warn' },
   PROMOTION:      { label: '승급',    tone: 'success' },
-  ARRANGEMENT:    { label: '배정',    tone: 'info' },
   BIAS_DETECTION: { label: '편향감지', tone: 'fault' },
 }
 
@@ -54,24 +51,16 @@ function normalize(n) {
 const activeFilter           = ref('all')
 const notifications          = ref([])
 const selectedNotificationId = ref(null)
-const activeAssistPanelId    = ref(null)
 const headlineFeedback       = ref('')
-
-// assistPanels는 SCM API 연동 전까지 mock 유지
-const assistPanels = ref(
-  notificationAssistPanels.map((panel) => ({
-    ...panel,
-    equipment:  { ...panel.equipment },
-    candidates: panel.candidates.map((c) => ({ ...c })),
-  }))
-)
 
 // ── API ───────────────────────────────────────────
 async function fetchNotifications() {
   try {
     const res = await hrApi.get('/api/v1/hr/notifications')
     const list = res.data?.success ? res.data.data : res.data
-    notifications.value = (Array.isArray(list) ? list : []).map(normalize)
+    notifications.value = (Array.isArray(list) ? list : [])
+      .filter((item) => item.notificationType !== 'ARRANGEMENT')
+      .map(normalize)
   } catch (err) {
     console.error('알림 조회 실패:', err)
   }
@@ -85,6 +74,18 @@ async function ackNotification(item) {
     )
   } catch (err) {
     console.error('알림 확인 실패:', err)
+  }
+}
+
+async function hideNotification(item) {
+  try {
+    await hrApi.patch(`/api/v1/hr/notifications/${item.notificationId}/hide`)
+    notifications.value = notifications.value.filter((n) => n.id !== item.id)
+    if (selectedNotificationId.value === item.id) {
+      selectedNotificationId.value = null
+    }
+  } catch (err) {
+    console.error('알림 숨김 실패:', err)
   }
 }
 
@@ -107,7 +108,6 @@ function handleFilterChange(filterKey) {
 
 function selectNotification(item) {
   selectedNotificationId.value = item.id
-  activeAssistPanelId.value = null
   if (item.unread) ackNotification(item)
 }
 
@@ -115,20 +115,6 @@ function handleHeadlineAction() {
   if (!headlineNotification.value) return
   selectNotification(headlineNotification.value)
   headlineFeedback.value = '선택된 알림으로 이동했습니다.'
-}
-
-function handleQuickAssign({ panel, candidate }) {
-  if (!panel || !candidate) return
-  assistPanels.value = assistPanels.value.map((entry) =>
-    entry.id === panel.id
-      ? {
-          ...entry,
-          equipment:  { ...entry.equipment, assignee: `현재 담당: ${candidate.name} (${candidate.tier}-Tier)`, status: '배정 완료' },
-          actionLabel: '배정 완료',
-        }
-      : entry
-  )
-  headlineFeedback.value = `${panel.equipment.code} 설비를 ${candidate.name}에게 즉시 배정했습니다.`
 }
 </script>
 
@@ -158,15 +144,9 @@ function handleQuickAssign({ panel, candidate }) {
           :page-size="4"
           @click-item="selectNotification"
           @click-action="selectNotification"
+          @dismiss-item="hideNotification"
         />
       </div>
-
-      <TeamLeaderNotificationAssistPanel
-        :panels="assistPanels"
-        :active-panel-id="activeAssistPanelId"
-        :page-size="1"
-        @quick-assign="handleQuickAssign"
-      />
     </section>
   </section>
 </template>
@@ -233,23 +213,14 @@ function handleQuickAssign({ panel, candidate }) {
 }
 
 .teamleader-notification-view__content {
-  display: grid;
-  grid-template-columns: minmax(0, 1.95fr) minmax(300px, 1fr);
-  gap: 16px;
-  align-items: stretch;
   min-height: 0;
+  align-items: stretch;
 }
 
 .teamleader-notification-view__main {
   display: grid;
   gap: 0px;
   min-height: 0;
-}
-
-@media (max-width: 1180px) {
-  .teamleader-notification-view__content {
-    grid-template-columns: 1fr;
-  }
 }
 
 @media (max-width: 720px) {

--- a/src/views/teamleader/TeamLeaderScmOrdersView.vue
+++ b/src/views/teamleader/TeamLeaderScmOrdersView.vue
@@ -90,7 +90,7 @@ function getStatusMeta(order) {
       return {
         columnKey: 'producing',
         line: `납기 ${formatDeadlineLabel(order.dueDate)}`,
-        daysLabel: order.technicianId ? `작업자 #${order.technicianId}` : '작업 진행중',
+        daysLabel: order.technicianName || (order.technicianId ? `작업자 #${order.technicianId}` : '작업 진행중'),
         actionLabel: null,
         actionDisabled: true,
         statusLabel: '생산중',
@@ -133,6 +133,7 @@ function mapOrderToCard(order) {
     statusLabel: meta.statusLabel,
     dueDate: order.dueDate,
     technicianId: order.technicianId ?? null,
+    technicianName: order.technicianName ?? null,
     columnKey: meta.columnKey,
   }
 }
@@ -169,7 +170,7 @@ const filteredUrgentOrders = computed(() =>
         title: order.itemName,
         progress: order.status === 'INPROGRESS' ? '진행중' : statusLabel,
         progressWidth: order.status === 'INPROGRESS' ? '65%' : order.status === 'ANALYZED' ? '20%' : '100%',
-        helper: order.technicianId ? `작업자 #${order.technicianId}` : '작업자 배정 필요',
+        helper: order.technicianName || (order.technicianId ? `작업자 #${order.technicianId}` : '작업자 배정 필요'),
         tone: getStatusTone(order.status),
       }
     })
@@ -200,7 +201,7 @@ async function handleAssignmentClick(item) {
   assignmentModalOpen.value = true
   candidateLoading.value = true
   try {
-    const candidates = await getAssignmentCandidates()
+    const candidates = await getAssignmentCandidates({ orderId: item.orderId })
     assignmentCandidates.value = Array.isArray(candidates) ? candidates : []
   } finally {
     candidateLoading.value = false

--- a/src/views/teamleader/TeamLeaderTaskMatchingView.vue
+++ b/src/views/teamleader/TeamLeaderTaskMatchingView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { BaseFilterTabs, BaseStatCardGrid } from '@/components/common/base'
 import TeamLeaderTaskMatchingDashboardPanel from '@/components/scm/teamleader/task-matching/TeamLeaderTaskMatchingDashboardPanel.vue'
 import TeamLeaderTaskMatchingAssignmentPanel from '@/components/scm/teamleader/task-matching/TeamLeaderTaskMatchingAssignmentPanel.vue'
@@ -8,16 +8,31 @@ import {
   getAssignmentCandidates,
   getAssignmentSummary,
   getAssignmentTimeline,
+  getLineWorkers,
+  getLinesSummary,
   getMyTeamLinesSummary,
-  getOrders,
-  getUrgentOrders,
+  getUnassignedOrders,
 } from '@/services/teamLeaderScmApi'
 
 const GRADE_LABELS = { D5: 'D5 최고난도', D4: 'D4', D3: 'D3', D2: 'D2', D1: 'D1' }
 const TIER_TONES   = { S: 'mint', A: 'primary', B: 'warning', C: 'danger' }
 const MATCH_TONES  = { INPROGRESS: 'primary', COMPLETE: 'mint', CONFIRM: 'soft', REJECT: 'danger' }
+const MATCHING_MODE_LABELS = {
+  EFFICIENCY_TYPE: '최적형 배정',
+  GROWTH_TYPE: '도전형 배정',
+}
+const UNASSIGNED_LINE_ID = 'unassigned-line'
 const DAY_START    = 8 * 60   // 08:00 in minutes from midnight
 const DAY_SPAN     = 12 * 60  // 12-hour work day
+
+function toLocalDateKey(value = new Date()) {
+  const date = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(date.getTime())) return ''
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
 
 const taskMatchingTabs = [
   { key: 'dashboard',  label: '운영 현황' },
@@ -29,11 +44,17 @@ const activeTab          = ref('dashboard')
 const assignmentSummary  = ref(null)
 const linesSummary       = ref([])
 const timeline           = ref([])
+const lineWorkers        = ref({})
 const allOrders          = ref([])
-const urgentOrders       = ref([])
 const rawCandidates      = ref([])
 const selectedOrderId    = ref(null)
 const assignedCandidateId = ref(null)
+
+function formatLineTitle(line) {
+  return line.factoryLineCode
+    ? `${line.factoryLineName} (${line.factoryLineCode})`
+    : line.factoryLineName
+}
 
 // ── Summary cards ─────────────────────────────────────────────────
 const summaryCards = computed(() => {
@@ -43,7 +64,7 @@ const summaryCards = computed(() => {
   const unassigned = assignmentSummary.value?.unassignedCount ?? 0
   return [
     { label: '실시간 생산 인원', value: `${assignmentSummary.value?.activeWorkerCount ?? 0}명`, helper: '활동중', tone: 'success' },
-    { label: '오늘 완료 작업',   value: `${assignmentSummary.value?.todayAssignedCount ?? 0}건`, tone: 'primary' },
+    { label: '오늘 완료 작업',   value: `${assignmentSummary.value?.todayCompletedCount ?? 0}건`, tone: 'primary' },
     { label: '라인 평균 가동률', value: `${avgRate}%`, tone: 'primary' },
     {
       label: '미배정 오더',
@@ -56,13 +77,14 @@ const summaryCards = computed(() => {
 
 // ── Dashboard: line status cards ───────────────────────────────────
 const lineStatuses = computed(() => {
-  const today = new Date().toISOString().split('T')[0]
+  const today = toLocalDateKey()
   return linesSummary.value.map((line) => {
     const lineItems = timeline.value.filter((t) => t.factoryLineId === line.factoryLineId)
     const todayItems = lineItems.filter((t) => t.assignedDate === today)
+    const visibleItems = todayItems.length > 0 ? todayItems : lineItems
 
     const seen = new Set()
-    const assignments = todayItems
+    let assignments = visibleItems
       .filter((t) => { if (seen.has(t.employeeId)) return false; seen.add(t.employeeId); return true })
       .slice(0, 3)
       .map((t) => ({
@@ -74,12 +96,21 @@ const lineStatuses = computed(() => {
                    t.matchingStatus === 'INPROGRESS'  ? '진행중' :
                    t.orderStatus    === 'COMPLETED'   ? '100%'  : '-',
       }))
+    if (assignments.length === 0) {
+      assignments = (lineWorkers.value[line.factoryLineId] ?? []).slice(0, 3).map((w) => ({
+        techId:    w.employeeId,
+        techName:  w.employeeName ?? `#${w.employeeId}`,
+        tier:      w.employeeTier ?? '-',
+        orderCode: w.equipmentName ?? '배치 설비',
+        progress:  '대기',
+      }))
+    }
 
     const rate = line.achievementRate ?? 0
     const tone = rate >= 85 ? 'mint' : rate >= 60 ? 'primary' : rate >= 40 ? 'warning' : 'danger'
     return {
       id:          `line-${line.factoryLineId}`,
-      title:       line.factoryLineName,
+      title:       formatLineTitle(line),
       percent:     `${rate}%`,
       tone,
       assignments,
@@ -89,36 +120,53 @@ const lineStatuses = computed(() => {
 
 // ── Dashboard: timeline rows ───────────────────────────────────────
 const timelineRows = computed(() => {
-  const today = new Date().toISOString().split('T')[0]
-  return linesSummary.value.map((line) => {
-    const items = timeline.value.filter(
+  const today = toLocalDateKey()
+  const rows = linesSummary.value.map((line) => {
+    const lineItems = timeline.value.filter((t) => t.factoryLineId === line.factoryLineId)
+    const todayItems = lineItems.filter(
       (t) => t.factoryLineId === line.factoryLineId && t.assignedDate === today
     )
-    const bars = items.slice(0, 3).map((t, idx) => {
-      let left, width
-      if (t.workStartAt && t.workEndAt) {
-        const s = new Date(t.workStartAt)
-        const e = new Date(t.workEndAt)
-        const sMin = s.getHours() * 60 + s.getMinutes()
-        const eMin = e.getHours() * 60 + e.getMinutes()
-        left  = `${(((sMin - DAY_START) / DAY_SPAN) * 100).toFixed(1)}%`
-        width = `${(((eMin - sMin)       / DAY_SPAN) * 100).toFixed(1)}%`
-      } else {
-        // Evenly distribute when no time data
-        const seg = 100 / (items.length + 1)
-        left  = `${(seg * (idx + 1) - seg * 0.4).toFixed(1)}%`
-        width = `${(seg * 0.7).toFixed(1)}%`
-      }
-      return { left, width, tone: MATCH_TONES[t.matchingStatus] ?? 'primary', label: t.orderNo }
-    })
-    return { id: line.factoryLineId, label: line.factoryLineName, bars }
+    const items = todayItems.length > 0 ? todayItems : lineItems
+    const bars = items.slice(0, 3).map((t, idx) => makeTimelineBar(t, idx, items.length))
+    return { id: line.factoryLineId, label: formatLineTitle(line), bars }
   })
+  const unassignedItems = timeline.value.filter((t) => !t.factoryLineId)
+  const todayUnassignedItems = unassignedItems.filter((t) => t.assignedDate === today)
+  const visibleUnassignedItems = todayUnassignedItems.length > 0 ? todayUnassignedItems : unassignedItems
+  if (visibleUnassignedItems.length > 0) {
+    rows.unshift(
+      ...visibleUnassignedItems.slice(0, 3).map((t, idx) => ({
+        id: `${UNASSIGNED_LINE_ID}-${t.orderNo ?? idx}`,
+        label: `배치 라인 미지정 ${idx + 1}`,
+        bars: [makeTimelineBar(t, idx, visibleUnassignedItems.length)],
+      }))
+    )
+  }
+  return rows
 })
+
+function makeTimelineBar(t, idx, itemCount) {
+  let left, width
+  if (t.workStartAt) {
+    const s = new Date(t.workStartAt)
+    const e = t.workEndAt ? new Date(t.workEndAt) : new Date()
+    const sMin = s.getHours() * 60 + s.getMinutes()
+    const eMin = e.getHours() * 60 + e.getMinutes()
+    const start = Math.max(sMin, DAY_START)
+    const end = Math.min(Math.max(eMin, start + 15), DAY_START + DAY_SPAN)
+    left  = `${(((start - DAY_START) / DAY_SPAN) * 100).toFixed(1)}%`
+    width = `${(((end - start) / DAY_SPAN) * 100).toFixed(1)}%`
+  } else {
+    const seg = 100 / (itemCount + 1)
+    left  = `${(seg * (idx + 1) - seg * 0.4).toFixed(1)}%`
+    width = `${(seg * 0.7).toFixed(1)}%`
+  }
+  return { left, width, tone: MATCH_TONES[t.matchingStatus] ?? 'primary', label: t.orderNo }
+}
 
 // ── Dashboard: alerts (urgent unassigned) ─────────────────────────
 const alerts = computed(() =>
-  urgentOrders.value
-    .filter((o) => o.status === 'ANALYZED')
+  allOrders.value
     .map((o) => {
       const diff    = o.dueDate ? Math.ceil((new Date(`${o.dueDate}T00:00:00`) - new Date()) / 86400000) : null
       const deadline = diff == null ? '납기 미정' : diff <= 0 ? '남기 D-DAY' : `남기 D-${diff}`
@@ -136,7 +184,6 @@ const alerts = computed(() =>
 // ── Assignment: pending orders ────────────────────────────────────
 const pendingOrders = computed(() =>
   allOrders.value
-    .filter((o) => o.status === 'ANALYZED')
     .map((o) => {
       const diff    = o.dueDate ? Math.ceil((new Date(`${o.dueDate}T00:00:00`) - new Date()) / 86400000) : null
       const deadline = diff == null ? '납기 미정' : diff <= 0 ? '남기 D-DAY' : `남기 D-${diff}`
@@ -171,6 +218,9 @@ const candidates = computed(() =>
     score:   c.score != null ? Number(c.score) : 0,
     fit:     c.suitabilityScore != null ? `${(Number(c.suitabilityScore) * 100).toFixed(1)}%` : '0.0%',
     tone:    TIER_TONES[c.tier] ?? 'soft',
+    matchingMode: c.matchingMode,
+    matchingModeLabel: MATCHING_MODE_LABELS[c.matchingMode] ?? '배정 유형 미정',
+    assignmentType: c.matchingMode === 'GROWTH_TYPE' ? 'challenge' : 'optimal',
   }))
 )
 
@@ -218,25 +268,47 @@ async function confirmAssignment({ orderId, candidateId }) {
 
 // ── Data loading ──────────────────────────────────────────────────
 async function loadData() {
-  const [summary, lines, tl, orders, urgent, cands] = await Promise.all([
+  const [summary, teamLines, allLines, tl, orders] = await Promise.all([
     getAssignmentSummary().catch(() => null),
     getMyTeamLinesSummary().catch(() => []),
+    getLinesSummary().catch(() => []),
     getAssignmentTimeline().catch(() => []),
-    getOrders().catch(() => []),
-    getUrgentOrders().catch(() => []),
-    getAssignmentCandidates().catch(() => []),
+    getUnassignedOrders().catch(() => []),
   ])
+  const lines = Array.isArray(teamLines) && teamLines.length > 0 ? teamLines : allLines
   assignmentSummary.value  = summary
   linesSummary.value       = Array.isArray(lines)  ? lines  : []
   timeline.value           = Array.isArray(tl)     ? tl     : []
   allOrders.value          = Array.isArray(orders) ? orders : []
-  urgentOrders.value       = Array.isArray(urgent) ? urgent : []
+  await loadLineWorkers(linesSummary.value)
+}
+
+async function loadLineWorkers(lines = []) {
+  const entries = await Promise.all(
+    lines.map(async (line) => {
+      const workers = await getLineWorkers(line.factoryLineId).catch(() => [])
+      return [line.factoryLineId, Array.isArray(workers) ? workers : []]
+    })
+  )
+  lineWorkers.value = Object.fromEntries(entries)
+}
+
+async function loadCandidates(orderId) {
+  if (!orderId) {
+    rawCandidates.value = []
+    return
+  }
+  const cands = await getAssignmentCandidates({ orderId }).catch(() => [])
   rawCandidates.value      = Array.isArray(cands)  ? cands  : []
 }
 
 onMounted(async () => {
   await loadData()
   selectedOrderId.value = pendingOrders.value[0]?.id ?? null
+})
+
+watch(selectedOrderId, async (orderId) => {
+  await loadCandidates(orderId)
 })
 </script>
 

--- a/src/views/worker/WorkerMyProfileView.vue
+++ b/src/views/worker/WorkerMyProfileView.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
 import { getWorkerProfileDashboard } from '@/services/workerHrApi'
 import WorkerNotificationBanner from '@/components/dashboard/common/WorkerNotificationBanner.vue'
 import WorkerOverallStatusCard from '@/components/dashboard/worker/WorkerOverallStatusCard.vue'
@@ -14,6 +15,7 @@ const workerTierMilestones = ref([])
 const workerTierChartData = ref([])
 const workerMissions = ref([])
 const workerNotification = ref(null)
+const router = useRouter()
 
 onMounted(async () => {
   try {
@@ -31,6 +33,13 @@ onMounted(async () => {
     loading.value = false
   }
 })
+
+function goNoticeBoard() {
+  router.push({
+    name: 'WorkerNoticeBoard',
+    query: workerNotification.value?.id ? { noticeId: workerNotification.value.id } : {},
+  })
+}
 </script>
 
 <template>
@@ -42,6 +51,7 @@ onMounted(async () => {
         v-if="workerNotification"
         :title="workerNotification.title"
         :description="workerNotification.description"
+        @click="goNoticeBoard"
       />
 
       <div class="worker-grid">
@@ -58,7 +68,10 @@ onMounted(async () => {
           />
         </div>
         <div class="worker-grid__missions">
-          <WorkerMissionBoard :missions="workerMissions" />
+          <WorkerMissionBoard
+            :missions="workerMissions"
+            :current-tier="workerData?.tier"
+          />
         </div>
       </div>
     </template>

--- a/src/views/worker/WorkerNoticeBoardView.vue
+++ b/src/views/worker/WorkerNoticeBoardView.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, watch, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
 import hrApi from '@/services/hrApi'
 import HRMNoticeListPanel  from '@/components/hr/common/notices/HRMNoticeListPanel.vue'
 import HRMNoticeDetailPanel from '@/components/hr/common/notices/HRMNoticeDetailPanel.vue'
@@ -37,12 +38,18 @@ const notices        = ref([])
 const selectedId     = ref(null)
 const selectedNotice = ref(null)
 const loading        = ref(true)
+const route = useRoute()
 
 async function fetchNotices() {
   try {
     const res = await hrApi.get('/api/v1/hr/notices')
     const list = res.data?.success ? res.data.data : res.data
     notices.value = (Array.isArray(list) ? list : []).map(normalizeList)
+    const queryNoticeId = route.query.noticeId ? Number(route.query.noticeId) : null
+    if (queryNoticeId && notices.value.some(notice => notice.id === queryNoticeId)) {
+      selectedId.value = queryNoticeId
+      return
+    }
     if (!selectedId.value && notices.value.length) {
       selectedId.value = notices.value[0].id
     }

--- a/src/views/worker/WorkerPointMissionView.vue
+++ b/src/views/worker/WorkerPointMissionView.vue
@@ -9,6 +9,7 @@ const loading = ref(true)
 const pointSummary = ref(null)
 const pointHistory = ref([])
 const upgradeMissions = ref([])
+const currentTier = ref('')
 
 onMounted(async () => {
   try {
@@ -16,6 +17,7 @@ onMounted(async () => {
     pointSummary.value = data.summary
     pointHistory.value = data.history
     upgradeMissions.value = data.missions
+    currentTier.value = data.currentTier
   } catch (e) {
     console.error('Failed to load point/mission data:', e)
   } finally {
@@ -33,7 +35,10 @@ onMounted(async () => {
 
       <div class="pm-grid">
         <WorkerPointAccrualHistory :history="pointHistory" />
-        <WorkerPointPerMission :missions="upgradeMissions" />
+        <WorkerPointPerMission
+          :missions="upgradeMissions"
+          :current-tier="currentTier"
+        />
       </div>
     </template>
   </div>


### PR DESCRIPTION
## 작업 내용
  - Worker/HRM/TL/DL 대시보드 및 KPI 화면의 백엔드 연동 데이터를 보강했습니다.
  - HRM 조직도 관리 화면에서 그룹/팀 편집, 부서원 표시, 부서장 지정, 팀원 추가 UX를 개선했습니다.
  - TL SCM 주문 현황에서 배정 대기 카드 버튼이 카드 밖으로 튀어나오지 않도록 레이아웃을 수정했습니다.
  - TL SCM 주문 현황의 생산중 주문 카드에 작업자 이름이 표시되도록 수정했습니다.
  - TL SCM 작업 매칭 화면의 운영 현황, 오늘 작업 타임라인, 미배정 오더 표시를 개선했습니다.
  - TL SCM 설비 현황에서 설비 선택 상태, 최근 정비 이력, 설비 목록 표시를 개선했습니다.
  - 공지 카드 클릭 시 각 역할별 공지 페이지로 이동하도록 보완했습니다.
  - Worker 작업 완료 보고 모달에서 완료 수량, 불량 수량, 품질 체크 입력 제거.
  - TL/DL 알림 목록에 x 버튼 숨김 기능 연결.
  - TL 알림 페이지 mock 보조 패널 제거.
  - TL/DL 알림 화면에서 ARRANGEMENT 배정 알림 제외.
  - TL 필터명 평가/배정을 평가로 변경.
  - Worker 대시보드 OVERALL 점수를 6개 스킬 점수 평균으로 계산하도록 변경.

  ## 검증
  - `npm run build` 성공

  ## 참고
  - 일부 SCM 운영 현황의 라인별 작업자 목록은 `worker_deployment` 데이터가 없으면 빈 배열로 응답됩니다.