### PR TITLE
refactor: HR 승인/평가 리뷰 UI 흐름 정리

### DIFF
--- a/src/components/hr/common/appeal/ReviewerAppealDetailPanel.vue
+++ b/src/components/hr/common/appeal/ReviewerAppealDetailPanel.vue
@@ -21,6 +21,11 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['approve', 'reject', 'review'])
+
+function canReview(detail, actionMode) {
+  if (!detail || !actionMode) return false
+  return detail.status !== 'COMPLETED'
+}
 </script>
 
 <template>
@@ -111,7 +116,7 @@ const emit = defineEmits(['approve', 'reject', 'review'])
           </div>
         </div>
 
-        <div v-if="actionMode" class="reviewer-appeal-detail__actions">
+        <div v-if="canReview(detail, actionMode)" class="reviewer-appeal-detail__actions">
           <template v-if="actionMode === 'tl'">
             <button class="reviewer-appeal-detail__btn reviewer-appeal-detail__btn--reject" :disabled="loading" @click="emit('reject')">
               기각

--- a/src/components/hr/common/appeal/ReviewerAppealDetailPanel.vue
+++ b/src/components/hr/common/appeal/ReviewerAppealDetailPanel.vue
@@ -1,0 +1,410 @@
+<script setup>
+import EvalDetailLayout from '@/components/hr/common/evaluation/EvalDetailLayout.vue'
+
+const props = defineProps({
+  detail: {
+    type: Object,
+    default: null,
+  },
+  roleLabel: {
+    type: String,
+    default: '평가자',
+  },
+  actionMode: {
+    type: String,
+    default: '',
+  },
+  loading: {
+    type: Boolean,
+    default: false,
+  },
+})
+
+const emit = defineEmits(['approve', 'reject', 'review'])
+</script>
+
+<template>
+  <EvalDetailLayout
+    :empty="!detail"
+    :panel-props="detail ? {
+      title: `${detail.employeeName} 신청 내역`,
+      description: `${roleLabel} 이의신청 검토`,
+      showToolbar: false,
+      showEditor: false,
+      readonly: true,
+    } : {}"
+    empty-title="이의신청을 선택하세요."
+    empty-description="좌측 목록에서 검토할 대상을 선택하면 상세 내용이 표시됩니다."
+  >
+    <template #summary>
+      <section v-if="detail" class="reviewer-appeal-detail__summary">
+        <div class="reviewer-appeal-detail__header">
+          <div>
+            <p class="reviewer-appeal-detail__eyebrow">평가 요약</p>
+            <h3 class="reviewer-appeal-detail__title">평가 내용 및 점수</h3>
+          </div>
+          <span
+            class="reviewer-appeal-detail__status"
+            :class="`reviewer-appeal-detail__status--${detail.status.toLowerCase()}`"
+          >
+            {{ detail.statusLabel }}
+          </span>
+        </div>
+
+        <div class="reviewer-appeal-detail__scores">
+          <div class="reviewer-appeal-detail__score reviewer-appeal-detail__score--quant">
+            <strong>{{ detail.quantScoreLabel ?? '-' }}</strong>
+            <span>정량</span>
+          </div>
+          <div class="reviewer-appeal-detail__score">
+            <strong>{{ detail.firstScoreLabel }}</strong>
+            <span>1차</span>
+          </div>
+          <div class="reviewer-appeal-detail__score reviewer-appeal-detail__score--second">
+            <strong>{{ detail.secondScoreLabel }}</strong>
+            <span>2차</span>
+          </div>
+        </div>
+
+        <div class="reviewer-appeal-detail__comment-card">
+          <p class="reviewer-appeal-detail__comment-label">팀리더 정성 평가 (1차)</p>
+          <p class="reviewer-appeal-detail__comment">
+            {{ detail.firstStageComment || '1차 평가 내용이 없습니다.' }}
+          </p>
+        </div>
+
+        <div class="reviewer-appeal-detail__comment-card reviewer-appeal-detail__comment-card--second">
+          <p class="reviewer-appeal-detail__comment-label reviewer-appeal-detail__comment-label--second">부서장 정성 평가 (2차)</p>
+          <p class="reviewer-appeal-detail__comment">
+            {{ detail.secondStageComment || '2차 평가 내용이 없습니다.' }}
+          </p>
+        </div>
+      </section>
+    </template>
+
+    <template #footer>
+      <div v-if="detail" class="reviewer-appeal-detail__footer">
+        <div class="reviewer-appeal-detail__request-card">
+          <div class="reviewer-appeal-detail__request-header">
+            <div>
+              <p class="reviewer-appeal-detail__request-eyebrow">이의신청 정보</p>
+              <h4 class="reviewer-appeal-detail__request-heading">신청 내용 확인</h4>
+            </div>
+            <span class="reviewer-appeal-detail__request-badge">{{ detail.appealTypeLabel }}</span>
+          </div>
+
+          <div class="reviewer-appeal-detail__meta">
+            <div class="reviewer-appeal-detail__meta-item">
+              <p class="reviewer-appeal-detail__meta-label">대상 평가기간</p>
+              <p class="reviewer-appeal-detail__meta-value">{{ detail.periodLabel }}</p>
+            </div>
+            <div class="reviewer-appeal-detail__meta-item">
+              <p class="reviewer-appeal-detail__meta-label">이의 유형</p>
+              <p class="reviewer-appeal-detail__meta-value">{{ detail.appealTypeLabel }}</p>
+            </div>
+          </div>
+
+          <div class="reviewer-appeal-detail__request-body">
+            <p class="reviewer-appeal-detail__meta-label">이의신청 내용</p>
+            <strong class="reviewer-appeal-detail__request-title">{{ detail.title }}</strong>
+            <p class="reviewer-appeal-detail__request-content">{{ detail.content }}</p>
+          </div>
+        </div>
+
+        <div v-if="actionMode" class="reviewer-appeal-detail__actions">
+          <template v-if="actionMode === 'tl'">
+            <button class="reviewer-appeal-detail__btn reviewer-appeal-detail__btn--reject" :disabled="loading" @click="emit('reject')">
+              기각
+            </button>
+            <button class="reviewer-appeal-detail__btn reviewer-appeal-detail__btn--approve" :disabled="loading" @click="emit('review')">
+              검토
+            </button>
+          </template>
+          <template v-else-if="actionMode === 'dl'">
+            <button class="reviewer-appeal-detail__btn reviewer-appeal-detail__btn--reject" :disabled="loading" @click="emit('reject')">
+              일부 인용
+            </button>
+            <button class="reviewer-appeal-detail__btn reviewer-appeal-detail__btn--approve" :disabled="loading" @click="emit('review')">
+              검토
+            </button>
+          </template>
+        </div>
+      </div>
+    </template>
+  </EvalDetailLayout>
+</template>
+
+<style scoped>
+.reviewer-appeal-detail__summary {
+  display: grid;
+  gap: 14px;
+  margin-bottom: 16px;
+  padding: 18px;
+  border: 1px solid #dcd6ff;
+  border-radius: 20px;
+  background: #faf8ff;
+}
+
+.reviewer-appeal-detail__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.reviewer-appeal-detail__eyebrow {
+  margin: 0 0 4px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--color-primary-500);
+}
+
+.reviewer-appeal-detail__title {
+  margin: 0;
+  font-size: 18px;
+  color: var(--color-primary-800);
+}
+
+.reviewer-appeal-detail__scores {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.reviewer-appeal-detail__score {
+  min-width: 72px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid #e1dbff;
+  text-align: center;
+}
+
+.reviewer-appeal-detail__score strong {
+  display: block;
+  font-size: 20px;
+  color: var(--color-primary-800);
+}
+
+.reviewer-appeal-detail__score span {
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+.reviewer-appeal-detail__score--quant {
+  border-color: #b9f0df;
+}
+
+.reviewer-appeal-detail__score--quant strong {
+  color: #0d7f63;
+}
+
+.reviewer-appeal-detail__score--second {
+  border-color: #bdd5f8;
+}
+
+.reviewer-appeal-detail__score--second strong {
+  color: #1d5dbf;
+}
+
+.reviewer-appeal-detail__comment-card {
+  padding: 14px 16px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid #e8e2ff;
+}
+
+.reviewer-appeal-detail__comment-card--second {
+  border-color: #c7deff;
+}
+
+.reviewer-appeal-detail__comment-label {
+  margin: 0 0 8px;
+  font-size: 12px;
+  font-weight: 700;
+  color: #6a57d3;
+}
+
+.reviewer-appeal-detail__comment-label--second {
+  color: #3a7bd5;
+}
+
+.reviewer-appeal-detail__comment {
+  margin: 0;
+  line-height: 1.7;
+  color: var(--color-primary-800);
+}
+
+.reviewer-appeal-detail__status {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.reviewer-appeal-detail__status--receiving {
+  background: #eef2ff;
+  color: #4f46e5;
+}
+
+.reviewer-appeal-detail__status--reviewing {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.reviewer-appeal-detail__status--completed {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.reviewer-appeal-detail__footer {
+  display: grid;
+  gap: 14px;
+}
+
+.reviewer-appeal-detail__request-card {
+  display: grid;
+  gap: 14px;
+  padding: 18px;
+  border: 1px solid #e8e2ff;
+  border-radius: 20px;
+  background: linear-gradient(180deg, rgba(250, 248, 255, 0.95) 0%, rgba(255, 255, 255, 0.98) 100%);
+}
+
+.reviewer-appeal-detail__request-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.reviewer-appeal-detail__request-eyebrow {
+  margin: 0 0 4px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--color-primary-500);
+}
+
+.reviewer-appeal-detail__request-heading {
+  margin: 0;
+  font-size: 18px;
+  color: var(--color-primary-800);
+}
+
+.reviewer-appeal-detail__request-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 30px;
+  padding: 0 12px;
+  border-radius: 999px;
+  background: #f1edff;
+  color: #5f50d6;
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.reviewer-appeal-detail__meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.reviewer-appeal-detail__meta-item {
+  display: grid;
+  gap: 6px;
+  padding: 18px 20px;
+  border-radius: 18px;
+  background: #faf8ff;
+  border: 1px solid var(--color-border-soft);
+}
+
+.reviewer-appeal-detail__meta-label {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--color-text-muted);
+}
+
+.reviewer-appeal-detail__meta-value {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--color-primary-800);
+}
+
+.reviewer-appeal-detail__request-body {
+  display: grid;
+  gap: 8px;
+  padding: 16px 18px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.88);
+  border: 1px solid #eee9ff;
+}
+
+.reviewer-appeal-detail__request-title {
+  display: block;
+  color: var(--color-primary-800);
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.reviewer-appeal-detail__request-content {
+  margin: 0;
+  line-height: 1.7;
+  color: #564d7a;
+  white-space: pre-wrap;
+  word-break: keep-all;
+}
+
+.reviewer-appeal-detail__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding-top: 4px;
+}
+
+.reviewer-appeal-detail__btn {
+  border: 0;
+  border-radius: 12px;
+  padding: 12px 16px;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.reviewer-appeal-detail__btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.reviewer-appeal-detail__btn--reject {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.reviewer-appeal-detail__btn--approve {
+  background: #e9e5ff;
+  color: #5b21b6;
+}
+
+@media (max-width: 960px) {
+  .reviewer-appeal-detail__header {
+    flex-direction: column;
+  }
+
+  .reviewer-appeal-detail__request-header,
+  .reviewer-appeal-detail__meta {
+    grid-template-columns: 1fr;
+    display: grid;
+  }
+
+  .reviewer-appeal-detail__request-badge {
+    justify-self: start;
+  }
+}
+</style>

--- a/src/components/hr/common/appeal/ReviewerAppealListPanel.vue
+++ b/src/components/hr/common/appeal/ReviewerAppealListPanel.vue
@@ -1,0 +1,95 @@
+<script setup>
+import { computed, ref, watch } from 'vue'
+import EvaluationMemberCard from '@/components/hr/common/evaluation/EvaluationMemberCard.vue'
+import EvalListLayout from '@/components/hr/common/evaluation/EvalListLayout.vue'
+import { formatMemberMeta } from '@/utils/hrListFormat'
+
+const props = defineProps({
+  appeals: {
+    type: Array,
+    default: () => [],
+  },
+  selectedId: {
+    type: [Number, String],
+    default: null,
+  },
+})
+
+const emit = defineEmits(['select'])
+
+const search = ref('')
+const AVATAR_TONES = ['purple', 'green', 'gold']
+const filteredAppeals = computed(() => {
+  const keyword = search.value.trim().toLowerCase()
+
+  return props.appeals.filter((appeal) => {
+    const matchesKeyword =
+      !keyword
+      || appeal.employeeName?.toLowerCase().includes(keyword)
+      || appeal.title?.toLowerCase().includes(keyword)
+      || appeal.periodLabel?.toLowerCase().includes(keyword)
+
+    return matchesKeyword
+  })
+})
+
+const cardAppeals = computed(() =>
+  filteredAppeals.value.map((appeal, index) => ({
+    ...appeal,
+    avatar: appeal.employeeName?.[0] ?? '?',
+    avatarTone: AVATAR_TONES[index % AVATAR_TONES.length],
+    tier: appeal.employeeTier ?? '',
+    meta: formatMemberMeta(appeal.employeeCode, appeal.departmentName, appeal.teamName),
+    cardStatus: appeal.status === 'COMPLETED' ? 'submitted' : 'in_progress',
+    cardDate: appeal.status === 'SUBMITTED'
+      ? '검토 대기'
+      : appeal.status === 'RECEIVING'
+        ? '접수 완료'
+        : appeal.status === 'REVIEWING'
+          ? '검토중'
+          : '처리 완료',
+  })),
+)
+
+watch(filteredAppeals, (appeals) => {
+  if (!appeals.length) return
+  const hasSelected = appeals.some((appeal) => String(appeal.appealId) === String(props.selectedId))
+  if (!hasSelected) {
+    emit('select', appeals[0].appealId)
+  }
+}, { immediate: true })
+</script>
+
+<template>
+  <EvalListLayout
+    eyebrow="이의신청 현황"
+    title="신청 내역"
+    :total-label="`총 ${appeals.length}건`"
+    search-aria-label="이의신청 검색"
+    search-placeholder="이름으로 검색"
+    :search-value="search"
+    :has-items="cardAppeals.length > 0"
+    empty-title="확인할 이의신청이 없습니다."
+    empty-description="현재 차수에서 검토할 대상이 생기면 이곳에 표시됩니다."
+    @update:search-value="search = $event"
+  >
+    <template #default>
+      <EvaluationMemberCard
+        v-for="appeal in cardAppeals"
+        :key="appeal.appealId"
+        :member-id="appeal.appealId"
+        :name="appeal.employeeName"
+        :avatar="appeal.avatar"
+        :avatar-tone="appeal.avatarTone"
+        :tier="appeal.tier"
+        :meta="appeal.meta"
+        :status="appeal.cardStatus"
+        :status-date="appeal.cardDate"
+        :selected="String(appeal.appealId) === String(selectedId)"
+        @select="emit('select', appeal.appealId)"
+      />
+    </template>
+  </EvalListLayout>
+</template>
+
+<style scoped></style>

--- a/src/components/hr/common/evaluation/AiEvaluationFormPanel.vue
+++ b/src/components/hr/common/evaluation/AiEvaluationFormPanel.vue
@@ -52,6 +52,14 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  showToolbar: {
+    type: Boolean,
+    default: true,
+  },
+  showEditor: {
+    type: Boolean,
+    default: true,
+  },
 })
 
 const emit = defineEmits([
@@ -88,7 +96,7 @@ function handleFileChange(event) {
 
     <slot name="summary" />
 
-    <div class="evaluation-form-panel__toolbar">
+    <div v-if="showToolbar" class="evaluation-form-panel__toolbar">
       <div class="evaluation-form-panel__toolbar-left">
         <button
           type="button"
@@ -128,6 +136,7 @@ function handleFileChange(event) {
     </div>
 
     <textarea
+      v-if="showEditor"
       class="evaluation-form-panel__editor"
       :class="{ 'evaluation-form-panel__editor--readonly': readonly }"
       :value="modelValue"
@@ -270,16 +279,16 @@ function handleFileChange(event) {
 }
 
 .evaluation-form-panel__editor--readonly {
-  background: linear-gradient(135deg, #f8f7ff 0%, #f1effe 100%);
-  border-color: #e0dbff;
-  color: #6e68b2;
+  background: #faf8ff;
+  border-color: #dcd6ff;
+  color: var(--color-primary-800);
   cursor: default;
   resize: none;
   outline: none;
 }
 
 .evaluation-form-panel__editor--readonly:focus {
-  border-color: #e0dbff;
+  border-color: #dcd6ff;
   outline: none;
   box-shadow: none;
 }

--- a/src/components/hr/common/evaluation/EvalDetailLayout.vue
+++ b/src/components/hr/common/evaluation/EvalDetailLayout.vue
@@ -1,0 +1,70 @@
+<script setup>
+import { BaseEmptyState } from '@/components/common/base'
+import AiEvaluationFormPanel from '@/components/hr/common/evaluation/AiEvaluationFormPanel.vue'
+
+defineProps({
+  panelProps: {
+    type: Object,
+    default: () => ({}),
+  },
+  empty: {
+    type: Boolean,
+    default: false,
+  },
+  emptyTitle: {
+    type: String,
+    default: '대상을 선택하세요.',
+  },
+  emptyDescription: {
+    type: String,
+    default: '좌측 목록에서 대상을 선택하면 상세 내용이 표시됩니다.',
+  },
+  emptyIcon: {
+    type: String,
+    default: '✋',
+  },
+})
+</script>
+
+<template>
+  <AiEvaluationFormPanel
+    v-if="!empty"
+    class="unified-detail-panel"
+    v-bind="panelProps"
+  >
+    <template v-if="$slots.summary" #summary>
+      <slot name="summary" />
+    </template>
+
+    <template v-if="$slots.footer" #footer>
+      <slot name="footer" />
+    </template>
+  </AiEvaluationFormPanel>
+
+  <section v-else class="unified-detail-panel unified-detail-panel--empty">
+    <BaseEmptyState
+      :icon="emptyIcon"
+      :title="emptyTitle"
+      :description="emptyDescription"
+    />
+  </section>
+</template>
+
+<style scoped>
+.unified-detail-panel {
+  overflow-y: auto;
+  min-height: 600px;
+  max-height: calc(100vh - 200px);
+}
+
+.unified-detail-panel--empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 24px;
+  background: var(--color-bg-surface);
+  box-sizing: border-box;
+}
+</style>

--- a/src/components/hr/common/evaluation/EvalListLayout.vue
+++ b/src/components/hr/common/evaluation/EvalListLayout.vue
@@ -1,0 +1,211 @@
+<script setup>
+import { BaseEmptyState } from '@/components/common/base'
+
+defineProps({
+  eyebrow: {
+    type: String,
+    required: true,
+  },
+  title: {
+    type: String,
+    required: true,
+  },
+  totalLabel: {
+    type: String,
+    required: true,
+  },
+  searchPlaceholder: {
+    type: String,
+    default: '이름으로 검색',
+  },
+  searchValue: {
+    type: String,
+    default: '',
+  },
+  searchAriaLabel: {
+    type: String,
+    default: '목록 검색',
+  },
+  emptyTitle: {
+    type: String,
+    required: true,
+  },
+  emptyDescription: {
+    type: String,
+    required: true,
+  },
+  hasItems: {
+    type: Boolean,
+    required: true,
+  },
+})
+
+const emit = defineEmits(['update:searchValue'])
+</script>
+
+<template>
+  <section class="unified-list-panel">
+    <div class="unified-list-panel__header">
+      <div>
+        <p class="unified-list-panel__eyebrow">{{ eyebrow }}</p>
+        <h3 class="unified-list-panel__title">{{ title }}</h3>
+      </div>
+      <span class="unified-list-panel__total">{{ totalLabel }}</span>
+    </div>
+
+    <div v-if="$slots.filters" class="unified-list-panel__filters">
+      <slot name="filters" />
+    </div>
+
+    <label class="unified-list-panel__search" :aria-label="searchAriaLabel">
+      <span class="unified-list-panel__search-icon" aria-hidden="true">⌕</span>
+      <input
+        :value="searchValue"
+        type="text"
+        class="unified-list-panel__search-input"
+        :placeholder="searchPlaceholder"
+        @input="emit('update:searchValue', $event.target.value)"
+      />
+    </label>
+
+    <div v-if="hasItems" class="unified-list-panel__list">
+      <slot />
+    </div>
+
+    <BaseEmptyState
+      v-else
+      icon="⌕"
+      :title="emptyTitle"
+      :description="emptyDescription"
+      class="unified-list-panel__empty"
+    />
+
+    <div v-if="$slots.pagination" class="unified-list-panel__pagination">
+      <slot name="pagination" />
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.unified-list-panel {
+  display: grid;
+  grid-template-rows: auto auto auto minmax(0, 1fr) auto;
+  gap: 12px;
+  padding: 20px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 24px;
+  background: var(--color-bg-surface);
+  height: 100%;
+  min-height: 600px;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+.unified-list-panel__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.unified-list-panel__eyebrow {
+  margin: 0 0 4px;
+  font-size: var(--font-size-xs-plus);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary-500);
+}
+
+.unified-list-panel__title {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary-800);
+}
+
+.unified-list-panel__total {
+  display: inline-flex;
+  align-items: center;
+  min-height: 32px;
+  padding: 0 12px;
+  border-radius: 999px;
+  background: var(--color-primary-100);
+  color: var(--color-primary-700);
+  font-size: var(--font-size-xs-plus);
+  font-weight: var(--font-weight-semibold);
+  white-space: nowrap;
+}
+
+.unified-list-panel__filters {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.unified-list-panel__search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  padding: 10px 12px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 14px;
+  background: var(--color-bg-surface-muted);
+}
+
+.unified-list-panel__search-icon {
+  flex-shrink: 0;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-base-plus);
+}
+
+.unified-list-panel__search-input {
+  width: 100%;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  outline: none;
+  font-size: var(--font-size-sm);
+  color: var(--color-primary-800);
+}
+
+.unified-list-panel__search-input::placeholder {
+  color: var(--color-text-muted);
+}
+
+.unified-list-panel__list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.unified-list-panel__empty {
+  align-self: center;
+}
+
+.unified-list-panel__pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 34px;
+}
+
+@media (max-width: 720px) {
+  .unified-list-panel {
+    padding: 16px;
+  }
+
+  .unified-list-panel__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .unified-list-panel__filters,
+  .unified-list-panel__pagination {
+    flex-wrap: wrap;
+  }
+}
+</style>

--- a/src/components/hr/common/evaluation/EvaluationMemberCard.vue
+++ b/src/components/hr/common/evaluation/EvaluationMemberCard.vue
@@ -76,7 +76,7 @@ const avatarStyle = computed(() => (props.avatarColor ? { background: props.avat
 }
 
 .evaluation-member-card:hover {
-  transform: translateY(-1px);
+  transform: none;
 }
 
 .evaluation-member-card--submitted {
@@ -86,8 +86,8 @@ const avatarStyle = computed(() => (props.avatarColor ? { background: props.avat
 
 .evaluation-member-card--in_progress,
 .evaluation-member-card--in-progress {
-  background: #f1ecff;
-  border-color: #d4c8ff;
+  background: #f7f4ff;
+  border-color: #e5dfff;
 }
 
 .evaluation-member-card--not_started,

--- a/src/components/hr/common/evaluation/EvaluationMemberCard.vue
+++ b/src/components/hr/common/evaluation/EvaluationMemberCard.vue
@@ -49,12 +49,15 @@ const avatarStyle = computed(() => (props.avatarColor ? { background: props.avat
           </span>
         </div>
         <p v-if="meta" class="evaluation-member-card__meta">{{ meta }}</p>
-        <span v-if="statusLabel" class="evaluation-member-card__status" :class="`evaluation-member-card__status--${status}`">
-          {{ statusLabel }}
-        </span>
       </div>
     </div>
-    <span v-if="statusDate" class="evaluation-member-card__date">{{ statusDate }}</span>
+    <span
+      v-if="statusDate"
+      class="evaluation-member-card__date"
+      :class="`evaluation-member-card__date--${status}`"
+    >
+      {{ statusDate }}
+    </span>
   </article>
 </template>
 
@@ -185,28 +188,6 @@ const avatarStyle = computed(() => (props.avatarColor ? { background: props.avat
   word-break: keep-all;
 }
 
-.evaluation-member-card__status {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-semibold);
-}
-
-.evaluation-member-card__status--submitted {
-  color: #168765;
-}
-
-.evaluation-member-card__status--in_progress,
-.evaluation-member-card__status--in-progress {
-  color: #6a57d3;
-}
-
-.evaluation-member-card__status--not_started,
-.evaluation-member-card__status--not-started {
-  color: #7c8397;
-}
-
 .evaluation-member-card__date {
   display: inline-flex;
   align-items: center;
@@ -221,6 +202,23 @@ const avatarStyle = computed(() => (props.avatarColor ? { background: props.avat
   font-weight: var(--font-weight-semibold);
   white-space: nowrap;
   flex-shrink: 0;
+}
+
+.evaluation-member-card__date--submitted {
+  background: #e8faf4;
+  color: #1d7f5b;
+}
+
+.evaluation-member-card__date--in_progress,
+.evaluation-member-card__date--in-progress {
+  background: #f1edff;
+  color: #5f50d6;
+}
+
+.evaluation-member-card__date--not_started,
+.evaluation-member-card__date--not-started {
+  background: #eef1f6;
+  color: #7c8798;
 }
 
 @media (max-width: 720px) {

--- a/src/components/hr/common/evaluation/ListFilterDropdown.vue
+++ b/src/components/hr/common/evaluation/ListFilterDropdown.vue
@@ -1,0 +1,161 @@
+<script setup>
+defineProps({
+  label: {
+    type: String,
+    required: true,
+  },
+  valueLabel: {
+    type: String,
+    required: true,
+  },
+  options: {
+    type: Array,
+    default: () => [],
+  },
+  modelValue: {
+    type: String,
+    default: '',
+  },
+  open: {
+    type: Boolean,
+    default: false,
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+})
+
+const emit = defineEmits(['toggle', 'select'])
+</script>
+
+<template>
+  <div class="list-filter-dropdown">
+    <button
+      type="button"
+      class="list-filter-dropdown__button"
+      :class="{ 'list-filter-dropdown__button--disabled': disabled }"
+      :disabled="disabled"
+      @click="emit('toggle')"
+    >
+      <span class="list-filter-dropdown__label">{{ label }}: {{ valueLabel }}</span>
+      <span class="list-filter-dropdown__chevron" :class="{ 'list-filter-dropdown__chevron--open': open }">▾</span>
+    </button>
+    <ul v-if="open && !disabled" class="list-filter-dropdown__menu">
+      <li
+        v-for="option in options"
+        :key="option.value"
+        class="list-filter-dropdown__option"
+        :class="{ 'list-filter-dropdown__option--active': modelValue === option.value }"
+        @click="emit('select', option.value)"
+      >
+        {{ option.label }}
+      </li>
+    </ul>
+  </div>
+</template>
+
+<style scoped>
+.list-filter-dropdown {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+}
+
+.list-filter-dropdown__button {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 100%;
+  height: 38px;
+  padding: 0 36px 0 14px;
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-default);
+  border-radius: 12px;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-primary-700);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  position: relative;
+  box-sizing: border-box;
+  outline: none;
+  transition:
+    border-color 0.16s ease,
+    box-shadow 0.16s ease,
+    background-color 0.16s ease;
+}
+
+.list-filter-dropdown__button:hover:not(:disabled) {
+  border-color: var(--color-border-strong);
+  background: var(--color-bg-surface);
+}
+
+.list-filter-dropdown__button:focus-visible:not(:disabled) {
+  border-color: var(--color-primary-500);
+  box-shadow: 0 0 0 3px rgba(91, 80, 214, 0.08);
+}
+
+.list-filter-dropdown__button[disabled] {
+  opacity: 1;
+}
+
+.list-filter-dropdown__button--disabled {
+  cursor: not-allowed;
+  color: var(--color-text-muted);
+  background: var(--color-bg-surface-muted);
+}
+
+.list-filter-dropdown__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.list-filter-dropdown__chevron {
+  position: absolute;
+  right: 10px;
+  flex-shrink: 0;
+  color: var(--color-text-muted);
+  transition: transform 0.2s ease;
+}
+
+.list-filter-dropdown__chevron--open {
+  transform: rotate(180deg);
+}
+
+.list-filter-dropdown__menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 10;
+  list-style: none;
+  width: 100%;
+  padding: 0;
+  margin: 0;
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-default);
+  border-radius: 14px;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+.list-filter-dropdown__option {
+  padding: 10px 14px;
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  color: var(--color-text-default);
+}
+
+.list-filter-dropdown__option:hover {
+  background: var(--color-primary-100);
+}
+
+.list-filter-dropdown__option--active {
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary-700);
+  background: var(--color-primary-100);
+}
+</style>

--- a/src/components/hr/common/evaluation/ListPagination.vue
+++ b/src/components/hr/common/evaluation/ListPagination.vue
@@ -1,0 +1,47 @@
+<script setup>
+defineProps({
+  currentPage: {
+    type: Number,
+    required: true,
+  },
+  totalPages: {
+    type: Number,
+    required: true,
+  },
+})
+
+const emit = defineEmits(['change'])
+</script>
+
+<template>
+  <button
+    v-for="page in totalPages"
+    :key="page"
+    type="button"
+    class="list-pagination__page"
+    :class="{ 'list-pagination__page--active': page === currentPage }"
+    @click="emit('change', page)"
+  >
+    {{ page }}
+  </button>
+</template>
+
+<style scoped>
+.list-pagination__page {
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-surface);
+  color: var(--color-primary-700);
+  font-size: var(--font-size-xs-plus);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+}
+
+.list-pagination__page--active {
+  border-color: var(--color-primary-600);
+  background: var(--color-primary-600);
+  color: var(--color-text-inverse);
+}
+</style>

--- a/src/components/hr/departmentleader/second-evaluation/DepartmentLeaderEvalFormPanel.vue
+++ b/src/components/hr/departmentleader/second-evaluation/DepartmentLeaderEvalFormPanel.vue
@@ -1,12 +1,15 @@
 <script setup>
 import { computed, onBeforeUnmount, ref, watch } from 'vue'
-import AiEvaluationFormPanel from '@/components/hr/common/evaluation/AiEvaluationFormPanel.vue'
 import EvaluationGuideModal from '@/components/hr/common/evaluation/EvaluationGuideModal.vue'
 import DepartmentLeaderFirstEvaluationSummary from './DepartmentLeaderFirstEvaluationSummary.vue'
+import EvalDetailLayout from '@/components/hr/common/evaluation/EvalDetailLayout.vue'
 
 const props = defineProps({
   member: { type: Object, default: null },
   readonly: { type: Boolean, default: false },
+  appealInfo: { type: Object, default: null },
+  progressLabel: { type: String, default: '2차 평가 작성 현황' },
+  submitLabel: { type: String, default: '최종 제출' },
 })
 
 const emit = defineEmits(['save', 'submit'])
@@ -145,20 +148,21 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <AiEvaluationFormPanel
+  <EvalDetailLayout
     v-if="member"
-    class="department-evaluation-form-panel"
-    :title="`${member.name} 2차 평가 작성`"
-    :description="`${member.name} (${member.code}) 2차 평가 내용을 음성으로 작성하고 텍스트로 변환할 수 있습니다.`"
-    :model-value="draftText"
-    :notice-text="'팀리더 1차 평가 내용과 AI 권고 점수는 참고 자료입니다. 음성 입력 또는 파일 업로드로 초안을 만든 뒤 아래 편집 영역에서 2차 평가 문장을 직접 완성하세요.'"
-    :editor-placeholder="'2차 평가 의견을 입력하세요. 1차 평가 내용 검토, 종합 판단, 보완 의견이 드러나도록 작성합니다.'"
-    :recording-state="recordingState"
-    :uploaded-file-name="uploadedFileName"
-    :show-guide-button="true"
-    :guide-button-label="'작성 가이드'"
-    :guide-active="guideOpen"
-    :readonly="readonly"
+    :panel-props="{
+      title: `${member.name} 2차 평가 작성`,
+      description: `${member.name} (${member.code}) 2차 평가 내용을 음성으로 작성하고 텍스트로 변환할 수 있습니다.`,
+      modelValue: draftText,
+      noticeText: '팀리더 1차 평가 내용과 AI 권고 점수는 참고 자료입니다. 음성 입력 또는 파일 업로드로 초안을 만든 뒤 아래 편집 영역에서 2차 평가 문장을 직접 완성하세요.',
+      editorPlaceholder: '2차 평가 의견을 입력하세요. 1차 평가 내용 검토, 종합 판단, 보완 의견이 드러나도록 작성합니다.',
+      recordingState,
+      uploadedFileName,
+      showGuideButton: true,
+      guideButtonLabel: '작성 가이드',
+      guideActive: guideOpen,
+      readonly,
+    }"
     @update:model-value="draftText = $event"
     @voice-input="handleVoiceInput"
     @file-selected="handleFileChange"
@@ -166,7 +170,26 @@ onBeforeUnmount(() => {
     @toggle-guide="guideOpen = !guideOpen"
   >
     <template #summary>
-      <DepartmentLeaderFirstEvaluationSummary :summary="member.firstEvaluationSummary" />
+      <div class="eval-form__summary-stack">
+        <DepartmentLeaderFirstEvaluationSummary :summary="member.firstEvaluationSummary" />
+        <section v-if="appealInfo" class="eval-form__appeal-card">
+          <div class="eval-form__appeal-meta">
+            <div class="eval-form__appeal-meta-item">
+              <p class="eval-form__appeal-eyebrow">대상 평가기간</p>
+              <strong>{{ appealInfo.periodLabel }}</strong>
+            </div>
+            <div class="eval-form__appeal-meta-item">
+              <p class="eval-form__appeal-eyebrow">이의 유형</p>
+              <strong>{{ appealInfo.typeLabel }}</strong>
+            </div>
+          </div>
+          <div class="eval-form__appeal-body">
+            <p class="eval-form__appeal-eyebrow">이의신청 내용</p>
+            <strong>{{ appealInfo.title }}</strong>
+            <p class="eval-form__appeal-copy">{{ appealInfo.content }}</p>
+          </div>
+        </section>
+      </div>
     </template>
 
     <template #footer>
@@ -175,7 +198,7 @@ onBeforeUnmount(() => {
           class="eval-form__submit-hint"
           :class="{ 'eval-form__submit-hint--submitted': readonly }"
         >
-          <strong>2차 평가 작성 현황</strong>
+          <strong>{{ progressLabel }}</strong>
           <span>{{ `${draftText.trim().length}자 입력 완료` }}</span>
           <span v-if="member.expectedScore != null" class="eval-form__score-hint">
             예상 점수: {{ member.expectedScore }}점
@@ -190,46 +213,24 @@ onBeforeUnmount(() => {
             :disabled="!canSubmit"
             @click="emit('submit', { draftText, inputMethod })"
           >
-            최종 제출
+            {{ submitLabel }}
           </button>
         </template>
       </div>
     </template>
-  </AiEvaluationFormPanel>
+  </EvalDetailLayout>
 
   <EvaluationGuideModal :open="guideOpen" @close="guideOpen = false" />
 
-  <section v-if="!member" class="eval-form eval-form--empty">
-    <p>좌측 목록에서 팀원을 선택하세요.</p>
-  </section>
+  <EvalDetailLayout
+    v-if="!member"
+    :empty="true"
+    empty-title="팀원을 선택하세요."
+    empty-description="좌측 목록에서 팀원을 선택하면 2차 평가 상세가 표시됩니다."
+  />
 </template>
 
 <style scoped>
-.eval-form {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-  padding: 24px;
-  border: 1px solid var(--color-border-default);
-  border-radius: 24px;
-  background: var(--color-bg-surface);
-  overflow-y: auto;
-  max-height: calc(100vh - 200px);
-}
-
-.eval-form--empty {
-  align-items: center;
-  justify-content: center;
-  color: var(--color-text-muted);
-  font-size: var(--font-size-base);
-}
-
-.department-evaluation-form-panel {
-  overflow-y: auto;
-  min-height: 600px;
-  max-height: calc(100vh - 200px);
-}
-
 .eval-form__actions {
   display: flex;
   align-items: center;
@@ -237,6 +238,58 @@ onBeforeUnmount(() => {
   justify-content: flex-end;
   padding-top: 4px;
   flex-wrap: wrap;
+}
+
+.eval-form__summary-stack {
+  display: grid;
+  gap: 14px;
+}
+
+.eval-form__appeal-card {
+  display: grid;
+  gap: 14px;
+  padding: 16px 18px;
+  border-radius: 18px;
+  border: 1px solid #e8e2ff;
+  background: #faf8ff;
+}
+
+.eval-form__appeal-meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.eval-form__appeal-meta-item {
+  display: grid;
+  gap: 6px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid var(--color-border-soft);
+}
+
+.eval-form__appeal-eyebrow {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--color-text-muted);
+}
+
+.eval-form__appeal-body {
+  display: grid;
+  gap: 8px;
+  padding: 16px 18px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid var(--color-border-soft);
+}
+
+.eval-form__appeal-copy {
+  margin: 0;
+  line-height: 1.7;
+  color: var(--color-primary-800);
+  white-space: pre-wrap;
 }
 
 .eval-form__submit-hint {
@@ -295,5 +348,11 @@ onBeforeUnmount(() => {
   color: var(--color-text-muted);
   cursor: not-allowed;
   opacity: 1;
+}
+
+@media (max-width: 900px) {
+  .eval-form__appeal-meta {
+    grid-template-columns: 1fr;
+  }
 }
 </style>

--- a/src/components/hr/departmentleader/second-evaluation/DepartmentLeaderEvalMemberListPanel.vue
+++ b/src/components/hr/departmentleader/second-evaluation/DepartmentLeaderEvalMemberListPanel.vue
@@ -1,30 +1,28 @@
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
 import EvaluationMemberCard from '@/components/hr/common/evaluation/EvaluationMemberCard.vue'
+import ListPagination from '@/components/hr/common/evaluation/ListPagination.vue'
+import EvalListLayout from '@/components/hr/common/evaluation/EvalListLayout.vue'
 
 const props = defineProps({
   members: { type: Array, default: () => [] },
   selectedId: { type: Number, default: null },
+  pageSize: { type: Number, default: 4 },
 })
 
 const emit = defineEmits(['select'])
 
-const statusConfig = {
-  submitted: { label: '제출 완료' },
-  in_progress: { label: '작성 중' },
-  not_started: { label: '미작성' },
-}
-
 const search = ref('')
-const teamFilter   = ref('전체')
+const teamFilter = ref('전체')
 const statusFilter = ref('전체')
-const teamDropdownOpen   = ref(false)
+const currentPage = ref(1)
+const teamDropdownOpen = ref(false)
 const statusDropdownOpen = ref(false)
 
 const teams = computed(() => ['전체', ...new Set(props.members.map((m) => m.team).filter(Boolean))])
 const statusOptions = [
-  { value: '전체',       label: '전체' },
-  { value: 'submitted',  label: '제출 완료' },
+  { value: '전체', label: '전체' },
+  { value: 'submitted', label: '제출 완료' },
   { value: 'in_progress', label: '작성 중' },
   { value: 'not_started', label: '미작성' },
 ]
@@ -32,12 +30,29 @@ const statusOptions = [
 const filtered = computed(() =>
   props.members.filter((m) => {
     const keyword = search.value.trim()
-    const matchTeam   = teamFilter.value   === '전체' || m.team   === teamFilter.value
+    const matchTeam = teamFilter.value === '전체' || m.team === teamFilter.value
     const matchStatus = statusFilter.value === '전체' || m.status === statusFilter.value
-    const matchSearch = !keyword || m.name.includes(keyword) || m.team?.includes(keyword)
+    const matchSearch = !keyword || m.name.includes(keyword)
     return matchTeam && matchStatus && matchSearch
   })
 )
+
+const totalPages = computed(() => Math.max(1, Math.ceil(filtered.value.length / props.pageSize)))
+
+const pagedMembers = computed(() => {
+  const startIndex = (currentPage.value - 1) * props.pageSize
+  return filtered.value.slice(startIndex, startIndex + props.pageSize)
+})
+
+watch([search, teamFilter, statusFilter], () => {
+  currentPage.value = 1
+})
+
+watch(totalPages, (pageCount) => {
+  if (currentPage.value > pageCount) {
+    currentPage.value = pageCount
+  }
+})
 
 function selectTeam(t) {
   teamFilter.value = t
@@ -49,150 +64,109 @@ function selectStatus(s) {
   statusDropdownOpen.value = false
 }
 
+function goToPage(page) {
+  currentPage.value = page
+}
+
 const statusFilterLabel = computed(
   () => statusOptions.find((o) => o.value === statusFilter.value)?.label ?? '전체'
 )
 </script>
 
 <template>
-  <section class="eval-member-list">
-    <div class="eval-member-list__header">
-      <div>
-        <p class="eval-member-list__eyebrow">평가 대상 현황</p>
-        <h3 class="eval-member-list__title">대상자 목록</h3>
-      </div>
-      <span class="eval-member-list__count">총 {{ members.length }}명</span>
-    </div>
-
-    <div class="eval-member-list__filters">
-      <div class="eval-member-list__dropdown-wrap">
-        <button class="eval-member-list__filter-btn" @click="teamDropdownOpen = !teamDropdownOpen; statusDropdownOpen = false">
-          <span class="eval-member-list__filter-label">팀: {{ teamFilter }}</span>
-          <span class="eval-member-list__filter-chevron">▾</span>
+  <EvalListLayout
+    eyebrow="평가 대상 현황"
+    title="대상자 목록"
+    :total-label="`총 ${members.length}명`"
+    search-aria-label="평가 대상 검색"
+    search-placeholder="이름으로 검색"
+    :search-value="search"
+    :has-items="filtered.length > 0"
+    empty-title="조건에 맞는 평가 대상이 없습니다."
+    empty-description="검색어나 상태 필터를 조정해 다른 대상을 확인해보세요."
+    @update:search-value="search = $event"
+  >
+    <template #filters>
+      <div class="hrm-panel__dropdown-wrap">
+        <button class="hrm-panel__filter-btn" @click="teamDropdownOpen = !teamDropdownOpen; statusDropdownOpen = false">
+          <span class="hrm-panel__filter-label">팀: {{ teamFilter }}</span>
+          <span
+            class="hrm-panel__filter-chevron"
+            :class="{ 'hrm-panel__filter-chevron--open': teamDropdownOpen }"
+          >▾</span>
         </button>
-        <ul v-if="teamDropdownOpen" class="eval-member-list__dropdown">
+        <ul v-if="teamDropdownOpen" class="hrm-panel__dropdown">
           <li
-            v-for="t in teams"
-            :key="t"
-            class="eval-member-list__dropdown-item"
-            :class="{ 'eval-member-list__dropdown-item--active': teamFilter === t }"
-            @click="selectTeam(t)"
-          >{{ t }}</li>
+            v-for="team in teams"
+            :key="team"
+            class="hrm-panel__dropdown-item"
+            :class="{ 'hrm-panel__dropdown-item--active': teamFilter === team }"
+            @click="selectTeam(team)"
+          >
+            {{ team }}
+          </li>
         </ul>
       </div>
 
-      <div class="eval-member-list__dropdown-wrap">
-        <button class="eval-member-list__filter-btn" @click="statusDropdownOpen = !statusDropdownOpen; teamDropdownOpen = false">
-          <span class="eval-member-list__filter-label">상태: {{ statusFilterLabel }}</span>
-          <span class="eval-member-list__filter-chevron">▾</span>
+      <div class="hrm-panel__dropdown-wrap">
+        <button class="hrm-panel__filter-btn" @click="statusDropdownOpen = !statusDropdownOpen; teamDropdownOpen = false">
+          <span class="hrm-panel__filter-label">상태: {{ statusFilterLabel }}</span>
+          <span
+            class="hrm-panel__filter-chevron"
+            :class="{ 'hrm-panel__filter-chevron--open': statusDropdownOpen }"
+          >▾</span>
         </button>
-        <ul v-if="statusDropdownOpen" class="eval-member-list__dropdown">
+        <ul v-if="statusDropdownOpen" class="hrm-panel__dropdown">
           <li
-            v-for="o in statusOptions"
-            :key="o.value"
-            class="eval-member-list__dropdown-item"
-            :class="{ 'eval-member-list__dropdown-item--active': statusFilter === o.value }"
-            @click="selectStatus(o.value)"
-          >{{ o.label }}</li>
+            v-for="option in statusOptions"
+            :key="option.value"
+            class="hrm-panel__dropdown-item"
+            :class="{ 'hrm-panel__dropdown-item--active': statusFilter === option.value }"
+            @click="selectStatus(option.value)"
+          >
+            {{ option.label }}
+          </li>
         </ul>
       </div>
-    </div>
+    </template>
 
-    <label class="eval-member-list__search" aria-label="평가 대상 검색">
-      <span class="eval-member-list__search-icon" aria-hidden="true">⌕</span>
-      <input
-        v-model="search"
-        class="eval-member-list__search-input"
-        placeholder="이름 또는 팀명으로 검색"
-      />
-    </label>
-
-    <ul class="eval-member-list__list">
-      <li
-        v-for="m in filtered"
+    <template #default>
+      <EvaluationMemberCard
+        v-for="m in pagedMembers"
         :key="m.id"
-        class="eval-member-list__item"
-      >
-        <EvaluationMemberCard
-          :member-id="m.id"
-          :name="m.name"
-          :avatar="m.avatar"
-          :avatar-color="m.avatarColor"
-          :tier="m.tier"
-          :meta="m.code && m.team ? `${m.code} | ${m.team}` : m.code || m.team || ''"
-          :status="m.status"
-          :status-date="m.statusDate"
-          :selected="m.id === selectedId"
-          @select="emit('select', m)"
-        />
-      </li>
-    </ul>
+        :member-id="m.id"
+        :name="m.name"
+        :avatar="m.avatar"
+        :avatar-color="m.avatarColor"
+        :tier="m.tier"
+        :meta="m.meta"
+        :status="m.status"
+        :status-date="m.statusDate"
+        :selected="m.id === selectedId"
+        @select="emit('select', m)"
+      />
+    </template>
 
-  </section>
+    <template v-if="totalPages > 1" #pagination>
+      <ListPagination
+        :current-page="currentPage"
+        :total-pages="totalPages"
+        @change="goToPage"
+      />
+    </template>
+  </EvalListLayout>
 </template>
 
 <style scoped>
-.eval-member-list {
-  display: grid;
-  grid-template-rows: auto auto auto minmax(0, 1fr);
-  gap: 12px;
-  padding: 20px;
-  border: 1px solid var(--color-border-default);
-  border-radius: 24px;
-  background: var(--color-bg-surface);
-  height: 100%;
-  min-height: 600px;
-  box-sizing: border-box;
-  overflow: hidden;
-}
-
-.eval-member-list__header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.eval-member-list__eyebrow {
-  margin: 0 0 4px;
-  font-size: var(--font-size-xs-plus);
-  font-weight: var(--font-weight-bold);
-  color: var(--color-primary-500);
-}
-
-.eval-member-list__title {
-  margin: 0;
-  font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-bold);
-  color: var(--color-primary-800);
-}
-
-.eval-member-list__count {
-  display: inline-flex;
-  align-items: center;
-  min-height: 32px;
-  padding: 0 12px;
-  border-radius: 999px;
-  background: var(--color-primary-100);
-  color: var(--color-primary-700);
-  font-size: var(--font-size-xs-plus);
-  font-weight: var(--font-weight-semibold);
-  white-space: nowrap;
-}
-
-.eval-member-list__filters {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-}
-
-.eval-member-list__dropdown-wrap {
+.hrm-panel__dropdown-wrap {
   position: relative;
   flex: 1;
   min-width: 0;
 }
 
-.eval-member-list__filter-btn {
+.hrm-panel__filter-btn {
+  appearance: none;
+  -webkit-appearance: none;
   width: 100%;
   height: 38px;
   padding: 0 36px 0 14px;
@@ -205,25 +179,39 @@ const statusFilterLabel = computed(
   cursor: pointer;
   display: flex;
   align-items: center;
-  justify-content: flex-start;
   position: relative;
   box-sizing: border-box;
+  outline: none;
 }
 
-.eval-member-list__filter-label {
+.hrm-panel__filter-btn:hover:not(:disabled) {
+  border-color: var(--color-border-strong);
+}
+
+.hrm-panel__filter-btn:focus-visible:not(:disabled) {
+  border-color: var(--color-primary-500);
+  box-shadow: 0 0 0 3px rgba(91, 80, 214, 0.08);
+}
+
+.hrm-panel__filter-label {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.eval-member-list__filter-chevron {
+.hrm-panel__filter-chevron {
   position: absolute;
   right: 10px;
   flex-shrink: 0;
   color: var(--color-text-muted);
+  transition: transform 0.2s ease;
 }
 
-.eval-member-list__dropdown {
+.hrm-panel__filter-chevron--open {
+  transform: rotate(180deg);
+}
+
+.hrm-panel__dropdown {
   position: absolute;
   top: calc(100% + 6px);
   left: 0;
@@ -239,81 +227,20 @@ const statusFilterLabel = computed(
   overflow: hidden;
 }
 
-.eval-member-list__dropdown-item {
+.hrm-panel__dropdown-item {
+  list-style: none;
   padding: 10px 14px;
   font-size: var(--font-size-sm);
   cursor: pointer;
   color: var(--color-text-default);
 }
 
-.eval-member-list__dropdown-item:hover {
+.hrm-panel__dropdown-item:hover {
   background: var(--color-primary-100);
 }
 
-.eval-member-list__dropdown-item--active {
+.hrm-panel__dropdown-item--active {
   font-weight: var(--font-weight-bold);
   color: var(--color-primary-700);
-}
-
-.eval-member-list__search {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  min-width: 0;
-  border: 1px solid var(--color-border-default);
-  border-radius: 14px;
-  padding: 10px 12px;
-  background: var(--color-bg-surface-muted);
-}
-
-.eval-member-list__search-icon {
-  flex-shrink: 0;
-  color: var(--color-text-muted);
-  font-size: var(--font-size-base-plus);
-}
-
-.eval-member-list__search-input {
-  width: 100%;
-  min-width: 0;
-  border: none;
-  background: transparent;
-  outline: none;
-  font-size: var(--font-size-sm);
-  color: var(--color-text-default);
-}
-
-.eval-member-list__search-input::placeholder {
-  color: var(--color-text-muted);
-}
-
-.eval-member-list__list {
-  list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  padding: 0 4px 0 0;
-  margin: 0;
-  min-height: 0;
-  overflow-y: auto;
-}
-
-.eval-member-list__item {
-  list-style: none;
-}
-
-@media (max-width: 720px) {
-  .eval-member-list {
-    padding: 16px;
-  }
-
-  .eval-member-list__header {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .eval-member-list__filters {
-    flex-direction: column;
-  }
-
 }
 </style>

--- a/src/components/hr/departmentleader/second-evaluation/DepartmentLeaderFirstEvaluationSummary.vue
+++ b/src/components/hr/departmentleader/second-evaluation/DepartmentLeaderFirstEvaluationSummary.vue
@@ -47,7 +47,7 @@ defineProps({
   padding: 18px;
   border: 1px solid #dcd6ff;
   border-radius: 20px;
-  background: linear-gradient(180deg, #faf8ff 0%, #f4f1ff 100%);
+  background: #faf8ff;
 }
 
 .first-evaluation-summary__header {

--- a/src/components/hr/hrmanager/evaluation-approval/HRMApprovalBanner.vue
+++ b/src/components/hr/hrmanager/evaluation-approval/HRMApprovalBanner.vue
@@ -2,6 +2,7 @@
 defineProps({
   count: { type: Number, required: true },
   daysLeft: { type: Number, default: 3 },
+  label: { type: String, default: '이의신청' },
 })
 
 </script>
@@ -9,7 +10,7 @@ defineProps({
 <template>
   <div class="hrm-banner">
     <p class="hrm-banner__text">
-      ⏰ 검토 대기 중인 이의신청이 {{ count }}건 있습니다 — 월말 고과 확정까지 D-{{ daysLeft }}
+      ⏰ 검토 대기 중인 {{ label }}이 {{ count }}건 있습니다 — 월말 고과 확정까지 D-{{ daysLeft }}
     </p>
   </div>
 </template>

--- a/src/components/hr/hrmanager/evaluation-approval/HRMApprovalDetail.vue
+++ b/src/components/hr/hrmanager/evaluation-approval/HRMApprovalDetail.vue
@@ -1,28 +1,103 @@
 <script setup>
-defineProps({
+import { ref, watch } from 'vue'
+import AiEvaluationFormPanel from '@/components/hr/common/evaluation/AiEvaluationFormPanel.vue'
+
+const props = defineProps({
   item:     { type: Object,  required: true },
   readonly: { type: Boolean, default: false },
   held:     { type: Boolean, default: false },
+  mode:     { type: String,  default: 'appeal' },
 })
-defineEmits(['approve', 'reject', 'hold'])
+const emit = defineEmits(['approve', 'reject', 'hold'])
+
+const confirmComment = ref('')
+
+watch(() => props.item?.id, () => {
+  confirmComment.value = ''
+})
 </script>
 
 <template>
-  <article class="hrm-detail">
-    <!-- 상단: 아바타 + 이름 + 타입 뱃지 -->
+  <!-- 평가 확정 모드 — DL 스타일 AiEvaluationFormPanel 사용 -->
+  <AiEvaluationFormPanel
+    v-if="mode === 'evaluation'"
+    class="hrm-evaluation-panel"
+    :title="`${item.name} 평가 확정`"
+    :description="[item.department, item.team].filter(Boolean).join(' > ') || item.meta || ''"
+    :model-value="item.detail?.secondStageComment ?? ''"
+    :show-toolbar="false"
+    :show-editor="false"
+    :readonly="true"
+  >
+    <template #summary>
+      <section class="hrm-eval-summary">
+        <div class="hrm-eval-summary__header">
+          <div>
+            <p class="hrm-eval-summary__eyebrow">평가 요약</p>
+            <h3 class="hrm-eval-summary__title">평가 내용 및 점수</h3>
+          </div>
+          <div class="hrm-eval-summary__scores">
+            <div class="hrm-eval-summary__score hrm-eval-summary__score--quant">
+              <strong>{{ item.detail?.quantScore ?? '-' }}</strong>
+              <span>정량</span>
+            </div>
+            <div class="hrm-eval-summary__score">
+              <strong>{{ item.detail?.firstStageScore ?? '-' }}</strong>
+              <span>1차</span>
+            </div>
+            <div class="hrm-eval-summary__score hrm-eval-summary__score--second">
+              <strong>{{ item.detail?.secondStageScore ?? '-' }}</strong>
+              <span>2차</span>
+            </div>
+          </div>
+        </div>
+        <div class="hrm-eval-summary__comment-card">
+          <p class="hrm-eval-summary__comment-label">팀리더 정성 평가 (1차)</p>
+          <p class="hrm-eval-summary__comment">
+            {{ item.detail?.firstStageComment || '1차 평가 내용이 없습니다.' }}
+          </p>
+        </div>
+        <div class="hrm-eval-summary__comment-card hrm-eval-summary__comment-card--second">
+          <p class="hrm-eval-summary__comment-label hrm-eval-summary__comment-label--second">부서장 정성 평가 (2차)</p>
+          <p class="hrm-eval-summary__comment">
+            {{ item.detail?.secondStageComment || '2차 평가 내용이 없습니다.' }}
+          </p>
+        </div>
+      </section>
+    </template>
+
+    <template #footer>
+      <template v-if="!readonly">
+        <div class="hrm-confirm-comment">
+          <label class="hrm-confirm-comment__label">최종 확정 코멘트</label>
+          <textarea
+            v-model="confirmComment"
+            class="hrm-confirm-comment__input"
+            placeholder="최종 확정 의견을 입력하세요. (선택)"
+            rows="3"
+          />
+        </div>
+        <div class="hrm-eval-actions">
+          <button class="hrm-btn hrm-btn--approve" @click="emit('approve', confirmComment)">최종 확정</button>
+        </div>
+      </template>
+      <div v-else class="hrm-processed-result" :style="{ background: item.processedBg, color: item.processedColor }">
+        <span class="hrm-processed-result__label">{{ item.processedLabel }} 처리 완료</span>
+      </div>
+    </template>
+  </AiEvaluationFormPanel>
+
+  <!-- 이의신청 모드 -->
+  <article v-else class="hrm-detail">
     <div class="hrm-detail__top">
       <div class="hrm-detail__avatar">{{ item.detail.avatar }}</div>
       <div class="hrm-detail__name-block">
         <p class="hrm-detail__name">{{ item.name.split('').join(' ') }}</p>
         <p class="hrm-detail__dept">{{ item.detail.dept }}</p>
       </div>
-      <span
-        class="hrm-badge"
-        :style="{ background: item.typeBg, color: item.typeColor }"
-      >{{ item.detail.evalType }}</span>
+      <span class="hrm-badge" :style="{ background: item.typeBg, color: item.typeColor }">{{ item.detail.evalType }}</span>
     </div>
 
-    <!-- 점수 박스 -->
     <div class="hrm-score-box">
       <div class="hrm-score-item">
         <p class="hrm-score-label">정량 점수</p>
@@ -41,7 +116,6 @@ defineEmits(['approve', 'reject', 'hold'])
       </div>
     </div>
 
-    <!-- AI 분석 -->
     <div class="hrm-ai-box">
       <p class="hrm-ai-box__title">🤖 AI 분석 요약</p>
       <div class="hrm-ai-tags">
@@ -50,7 +124,6 @@ defineEmits(['approve', 'reject', 'hold'])
       <p class="hrm-ai-box__trust">데이터 신뢰도 {{ item.detail.dataTrust }}</p>
     </div>
 
-    <!-- 이의신청 내용 -->
     <div class="hrm-appeal-box">
       <div class="hrm-appeal-box__row">
         <span class="hrm-appeal-box__label">대상 분기</span>
@@ -66,7 +139,6 @@ defineEmits(['approve', 'reject', 'hold'])
       </div>
     </div>
 
-    <!-- 액션 버튼 -->
     <div v-if="!readonly && !held" class="hrm-actions">
       <button class="hrm-btn hrm-btn--reject"  @click="$emit('reject')">반려</button>
       <button class="hrm-btn hrm-btn--hold"    @click="$emit('hold')">보류</button>
@@ -90,37 +162,224 @@ defineEmits(['approve', 'reject', 'hold'])
 </template>
 
 <style scoped>
+/* ── 평가 확정 패널 ── */
+.hrm-evaluation-panel {
+  overflow-y: auto;
+  min-height: 600px;
+  max-height: calc(100vh - 200px);
+}
+
+/* 평가 요약 카드 (summary slot) */
+.hrm-eval-summary {
+  display: grid;
+  gap: 14px;
+  margin-bottom: 16px;
+  padding: 18px;
+  border: 1px solid #dcd6ff;
+  border-radius: 20px;
+  background: #faf8ff;
+}
+
+.hrm-eval-summary__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.hrm-eval-summary__eyebrow {
+  margin: 0 0 4px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--color-primary-500);
+}
+
+.hrm-eval-summary__title {
+  margin: 0;
+  font-size: 18px;
+  color: var(--color-primary-800);
+}
+
+.hrm-eval-summary__scores {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.hrm-eval-summary__score {
+  min-width: 72px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid #e1dbff;
+  text-align: center;
+}
+
+.hrm-eval-summary__score strong {
+  display: block;
+  font-size: 20px;
+  color: var(--color-primary-800);
+}
+
+.hrm-eval-summary__score span {
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+.hrm-eval-summary__score--quant {
+  border-color: #b9f0df;
+}
+
+.hrm-eval-summary__score--quant strong {
+  color: #0d7f63;
+}
+
+.hrm-eval-summary__score--second {
+  border-color: #bdd5f8;
+}
+
+.hrm-eval-summary__score--second strong {
+  color: #1d5dbf;
+}
+
+.hrm-eval-summary__comment-card {
+  padding: 14px 16px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid #e8e2ff;
+}
+
+.hrm-eval-summary__comment-card--second {
+  border-color: #c7deff;
+}
+
+.hrm-eval-summary__comment-label {
+  margin: 0 0 8px;
+  font-size: 12px;
+  font-weight: 700;
+  color: #6a57d3;
+}
+
+.hrm-eval-summary__comment-label--second {
+  color: #3a7bd5;
+}
+
+.hrm-eval-summary__comment {
+  margin: 0;
+  line-height: 1.7;
+  color: var(--color-primary-800);
+}
+
+/* 최종 확정 코멘트 */
+.hrm-confirm-comment {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.hrm-confirm-comment__label {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary-700);
+}
+
+.hrm-confirm-comment__input {
+  width: 100%;
+  padding: 12px 14px;
+  border: 1.5px solid var(--color-border-default);
+  border-radius: 12px;
+  font-size: var(--font-size-sm);
+  font-family: inherit;
+  color: var(--color-primary-800);
+  background: var(--color-bg-app);
+  resize: vertical;
+  line-height: 1.6;
+  box-sizing: border-box;
+}
+
+.hrm-confirm-comment__input:focus {
+  outline: none;
+  border-color: var(--color-primary-500);
+}
+
+/* footer 액션 */
+.hrm-eval-actions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
+}
+
+/* ── 이의신청 패널 ── */
 .hrm-detail {
-  flex: 1; display: flex; flex-direction: column; gap: 16px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-width: 0;
   background: var(--color-bg-surface);
   border: 1.5px solid var(--color-border-default);
-  border-radius: 12px; padding: 20px;
+  border-radius: 24px;
+  padding: 24px;
+  overflow-y: auto;
+  max-height: calc(100vh - 200px);
 }
 
 .hrm-detail__top { display: flex; align-items: center; gap: 14px; }
 .hrm-detail__avatar {
-  width: 52px; height: 52px;
+  width: 52px;
+  height: 52px;
   background: var(--color-primary-600);
   border-radius: 50%;
-  display: flex; align-items: center; justify-content: center;
-  font-size: var(--font-size-lg); font-weight: 900; color: var(--color-white); flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--font-size-lg);
+  font-weight: 900;
+  color: var(--color-white);
+  flex-shrink: 0;
 }
+.hrm-detail__name-block { flex: 1; min-width: 0; }
 .hrm-detail__name { font-size: var(--font-size-lg); font-weight: 900; color: var(--color-primary-800); line-height: 1.4; }
 .hrm-detail__dept { font-size: var(--font-size-xs); color: #a89ed8; }
+
 .hrm-badge {
   display: inline-flex; align-items: center; height: 18px; padding: 0 8px;
   border-radius: 3px; font-size: var(--font-size-xs); font-weight: 900; white-space: nowrap;
 }
 
 .hrm-score-box {
-  display: flex; gap: 24px; padding: 16px 20px;
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  padding: 16px 24px;
   background: var(--color-bg-app);
-  border: 1.5px solid var(--color-border-default);
-  border-radius: 8px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 16px;
 }
-.hrm-score-item { display: flex; flex-direction: column; gap: 2px; }
-.hrm-score-label { font-size: var(--font-size-xs); color: #a89ed8; }
-.hrm-score-value { font-size: var(--font-size-2xl); font-weight: var(--font-weight-regular); color: var(--color-primary-800); line-height: 1; font-family: 'Inter', sans-serif; }
+
+.hrm-score-item {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: center;
+}
+
+.hrm-score-label {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  font-weight: var(--font-weight-semibold);
+}
+
+.hrm-score-value {
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-regular);
+  color: var(--color-primary-800);
+  line-height: 1;
+  font-family: 'Inter', sans-serif;
+}
+
 .hrm-score-value--total { color: var(--tier-s); }
 .hrm-score-diff { font-size: var(--font-size-2xs); color: #7a6fa8; }
 
@@ -167,8 +426,8 @@ defineEmits(['approve', 'reject', 'hold'])
 }
 
 .hrm-actions { display: flex; justify-content: flex-end; gap: 8px; }
-
 .hrm-held-actions { display: flex; flex-direction: column; gap: 10px; }
+
 .hrm-processed-result {
   padding: 12px 16px;
   border-radius: 8px;
@@ -184,6 +443,7 @@ defineEmits(['approve', 'reject', 'hold'])
   opacity: 0.8;
   text-align: center;
 }
+
 .hrm-btn {
   height: 40px; padding: 0 16px; border-radius: 4px;
   font-size: var(--font-size-sm); font-weight: var(--font-weight-bold); cursor: pointer; border: 1.5px solid transparent;

--- a/src/components/hr/hrmanager/evaluation-approval/HRMApprovalDetail.vue
+++ b/src/components/hr/hrmanager/evaluation-approval/HRMApprovalDetail.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, watch } from 'vue'
-import AiEvaluationFormPanel from '@/components/hr/common/evaluation/AiEvaluationFormPanel.vue'
+import EvalDetailLayout from '@/components/hr/common/evaluation/EvalDetailLayout.vue'
 
 const props = defineProps({
   item:     { type: Object,  required: true },
@@ -19,15 +19,16 @@ watch(() => props.item?.id, () => {
 
 <template>
   <!-- 평가 확정 모드 — DL 스타일 AiEvaluationFormPanel 사용 -->
-  <AiEvaluationFormPanel
+  <EvalDetailLayout
     v-if="mode === 'evaluation'"
-    class="hrm-evaluation-panel"
-    :title="`${item.name} 평가 확정`"
-    :description="[item.department, item.team].filter(Boolean).join(' > ') || item.meta || ''"
-    :model-value="item.detail?.secondStageComment ?? ''"
-    :show-toolbar="false"
-    :show-editor="false"
-    :readonly="true"
+    :panel-props="{
+      title: `${item.name} 평가 확정`,
+      description: [item.department, item.team].filter(Boolean).join(' > ') || item.meta || '',
+      modelValue: item.detail?.secondStageComment ?? '',
+      showToolbar: false,
+      showEditor: false,
+      readonly: true,
+    }"
   >
     <template #summary>
       <section class="hrm-eval-summary">
@@ -85,90 +86,95 @@ watch(() => props.item?.id, () => {
         <span class="hrm-processed-result__label">{{ item.processedLabel }} 처리 완료</span>
       </div>
     </template>
-  </AiEvaluationFormPanel>
+  </EvalDetailLayout>
 
   <!-- 이의신청 모드 -->
-  <article v-else class="hrm-detail">
-    <div class="hrm-detail__top">
-      <div class="hrm-detail__avatar">{{ item.detail.avatar }}</div>
-      <div class="hrm-detail__name-block">
-        <p class="hrm-detail__name">{{ item.name.split('').join(' ') }}</p>
-        <p class="hrm-detail__dept">{{ item.detail.dept }}</p>
-      </div>
-      <span class="hrm-badge" :style="{ background: item.typeBg, color: item.typeColor }">{{ item.detail.evalType }}</span>
-    </div>
+  <EvalDetailLayout
+    v-else
+    :panel-props="{
+      title: `${item.name} 신청 내역`,
+      description: item.detail?.dept || item.meta || '이의신청 검토',
+      showToolbar: false,
+      showEditor: false,
+      readonly: true,
+    }"
+  >
+    <template #summary>
+      <section class="hrm-eval-summary hrm-eval-summary--appeal">
+        <div class="hrm-eval-summary__header">
+          <div>
+            <p class="hrm-eval-summary__eyebrow">평가 요약</p>
+            <h3 class="hrm-eval-summary__title">평가 내용 및 점수</h3>
+          </div>
+          <div class="hrm-eval-summary__scores">
+            <div class="hrm-eval-summary__score hrm-eval-summary__score--quant">
+              <strong>{{ item.detail.quantScore ?? '-' }}</strong>
+              <span>정량</span>
+            </div>
+            <div class="hrm-eval-summary__score">
+              <strong>{{ item.detail.firstStageScore ?? '-' }}</strong>
+              <span>1차</span>
+            </div>
+            <div class="hrm-eval-summary__score hrm-eval-summary__score--second">
+              <strong>{{ item.detail.secondStageScore ?? '-' }}</strong>
+              <span>2차</span>
+            </div>
+          </div>
+        </div>
+        <div class="hrm-eval-summary__comment-card">
+          <p class="hrm-eval-summary__comment-label">팀리더 정성 평가 (1차)</p>
+          <p class="hrm-eval-summary__comment">
+            {{ item.detail.firstStageComment || '1차 평가 내용이 없습니다.' }}
+          </p>
+        </div>
+        <div class="hrm-eval-summary__comment-card hrm-eval-summary__comment-card--second">
+          <p class="hrm-eval-summary__comment-label hrm-eval-summary__comment-label--second">부서장 정성 평가 (2차)</p>
+          <p class="hrm-eval-summary__comment">
+            {{ item.detail.secondStageComment || '2차 평가 내용이 없습니다.' }}
+          </p>
+        </div>
+      </section>
+    </template>
 
-    <div class="hrm-score-box">
-      <div class="hrm-score-item">
-        <p class="hrm-score-label">정량 점수</p>
-        <p class="hrm-score-value">{{ item.detail.quantScore }}</p>
-        <p class="hrm-score-diff">{{ item.detail.quantDiff }}</p>
-      </div>
-      <div class="hrm-score-item">
-        <p class="hrm-score-label">정성 점수</p>
-        <p class="hrm-score-value">{{ item.detail.qualScore }}</p>
-        <p class="hrm-score-diff">{{ item.detail.qualDiff }}</p>
-      </div>
-      <div class="hrm-score-item">
-        <p class="hrm-score-label">종합</p>
-        <p class="hrm-score-value hrm-score-value--total">{{ item.detail.totalScore }}</p>
-        <p class="hrm-score-diff">{{ item.detail.totalDiff }}</p>
-      </div>
-    </div>
+    <template #footer>
+      <div class="hrm-appeal-footer">
+        <div class="hrm-appeal-request-card">
+          <div class="hrm-appeal-request-card__meta">
+            <div class="hrm-appeal-request-card__meta-item">
+              <p class="hrm-confirm-comment__label">대상 평가기간</p>
+              <p class="hrm-appeal-request-card__meta-value">{{ item.detail.quarter || '-' }}</p>
+            </div>
+            <div class="hrm-appeal-request-card__meta-item">
+              <p class="hrm-confirm-comment__label">이의 유형</p>
+              <p class="hrm-appeal-request-card__meta-value">{{ item.detail.reason || '-' }}</p>
+            </div>
+          </div>
+          <p class="hrm-confirm-comment__label">이의신청 내용</p>
+          <strong class="hrm-appeal-request-card__title">{{ item.detail.appealTitle || '제목 없음' }}</strong>
+          <p class="hrm-appeal-request-card__content">{{ item.detail.content || '신청 내용이 없습니다.' }}</p>
+        </div>
 
-    <div class="hrm-ai-box">
-      <p class="hrm-ai-box__title">🤖 AI 분석 요약</p>
-      <div class="hrm-ai-tags">
-        <span v-for="tag in item.detail.aiTags" :key="tag" class="hrm-ai-tag">{{ tag }}</span>
+        <div v-if="!readonly && item.rawStatus === 'SUBMITTED'" class="hrm-eval-actions">
+          <button class="hrm-btn hrm-btn--reject" @click="$emit('reject')">거절</button>
+          <button class="hrm-btn hrm-btn--approve" @click="$emit('approve')">접수</button>
+        </div>
+        <div v-else-if="!readonly && item.rawStatus === 'COMPLETED'" class="hrm-eval-actions">
+          <button class="hrm-btn hrm-btn--approve" @click="$emit('approve')">최종 확정</button>
+        </div>
+        <div v-else-if="held" class="hrm-processed-result" :style="{ background: item.processedBg, color: item.processedColor }">
+          <span class="hrm-processed-result__label">접수 완료</span>
+          <span v-if="item.processedReason" class="hrm-processed-result__reason">사유: {{ item.processedReason }}</span>
+        </div>
+        <div v-else class="hrm-processed-result" :style="{ background: item.processedBg, color: item.processedColor }">
+          <span class="hrm-processed-result__label">{{ item.processedLabel }} 처리 완료</span>
+          <span v-if="item.processedReason" class="hrm-processed-result__reason">사유: {{ item.processedReason }}</span>
+        </div>
       </div>
-      <p class="hrm-ai-box__trust">데이터 신뢰도 {{ item.detail.dataTrust }}</p>
-    </div>
-
-    <div class="hrm-appeal-box">
-      <div class="hrm-appeal-box__row">
-        <span class="hrm-appeal-box__label">대상 분기</span>
-        <span class="hrm-appeal-box__value">{{ item.detail.quarter }}</span>
-      </div>
-      <div class="hrm-appeal-box__row">
-        <span class="hrm-appeal-box__label">신청 사유</span>
-        <span class="hrm-appeal-box__value hrm-appeal-box__value--reason">{{ item.detail.reason }}</span>
-      </div>
-      <p class="hrm-appeal-box__content">{{ item.detail.content }}</p>
-      <div v-if="item.detail.attachments?.length" class="hrm-appeal-box__attachments">
-        <span v-for="f in item.detail.attachments" :key="f" class="hrm-appeal-attachment">📎 {{ f }}</span>
-      </div>
-    </div>
-
-    <div v-if="!readonly && !held" class="hrm-actions">
-      <button class="hrm-btn hrm-btn--reject"  @click="$emit('reject')">반려</button>
-      <button class="hrm-btn hrm-btn--hold"    @click="$emit('hold')">보류</button>
-      <button class="hrm-btn hrm-btn--approve" @click="$emit('approve')">최종 승인</button>
-    </div>
-    <div v-else-if="held" class="hrm-held-actions">
-      <div class="hrm-processed-result" :style="{ background: item.processedBg, color: item.processedColor }">
-        <span class="hrm-processed-result__label">보류 처리됨</span>
-        <span v-if="item.processedReason" class="hrm-processed-result__reason">사유: {{ item.processedReason }}</span>
-      </div>
-      <div class="hrm-actions">
-        <button class="hrm-btn hrm-btn--reject"  @click="$emit('reject')">반려</button>
-        <button class="hrm-btn hrm-btn--approve" @click="$emit('approve')">최종 승인</button>
-      </div>
-    </div>
-    <div v-else class="hrm-processed-result" :style="{ background: item.processedBg, color: item.processedColor }">
-      <span class="hrm-processed-result__label">{{ item.processedLabel }} 처리 완료</span>
-      <span v-if="item.processedReason" class="hrm-processed-result__reason">사유: {{ item.processedReason }}</span>
-    </div>
-  </article>
+    </template>
+  </EvalDetailLayout>
 </template>
 
 <style scoped>
-/* ── 평가 확정 패널 ── */
-.hrm-evaluation-panel {
-  overflow-y: auto;
-  min-height: 600px;
-  max-height: calc(100vh - 200px);
-}
-
 /* 평가 요약 카드 (summary slot) */
 .hrm-eval-summary {
   display: grid;
@@ -253,6 +259,65 @@ watch(() => props.item?.id, () => {
   border-color: #c7deff;
 }
 
+.hrm-eval-summary--appeal .hrm-eval-summary__header {
+  align-items: center;
+}
+
+.hrm-appeal-footer {
+  display: grid;
+  gap: 14px;
+}
+
+.hrm-appeal-request-card {
+  padding: 14px 16px;
+  border: 1px solid #e8e2ff;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.92);
+}
+
+.hrm-appeal-request-card__meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.hrm-appeal-request-card__meta-item {
+  display: grid;
+  gap: 6px;
+  padding: 18px 20px;
+  border-radius: 18px;
+  background: #faf8ff;
+  border: 1px solid var(--color-border-soft);
+}
+
+.hrm-appeal-request-card__meta-value {
+  margin: 0;
+  font-size: 18px;
+  color: var(--color-primary-800);
+  font-weight: 700;
+}
+
+.hrm-appeal-request-card :deep(.hrm-confirm-comment__label) {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--color-text-muted);
+}
+
+.hrm-appeal-request-card__title {
+  display: block;
+  margin-top: 4px;
+  color: var(--color-primary-800);
+  font-size: 15px;
+}
+
+.hrm-appeal-request-card__content {
+  margin: 8px 0 0;
+  line-height: 1.7;
+  color: var(--color-primary-800);
+}
+
 .hrm-eval-summary__comment-label {
   margin: 0 0 8px;
   font-size: 12px;
@@ -310,123 +375,10 @@ watch(() => props.item?.id, () => {
   gap: 8px;
 }
 
-/* ── 이의신청 패널 ── */
-.hrm-detail {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  min-width: 0;
-  background: var(--color-bg-surface);
-  border: 1.5px solid var(--color-border-default);
-  border-radius: 24px;
-  padding: 24px;
-  overflow-y: auto;
-  max-height: calc(100vh - 200px);
-}
-
-.hrm-detail__top { display: flex; align-items: center; gap: 14px; }
-.hrm-detail__avatar {
-  width: 52px;
-  height: 52px;
-  background: var(--color-primary-600);
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: var(--font-size-lg);
-  font-weight: 900;
-  color: var(--color-white);
-  flex-shrink: 0;
-}
-.hrm-detail__name-block { flex: 1; min-width: 0; }
-.hrm-detail__name { font-size: var(--font-size-lg); font-weight: 900; color: var(--color-primary-800); line-height: 1.4; }
-.hrm-detail__dept { font-size: var(--font-size-xs); color: #a89ed8; }
-
 .hrm-badge {
   display: inline-flex; align-items: center; height: 18px; padding: 0 8px;
   border-radius: 3px; font-size: var(--font-size-xs); font-weight: 900; white-space: nowrap;
 }
-
-.hrm-score-box {
-  display: flex;
-  align-items: center;
-  gap: 24px;
-  padding: 16px 24px;
-  background: var(--color-bg-app);
-  border: 1px solid var(--color-border-default);
-  border-radius: 16px;
-}
-
-.hrm-score-item {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  align-items: center;
-}
-
-.hrm-score-label {
-  font-size: var(--font-size-xs);
-  color: var(--color-text-muted);
-  font-weight: var(--font-weight-semibold);
-}
-
-.hrm-score-value {
-  font-size: var(--font-size-2xl);
-  font-weight: var(--font-weight-regular);
-  color: var(--color-primary-800);
-  line-height: 1;
-  font-family: 'Inter', sans-serif;
-}
-
-.hrm-score-value--total { color: var(--tier-s); }
-.hrm-score-diff { font-size: var(--font-size-2xs); color: #7a6fa8; }
-
-.hrm-ai-box {
-  padding: 16px;
-  background: var(--color-primary-100);
-  border: 1.5px solid var(--color-border-default);
-  border-radius: 8px; display: flex; flex-direction: column; gap: 8px;
-}
-.hrm-ai-box__title { font-size: var(--font-size-xs); font-weight: var(--font-weight-bold); color: var(--color-primary-600); }
-.hrm-ai-tags { display: flex; flex-wrap: wrap; gap: 6px; }
-.hrm-ai-tag {
-  display: inline-block; padding: 2px 8px; height: 19px;
-  background: var(--color-success-soft); color: var(--color-info);
-  font-size: var(--font-size-2xs); font-weight: var(--font-weight-bold); border-radius: 3px; line-height: 15px;
-}
-.hrm-ai-box__trust { font-size: var(--font-size-xs); color: #7a6fa8; }
-
-.hrm-appeal-box {
-  padding: 14px 16px;
-  background: #fff8f9;
-  border: 1.5px solid #f5c0cc;
-  border-radius: 8px;
-  display: flex; flex-direction: column; gap: 8px;
-}
-.hrm-appeal-box__row { display: flex; align-items: baseline; gap: 10px; }
-.hrm-appeal-box__label {
-  font-size: var(--font-size-xs); color: #a89ed8;
-  white-space: nowrap; flex-shrink: 0; min-width: 60px;
-}
-.hrm-appeal-box__value { font-size: var(--font-size-sm); color: var(--color-primary-800); }
-.hrm-appeal-box__value--reason { font-weight: var(--font-weight-bold); color: #c0103e; }
-.hrm-appeal-box__content {
-  font-size: var(--font-size-sm); color: #7a6fa8;
-  line-height: 1.6; padding-top: 4px;
-  border-top: 1px solid #f5c0cc;
-}
-.hrm-appeal-box__attachments { display: flex; flex-wrap: wrap; gap: 6px; }
-.hrm-appeal-attachment {
-  display: inline-block; padding: 2px 8px; height: 20px;
-  background: #fee2e2; color: #991b1b;
-  font-size: var(--font-size-2xs); font-weight: var(--font-weight-bold);
-  border-radius: 3px; line-height: 16px;
-}
-
-.hrm-actions { display: flex; justify-content: flex-end; gap: 8px; }
-.hrm-held-actions { display: flex; flex-direction: column; gap: 10px; }
 
 .hrm-processed-result {
   padding: 12px 16px;

--- a/src/components/hr/hrmanager/evaluation-approval/HRMApprovalList.vue
+++ b/src/components/hr/hrmanager/evaluation-approval/HRMApprovalList.vue
@@ -1,8 +1,10 @@
 <script setup>
 import { ref, computed, watch } from 'vue'
 import BaseFilterTabs from '@/components/common/base/navigation/BaseFilterTabs.vue'
-import { BaseEmptyState } from '@/components/common/base'
 import EvaluationMemberCard from '@/components/hr/common/evaluation/EvaluationMemberCard.vue'
+import ListFilterDropdown from '@/components/hr/common/evaluation/ListFilterDropdown.vue'
+import ListPagination from '@/components/hr/common/evaluation/ListPagination.vue'
+import EvalListLayout from '@/components/hr/common/evaluation/EvalListLayout.vue'
 
 const props = defineProps({
   list:           { type: Array,  required: true },
@@ -85,66 +87,50 @@ watch(totalPages, (count) => {
 
 <template>
   <!-- 평가 승인 / 이의신청 공통 대형 패널 모드 -->
-  <article v-if="mode === 'evaluation' || mode === 'appeal'" class="hrm-panel hrm-panel--evaluation">
-    <div class="hrm-panel__header">
-      <div>
-        <p class="hrm-panel__eyebrow">{{ mode === 'appeal' ? '이의신청 현황' : '평가 대상 현황' }}</p>
-        <h3 class="hrm-panel__title">대상자 목록</h3>
-      </div>
-      <span class="hrm-panel__total">총 {{ pendingCount + processedCount }}명</span>
-    </div>
-
-    <div class="hrm-panel__filters">
-      <!-- 부서 -->
-      <div class="hrm-panel__dropdown-wrap">
-        <button class="hrm-panel__filter-btn" @click="deptDropdownOpen = !deptDropdownOpen; teamDropdownOpen = false; statusDropdownOpen = false">
-          <span class="hrm-panel__filter-label">부서: {{ deptFilter }}</span>
-          <span class="hrm-panel__filter-chevron">▾</span>
-        </button>
-        <ul v-if="deptDropdownOpen" class="hrm-panel__dropdown">
-          <li v-for="d in departments" :key="d" class="hrm-panel__dropdown-item"
-              :class="{ 'hrm-panel__dropdown-item--active': deptFilter === d }"
-              @click="selectDept(d)">{{ d }}</li>
-        </ul>
-      </div>
-      <!-- 팀 -->
-      <div class="hrm-panel__dropdown-wrap">
-        <button class="hrm-panel__filter-btn" @click="teamDropdownOpen = !teamDropdownOpen; deptDropdownOpen = false; statusDropdownOpen = false">
-          <span class="hrm-panel__filter-label">팀: {{ teamFilter }}</span>
-          <span class="hrm-panel__filter-chevron">▾</span>
-        </button>
-        <ul v-if="teamDropdownOpen" class="hrm-panel__dropdown">
-          <li v-for="t in teams" :key="t" class="hrm-panel__dropdown-item"
-              :class="{ 'hrm-panel__dropdown-item--active': teamFilter === t }"
-              @click="selectTeam(t)">{{ t }}</li>
-        </ul>
-      </div>
-      <!-- 상태 -->
-      <div class="hrm-panel__dropdown-wrap">
-        <button class="hrm-panel__filter-btn" @click="statusDropdownOpen = !statusDropdownOpen; deptDropdownOpen = false; teamDropdownOpen = false">
-          <span class="hrm-panel__filter-label">상태: {{ statusFilterLabel }}</span>
-          <span class="hrm-panel__filter-chevron">▾</span>
-        </button>
-        <ul v-if="statusDropdownOpen" class="hrm-panel__dropdown">
-          <li v-for="o in statusOptions" :key="o.value" class="hrm-panel__dropdown-item"
-              :class="{ 'hrm-panel__dropdown-item--active': statusFilter === o.value }"
-              @click="selectStatus(o.value)">{{ o.label }}</li>
-        </ul>
-      </div>
-    </div>
-
-    <label class="hrm-panel__search" aria-label="평가 대상 검색">
-      <span class="hrm-panel__search-icon" aria-hidden="true">⌕</span>
-      <input
-        v-model="search"
-        type="text"
-        class="hrm-panel__search-input"
-        :placeholder="mode === 'appeal' ? '이름으로 검색' : '이름으로 검색'"
+  <EvalListLayout
+    v-if="mode === 'evaluation' || mode === 'appeal'"
+    eyebrow="평가 대상 현황"
+    title="대상자 목록"
+    :total-label="`총 ${pendingCount + processedCount}${mode === 'appeal' ? '건' : '명'}`"
+    search-aria-label="평가 대상 검색"
+    search-placeholder="이름으로 검색"
+    :search-value="search"
+    :has-items="filteredEvalList.length > 0"
+    :empty-title="mode === 'appeal' ? '조건에 맞는 이의신청 대상이 없습니다.' : '조건에 맞는 평가 대상이 없습니다.'"
+    empty-description="검색어나 필터를 조정해 다른 대상을 확인해보세요."
+    @update:search-value="search = $event"
+  >
+    <template #filters>
+      <ListFilterDropdown
+        label="부서"
+        :value-label="deptFilter"
+        :options="departments.map((department) => ({ value: department, label: department }))"
+        :model-value="deptFilter"
+        :open="deptDropdownOpen"
+        @toggle="deptDropdownOpen = !deptDropdownOpen; teamDropdownOpen = false; statusDropdownOpen = false"
+        @select="selectDept"
       />
-    </label>
+      <ListFilterDropdown
+        label="팀"
+        :value-label="teamFilter"
+        :options="teams.map((team) => ({ value: team, label: team }))"
+        :model-value="teamFilter"
+        :open="teamDropdownOpen"
+        @toggle="teamDropdownOpen = !teamDropdownOpen; deptDropdownOpen = false; statusDropdownOpen = false"
+        @select="selectTeam"
+      />
+      <ListFilterDropdown
+        label="상태"
+        :value-label="statusFilterLabel"
+        :options="statusOptions"
+        :model-value="statusFilter"
+        :open="statusDropdownOpen"
+        @toggle="statusDropdownOpen = !statusDropdownOpen; deptDropdownOpen = false; teamDropdownOpen = false"
+        @select="selectStatus"
+      />
+    </template>
 
-    <template v-if="filteredEvalList.length">
-      <div class="hrm-eval-list">
+    <template #default>
         <EvaluationMemberCard
           v-for="item in pagedList"
           :key="item.id"
@@ -155,35 +141,21 @@ watch(totalPages, (count) => {
           :tier="item.tier"
           :meta="item.meta"
           :status="item.status"
-          :status-label="statusConfig[item.status]?.label"
+          :status-label="item.statusLabel ?? statusConfig[item.status]?.label"
           :status-date="item.statusDate"
           :selected="selectedId === item.id"
           @select="emit('select', item.id)"
         />
-      </div>
-
-      <div v-if="totalPages > 1" class="hrm-panel__pagination">
-        <button
-          v-for="page in totalPages"
-          :key="page"
-          type="button"
-          class="hrm-panel__page"
-          :class="{ 'hrm-panel__page--active': page === currentPage }"
-          @click="currentPage = page"
-        >
-          {{ page }}
-        </button>
-      </div>
     </template>
 
-    <BaseEmptyState
-      v-else
-      icon="⌕"
-      :title="mode === 'appeal' ? '조건에 맞는 이의신청 대상이 없습니다.' : '조건에 맞는 평가 대상이 없습니다.'"
-      description="검색어나 필터를 조정해 다른 대상을 확인해보세요."
-      class="hrm-panel__empty"
-    />
-  </article>
+    <template v-if="totalPages > 1" #pagination>
+      <ListPagination
+        :current-page="currentPage"
+        :total-pages="totalPages"
+        @change="currentPage = $event"
+      />
+    </template>
+  </EvalListLayout>
 
   <!-- 사용 안 하는 구형 리스트 모드 -->
   <article v-else class="hrm-panel">

--- a/src/components/hr/hrmanager/evaluation-approval/HRMApprovalList.vue
+++ b/src/components/hr/hrmanager/evaluation-approval/HRMApprovalList.vue
@@ -1,7 +1,10 @@
 <script setup>
+import { ref, computed, watch } from 'vue'
 import BaseFilterTabs from '@/components/common/base/navigation/BaseFilterTabs.vue'
+import { BaseEmptyState } from '@/components/common/base'
+import EvaluationMemberCard from '@/components/hr/common/evaluation/EvaluationMemberCard.vue'
 
-defineProps({
+const props = defineProps({
   list:           { type: Array,  required: true },
   pendingCount:   { type: Number, required: true },
   heldCount:      { type: Number, default: 0 },
@@ -9,35 +12,205 @@ defineProps({
   tabs:           { type: Array,  required: true },
   activeTab:      { type: String, required: true },
   selectedId:     { default: null },
+  pendingLabel:   { type: String, default: '이의신청 검토 대기' },
+  heldLabel:      { type: String, default: '보류' },
+  processedLabel: { type: String, default: '처리 완료' },
+  emptyText:      { type: String, default: '승인 대기 내역이 없습니다.' },
+  mode:           { type: String, default: 'appeal' },
+  pageSize:       { type: Number, default: 5 },
 })
-defineEmits(['tab-change', 'select'])
+const emit = defineEmits(['tab-change', 'select'])
+
+const search = ref('')
+const currentPage = ref(1)
+const deptFilter = ref('전체')
+const teamFilter = ref('전체')
+const statusFilter = ref('전체')
+const deptDropdownOpen = ref(false)
+const teamDropdownOpen = ref(false)
+const statusDropdownOpen = ref(false)
+
+const statusConfig = {
+  submitted:   { label: '확정 완료' },
+  in_progress: { label: '검토 대기' },
+  not_started: { label: '미작성' },
+}
+
+const statusOptions = [
+  { value: '전체',        label: '전체' },
+  { value: 'in_progress', label: '검토 대기' },
+  { value: 'submitted',   label: '확정 완료' },
+]
+
+const departments = computed(() => ['전체', ...new Set(props.list.map(i => i.department).filter(Boolean))])
+const teams = computed(() => {
+  const base = props.list.filter(i => deptFilter.value === '전체' || i.department === deptFilter.value)
+  return ['전체', ...new Set(base.map(i => i.team).filter(Boolean))]
+})
+
+const filteredEvalList = computed(() => {
+  const keyword = search.value.trim().toLowerCase()
+  return props.list.filter(item => {
+    const matchDept   = deptFilter.value   === '전체' || item.department === deptFilter.value
+    const matchTeam   = teamFilter.value   === '전체' || item.team       === teamFilter.value
+    const matchStatus = statusFilter.value === '전체' || item.status     === statusFilter.value
+    const matchSearch = !keyword || item.name?.toLowerCase().includes(keyword)
+    return matchDept && matchTeam && matchStatus && matchSearch
+  })
+})
+
+const statusFilterLabel = computed(() => statusOptions.find(o => o.value === statusFilter.value)?.label ?? '전체')
+
+function selectDept(v)   { deptFilter.value = v;   teamFilter.value = '전체'; deptDropdownOpen.value   = false }
+function selectTeam(v)   { teamFilter.value = v;   teamDropdownOpen.value   = false }
+function selectStatus(v) { statusFilter.value = v; statusDropdownOpen.value = false }
+
+const totalPages = computed(() =>
+  Math.max(1, Math.ceil(filteredEvalList.value.length / props.pageSize))
+)
+
+const pagedList = computed(() => {
+  const start = (currentPage.value - 1) * props.pageSize
+  return filteredEvalList.value.slice(start, start + props.pageSize)
+})
+
+watch([search, deptFilter, teamFilter, statusFilter], () => {
+  currentPage.value = 1
+})
+
+watch(totalPages, (count) => {
+  if (currentPage.value > count) currentPage.value = count
+})
 </script>
 
 <template>
-  <article class="hrm-panel">
+  <!-- 평가 승인 / 이의신청 공통 대형 패널 모드 -->
+  <article v-if="mode === 'evaluation' || mode === 'appeal'" class="hrm-panel hrm-panel--evaluation">
+    <div class="hrm-panel__header">
+      <div>
+        <p class="hrm-panel__eyebrow">{{ mode === 'appeal' ? '이의신청 현황' : '평가 대상 현황' }}</p>
+        <h3 class="hrm-panel__title">대상자 목록</h3>
+      </div>
+      <span class="hrm-panel__total">총 {{ pendingCount + processedCount }}명</span>
+    </div>
+
+    <div class="hrm-panel__filters">
+      <!-- 부서 -->
+      <div class="hrm-panel__dropdown-wrap">
+        <button class="hrm-panel__filter-btn" @click="deptDropdownOpen = !deptDropdownOpen; teamDropdownOpen = false; statusDropdownOpen = false">
+          <span class="hrm-panel__filter-label">부서: {{ deptFilter }}</span>
+          <span class="hrm-panel__filter-chevron">▾</span>
+        </button>
+        <ul v-if="deptDropdownOpen" class="hrm-panel__dropdown">
+          <li v-for="d in departments" :key="d" class="hrm-panel__dropdown-item"
+              :class="{ 'hrm-panel__dropdown-item--active': deptFilter === d }"
+              @click="selectDept(d)">{{ d }}</li>
+        </ul>
+      </div>
+      <!-- 팀 -->
+      <div class="hrm-panel__dropdown-wrap">
+        <button class="hrm-panel__filter-btn" @click="teamDropdownOpen = !teamDropdownOpen; deptDropdownOpen = false; statusDropdownOpen = false">
+          <span class="hrm-panel__filter-label">팀: {{ teamFilter }}</span>
+          <span class="hrm-panel__filter-chevron">▾</span>
+        </button>
+        <ul v-if="teamDropdownOpen" class="hrm-panel__dropdown">
+          <li v-for="t in teams" :key="t" class="hrm-panel__dropdown-item"
+              :class="{ 'hrm-panel__dropdown-item--active': teamFilter === t }"
+              @click="selectTeam(t)">{{ t }}</li>
+        </ul>
+      </div>
+      <!-- 상태 -->
+      <div class="hrm-panel__dropdown-wrap">
+        <button class="hrm-panel__filter-btn" @click="statusDropdownOpen = !statusDropdownOpen; deptDropdownOpen = false; teamDropdownOpen = false">
+          <span class="hrm-panel__filter-label">상태: {{ statusFilterLabel }}</span>
+          <span class="hrm-panel__filter-chevron">▾</span>
+        </button>
+        <ul v-if="statusDropdownOpen" class="hrm-panel__dropdown">
+          <li v-for="o in statusOptions" :key="o.value" class="hrm-panel__dropdown-item"
+              :class="{ 'hrm-panel__dropdown-item--active': statusFilter === o.value }"
+              @click="selectStatus(o.value)">{{ o.label }}</li>
+        </ul>
+      </div>
+    </div>
+
+    <label class="hrm-panel__search" aria-label="평가 대상 검색">
+      <span class="hrm-panel__search-icon" aria-hidden="true">⌕</span>
+      <input
+        v-model="search"
+        type="text"
+        class="hrm-panel__search-input"
+        :placeholder="mode === 'appeal' ? '이름으로 검색' : '이름으로 검색'"
+      />
+    </label>
+
+    <template v-if="filteredEvalList.length">
+      <div class="hrm-eval-list">
+        <EvaluationMemberCard
+          v-for="item in pagedList"
+          :key="item.id"
+          :member-id="item.id"
+          :name="item.name"
+          :avatar="item.avatar"
+          :avatar-tone="item.avatarTone"
+          :tier="item.tier"
+          :meta="item.meta"
+          :status="item.status"
+          :status-label="statusConfig[item.status]?.label"
+          :status-date="item.statusDate"
+          :selected="selectedId === item.id"
+          @select="emit('select', item.id)"
+        />
+      </div>
+
+      <div v-if="totalPages > 1" class="hrm-panel__pagination">
+        <button
+          v-for="page in totalPages"
+          :key="page"
+          type="button"
+          class="hrm-panel__page"
+          :class="{ 'hrm-panel__page--active': page === currentPage }"
+          @click="currentPage = page"
+        >
+          {{ page }}
+        </button>
+      </div>
+    </template>
+
+    <BaseEmptyState
+      v-else
+      icon="⌕"
+      :title="mode === 'appeal' ? '조건에 맞는 이의신청 대상이 없습니다.' : '조건에 맞는 평가 대상이 없습니다.'"
+      description="검색어나 필터를 조정해 다른 대상을 확인해보세요."
+      class="hrm-panel__empty"
+    />
+  </article>
+
+  <!-- 사용 안 하는 구형 리스트 모드 -->
+  <article v-else class="hrm-panel">
     <p class="hrm-panel__header">
-      <template v-if="activeTab === '처리 완료'">✅ 처리 완료 ({{ processedCount }}건)</template>
-      <template v-else-if="activeTab === '보류'">⏳ 보류 ({{ heldCount }}건)</template>
-      <template v-else>📋 이의신청 검토 대기 ({{ pendingCount }}건)</template>
+      <template v-if="activeTab === '처리 완료'">✅ {{ processedLabel }} ({{ processedCount }}건)</template>
+      <template v-else-if="activeTab === '보류'">⏳ {{ heldLabel }} ({{ heldCount }}건)</template>
+      <template v-else>📋 {{ pendingLabel }} ({{ pendingCount }}건)</template>
     </p>
 
     <BaseFilterTabs
       :items="tabs"
       :modelValue="activeTab"
       variant="underline"
-      @change="$emit('tab-change', $event)"
+      size="md"
+      @change="emit('tab-change', $event)"
     />
 
     <div class="hrm-list">
       <div v-if="list.length === 0" class="hrm-list__empty">
-        승인 대기 내역이 없습니다.
+        {{ emptyText }}
       </div>
       <div
         v-for="item in list"
         :key="item.id"
         class="hrm-list-item"
         :class="{ 'hrm-list-item--selected': selectedId === item.id }"
-        @click="$emit('select', item.id)"
+        @click="emit('select', item.id)"
       >
         <div class="hrm-list-item__info">
           <div class="hrm-list-item__row1">
@@ -56,17 +229,217 @@ defineEmits(['tab-change', 'select'])
 </template>
 
 <style scoped>
+/* 공통 */
 .hrm-panel {
-  width: 460px; flex-shrink: 0;
+  width: 100%;
+  min-width: 0;
+  flex-shrink: 1;
   background: var(--color-bg-surface);
   border: 1.5px solid var(--color-border-default);
-  border-radius: 12px; padding: 20px;
-}
-.hrm-panel__header {
-  font-size: var(--font-size-sm); font-weight: var(--font-weight-bold); color: #a89ed8;
-  letter-spacing: 0.5px; text-transform: uppercase; margin-bottom: 16px;
+  border-radius: 12px;
+  padding: 20px;
 }
 
+/* 평가 승인 모드 */
+.hrm-panel--evaluation {
+  display: grid;
+  grid-template-rows: auto auto auto minmax(0, 1fr) auto;
+  gap: 12px;
+  border-radius: 24px;
+  padding: 20px;
+  height: 100%;
+  min-height: 0;
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+.hrm-panel__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.hrm-panel__eyebrow {
+  margin: 0 0 4px;
+  font-size: var(--font-size-xs-plus);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary-500);
+}
+
+.hrm-panel__total {
+  display: inline-flex;
+  align-items: center;
+  min-height: 32px;
+  padding: 0 12px;
+  border-radius: 999px;
+  background: var(--color-primary-100);
+  color: var(--color-primary-700);
+  font-size: var(--font-size-xs-plus);
+  font-weight: var(--font-weight-semibold);
+  white-space: nowrap;
+}
+
+.hrm-panel__title {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary-800);
+}
+
+.hrm-panel__filters {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.hrm-panel__dropdown-wrap {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+}
+
+.hrm-panel__filter-btn {
+  width: 100%;
+  height: 38px;
+  padding: 0 36px 0 14px;
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-default);
+  border-radius: 12px;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-primary-700);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  position: relative;
+  box-sizing: border-box;
+}
+
+.hrm-panel__filter-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hrm-panel__filter-chevron {
+  position: absolute;
+  right: 10px;
+  flex-shrink: 0;
+  color: var(--color-text-muted);
+}
+
+.hrm-panel__dropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 10;
+  list-style: none;
+  width: 100%;
+  padding: 0;
+  margin: 0;
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-default);
+  border-radius: 14px;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+  overflow: hidden;
+}
+
+.hrm-panel__dropdown-item {
+  padding: 10px 14px;
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  color: var(--color-text-default);
+}
+
+.hrm-panel__dropdown-item:hover {
+  background: var(--color-primary-100);
+}
+
+.hrm-panel__dropdown-item--active {
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary-700);
+}
+
+.hrm-panel__search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  padding: 10px 12px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 14px;
+  background: var(--color-bg-surface-muted);
+}
+
+.hrm-panel__search-icon {
+  flex-shrink: 0;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-base-plus);
+}
+
+.hrm-panel__search-input {
+  width: 100%;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  outline: none;
+  font-size: var(--font-size-sm);
+  color: var(--color-primary-800);
+}
+
+.hrm-panel__search-input::placeholder {
+  color: var(--color-text-muted);
+}
+
+.hrm-eval-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.hrm-panel__pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 34px;
+}
+
+.hrm-panel__page {
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-surface);
+  color: var(--color-primary-700);
+  font-size: var(--font-size-xs-plus);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+}
+
+.hrm-panel__page--active {
+  border-color: var(--color-primary-600);
+  background: var(--color-primary-600);
+  color: var(--color-text-inverse);
+}
+
+.hrm-panel__empty {
+  align-self: center;
+}
+
+/* 이의신청 모드 */
+.hrm-panel__header {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+  color: #a89ed8;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  margin-bottom: 16px;
+}
 
 :deep(.base-filter-tabs) { margin-bottom: 12px; }
 
@@ -96,6 +469,10 @@ defineEmits(['tab-change', 'select'])
   display: inline-flex; align-items: center; height: 14px; padding: 0 7px;
   border-radius: 3px; font-size: var(--font-size-2xs); font-weight: 900;
 }
+.hrm-processed-badge {
+  display: inline-flex; align-items: center; height: 14px; padding: 0 7px;
+  border-radius: 3px; font-size: var(--font-size-2xs); font-weight: 900;
+}
 
 .hrm-list-item__check {
   width: 14px; height: 14px; border: 1.5px solid var(--color-border-strong);
@@ -103,8 +480,19 @@ defineEmits(['tab-change', 'select'])
 }
 .hrm-list-item__check--filled { background: var(--color-primary-600); border-color: var(--color-primary-600); }
 
-.hrm-processed-badge {
-  display: inline-flex; align-items: center; height: 14px; padding: 0 7px;
-  border-radius: 3px; font-size: var(--font-size-2xs); font-weight: 900;
+@media (max-width: 720px) {
+  .hrm-panel--evaluation {
+    padding: 16px;
+  }
+
+  .hrm-panel__meta {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .hrm-panel__pagination {
+    flex-wrap: wrap;
+  }
 }
 </style>

--- a/src/components/hr/hrmanager/promotion-review/HRMPromotionDetail.vue
+++ b/src/components/hr/hrmanager/promotion-review/HRMPromotionDetail.vue
@@ -1,284 +1,379 @@
 <script setup>
-import { ref, watch } from 'vue'
+import { ref, watch, computed } from 'vue'
 
 const props = defineProps({
   item: { type: Object, required: true },
 })
-
 const emit = defineEmits(['hold', 'confirm'])
 
 const comment = ref('')
+watch(() => props.item?.id, () => { comment.value = '' })
 
-watch(() => props.item.id, () => { comment.value = '' })
+const pointPercent = computed(() => {
+  const acc = props.item?.tierAccumulatedPoint ?? 0
+  const target = props.item?.targetPromotionPoint ?? 0
+  if (!target) return 0
+  return Math.min(100, Math.round((acc / target) * 100))
+})
+
+const isProcessed = computed(() =>
+  ['CONFIRMATION_OF_PROMOTION', 'TIER_APPLIED', 'SUSPENSION'].includes(props.item?.rawStatus)
+)
+
+const TIER_TONE = { S: 'gold', A: 'purple', B: 'green', C: 'green' }
 </script>
 
 <template>
   <article class="promo-detail">
-    <p class="promo-detail__title">🔍 심사 상세 — {{ item.name }}</p>
-
-    <!-- 직원 정보 -->
-    <div class="promo-detail__header">
-      <span class="promo-detail__avatar" :style="{ background: item.avatarColor }">
-        {{ item.name[0] }}
-      </span>
-      <div class="promo-detail__info">
-        <p class="promo-detail__name">{{ item.name }}</p>
-        <p class="promo-detail__subtitle">{{ item.currentTier }}-Tier → {{ item.targetTier }}-Tier 심사</p>
+    <!-- 헤더 -->
+    <div class="promo-detail__top">
+      <div
+        class="promo-detail__avatar"
+        :class="`promo-detail__avatar--${TIER_TONE[item.targetTier] ?? 'purple'}`"
+      >
+        {{ item.name?.[0] ?? '?' }}
       </div>
-      <span class="promo-detail__score">{{ item.totalScore }}점</span>
+      <div class="promo-detail__name-block">
+        <p class="promo-detail__name">{{ item.name }}</p>
+        <p class="promo-detail__subtitle">{{ item.currentTier }}-Tier → {{ item.targetTier }}-Tier 승급 심사</p>
+      </div>
+      <span
+        class="promo-detail__status-badge"
+        :class="`promo-detail__status-badge--${item.rawStatus}`"
+      >
+        {{ item.statusLabel }}
+      </span>
     </div>
 
-    <!-- 요건 달성 현황 -->
-    <div class="promo-detail__section">
-      <p class="promo-detail__section-title">{{ item.targetTier }}-Tier 승급 요건 달성 현황</p>
-      <div class="promo-detail__requirements">
-        <div
-          v-for="req in item.detail.requirements"
-          :key="req.label"
-          class="promo-req"
-          :class="req.met ? 'promo-req--met' : 'promo-req--fail'"
-        >
-          <span class="promo-req__icon">{{ req.met ? '✓' : '✗' }}</span>
-          <span class="promo-req__label">{{ req.label }}</span>
-          <span class="promo-req__value">{{ req.current }}</span>
-          <span v-if="req.met" class="promo-req__check">✓</span>
+    <!-- 포인트 요약 카드 -->
+    <section class="promo-points-summary">
+      <div class="promo-points-summary__header">
+        <div>
+          <p class="promo-points-summary__eyebrow">승급 포인트 현황</p>
+          <h3 class="promo-points-summary__title">{{ item.targetTier }}-Tier 승급 요건</h3>
+        </div>
+        <div class="promo-points-summary__scores">
+          <div class="promo-points-summary__score">
+            <strong>{{ item.tierAccumulatedPoint ?? '-' }}</strong>
+            <span>누적</span>
+          </div>
+          <div class="promo-points-summary__score promo-points-summary__score--target">
+            <strong>{{ item.targetPromotionPoint ?? '-' }}</strong>
+            <span>목표</span>
+          </div>
         </div>
       </div>
-    </div>
+      <div class="promo-points-summary__bar-wrap">
+        <div class="promo-points-summary__bar" :style="{ width: pointPercent + '%' }" />
+      </div>
+      <p class="promo-points-summary__bar-label">달성률 {{ pointPercent }}%</p>
+    </section>
 
     <!-- 심사 의견 -->
     <div class="promo-detail__section">
-      <p class="promo-detail__section-title">심사 의견</p>
+      <p class="promo-detail__section-label">심사 의견</p>
       <textarea
-        v-if="!item.processedStatus"
+        v-if="!isProcessed"
         v-model="comment"
         class="promo-detail__textarea"
-        placeholder="심사 의견을 입력하세요..."
+        placeholder="심사 의견을 입력하세요."
+        rows="4"
       />
-      <p v-else class="promo-detail__comment-readonly">{{ item.comment || '(의견 없음)' }}</p>
-    </div>
-
-    <!-- 이전 심사 이력 -->
-    <div v-if="item.detail.history.length > 0" class="promo-detail__section">
-      <p class="promo-detail__section-title">📋 이전 심사 이력</p>
-      <div class="promo-detail__history">
-        <p
-          v-for="h in item.detail.history"
-          :key="h.quarter"
-          class="promo-detail__history-item"
-        >{{ h.quarter }} · {{ h.result }} · 미달 {{ h.missingCount }}항목</p>
+      <div v-else class="promo-detail__comment-readonly">
+        {{ item.reviewComment || '(의견 없음)' }}
       </div>
     </div>
 
-    <!-- 액션 버튼 / 처리 결과 -->
-    <div v-if="!item.processedStatus" class="promo-detail__actions">
-      <button class="promo-detail__btn promo-detail__btn--hold"    @click="emit('hold',    { id: item.id, comment: comment.trim() })">보류</button>
+    <!-- 심사일 -->
+    <p v-if="item.tierReviewedAt" class="promo-detail__reviewed-at">
+      심사일: {{ item.tierReviewedAt?.slice(0, 10) ?? '-' }}
+    </p>
+
+    <!-- 액션 / 처리 결과 -->
+    <div v-if="!isProcessed" class="promo-detail__actions">
+      <button class="promo-detail__btn promo-detail__btn--hold" @click="emit('hold', { id: item.id, comment: comment.trim() })">
+        보류
+      </button>
       <button
         class="promo-detail__btn promo-detail__btn--confirm"
-        :disabled="!comment.trim()"
         @click="emit('confirm', { id: item.id, comment: comment.trim() })"
-      >승급 확정</button>
+      >
+        승급 확정
+      </button>
     </div>
     <div
       v-else
       class="promo-detail__processed"
-      :class="`promo-detail__processed--${item.processedStatus}`"
+      :class="`promo-detail__processed--${item.rawStatus}`"
     >
-      {{ item.processedStatus === 'confirm' ? '승급 확정 처리됨' : '보류 처리됨' }}
+      {{ item.rawStatus === 'SUSPENSION' ? '보류 처리됨' : '승급 확정 처리됨' }}
     </div>
   </article>
 </template>
 
 <style scoped>
 .promo-detail {
-  width: 340px;
-  flex-shrink: 0;
-  background: var(--color-bg-surface);
-  border: 1px solid var(--color-border-default);
-  border-radius: 16px;
-  padding: 20px;
   display: flex;
   flex-direction: column;
   gap: 16px;
-}
-.promo-detail__title {
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-bold);
-  color: var(--color-primary-500);
+  background: var(--color-bg-surface);
+  border: 1.5px solid var(--color-border-default);
+  border-radius: 24px;
+  padding: 24px;
+  overflow-y: auto;
+  max-height: calc(100vh - 200px);
 }
 
 /* 헤더 */
-.promo-detail__header {
+.promo-detail__top {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 14px;
 }
+
 .promo-detail__avatar {
-  width: 40px;
-  height: 40px;
+  width: 52px;
+  height: 52px;
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: var(--font-size-md);
+  font-size: var(--font-size-lg);
   font-weight: 900;
   color: #fff;
   flex-shrink: 0;
 }
+
+.promo-detail__avatar--gold   { background: #c08b00; }
+.promo-detail__avatar--purple { background: #5f50d6; }
+.promo-detail__avatar--green  { background: #269063; }
+
+.promo-detail__name-block { flex: 1; min-width: 0; }
 .promo-detail__name {
-  font-size: var(--font-size-base);
-  font-weight: var(--font-weight-bold);
+  font-size: var(--font-size-lg);
+  font-weight: 900;
   color: var(--color-primary-800);
+  line-height: 1.4;
 }
 .promo-detail__subtitle {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  color: #a89ed8;
 }
-.promo-detail__score {
-  margin-left: auto;
-  font-size: var(--font-size-lg);
+
+.promo-detail__status-badge {
+  display: inline-flex;
+  align-items: center;
+  height: 26px;
+  padding: 0 12px;
+  border-radius: 999px;
+  font-size: var(--font-size-xs);
   font-weight: var(--font-weight-bold);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.promo-detail__status-badge--UNDER_REVIEW {
+  background: #ede9fe;
+  color: #6d28d9;
+}
+
+.promo-detail__status-badge--CONFIRMATION_OF_PROMOTION,
+.promo-detail__status-badge--TIER_APPLIED {
+  background: #d1fae5;
+  color: #065f46;
+}
+
+.promo-detail__status-badge--SUSPENSION {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+/* 포인트 요약 카드 */
+.promo-points-summary {
+  display: grid;
+  gap: 12px;
+  padding: 18px;
+  border: 1px solid #dcd6ff;
+  border-radius: 20px;
+  background: #faf8ff;
+}
+
+.promo-points-summary__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.promo-points-summary__eyebrow {
+  margin: 0 0 4px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--color-primary-500);
+}
+
+.promo-points-summary__title {
+  margin: 0;
+  font-size: 18px;
   color: var(--color-primary-800);
 }
 
-/* 섹션 */
+.promo-points-summary__scores {
+  display: flex;
+  gap: 10px;
+}
+
+.promo-points-summary__score {
+  min-width: 72px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid #e1dbff;
+  text-align: center;
+}
+
+.promo-points-summary__score strong {
+  display: block;
+  font-size: 20px;
+  color: var(--color-primary-800);
+}
+
+.promo-points-summary__score span {
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+.promo-points-summary__score--target {
+  border-color: #bdd5f8;
+}
+
+.promo-points-summary__score--target strong {
+  color: #1d5dbf;
+}
+
+.promo-points-summary__bar-wrap {
+  height: 8px;
+  background: #e1dbff;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.promo-points-summary__bar {
+  height: 100%;
+  background: linear-gradient(90deg, #7c6ee6, #5f50d6);
+  border-radius: 4px;
+  transition: width 0.4s ease;
+}
+
+.promo-points-summary__bar-label {
+  margin: 0;
+  font-size: 12px;
+  color: var(--color-primary-600);
+  font-weight: 700;
+  text-align: right;
+}
+
+/* 심사 의견 */
 .promo-detail__section {
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
-.promo-detail__section-title {
-  font-size: var(--font-size-sm);
+
+.promo-detail__section-label {
+  font-size: var(--font-size-xs);
   font-weight: var(--font-weight-bold);
-  color: var(--color-primary-600);
+  color: var(--color-primary-700);
 }
 
-/* 요건 항목 */
-.promo-detail__requirements {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-.promo-req {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
-  border-radius: 8px;
-  font-size: var(--font-size-sm);
-}
-.promo-req--met  { background: #e3fbef; }
-.promo-req--fail { background: #fff0f0; }
-
-.promo-req__icon {
-  font-weight: 900;
-  font-size: var(--font-size-sm);
-  width: 14px;
-  flex-shrink: 0;
-}
-.promo-req--met  .promo-req__icon { color: var(--color-mint-500); }
-.promo-req--fail .promo-req__icon { color: var(--color-danger); }
-
-.promo-req__label {
-  flex: 1;
-  color: var(--color-primary-800);
-  font-weight: var(--font-weight-semibold);
-}
-.promo-req__value {
-  font-weight: var(--font-weight-bold);
-}
-.promo-req--met  .promo-req__value { color: var(--color-mint-500); }
-.promo-req--fail .promo-req__value { color: var(--color-danger); }
-
-.promo-req__check {
-  color: var(--color-mint-500);
-  font-weight: 900;
-}
-
-/* 심사 의견 */
 .promo-detail__textarea {
   width: 100%;
-  height: 72px;
-  padding: 10px 12px;
-  border: 1px solid var(--color-border-default);
-  border-radius: 8px;
+  padding: 12px 14px;
+  border: 1.5px solid var(--color-border-default);
+  border-radius: 12px;
   font-size: var(--font-size-sm);
+  font-family: inherit;
   color: var(--color-primary-800);
   background: var(--color-bg-app);
-  resize: none;
+  resize: vertical;
+  line-height: 1.6;
   box-sizing: border-box;
-  outline: none;
 }
+
 .promo-detail__textarea:focus {
-  border-color: var(--color-primary-400);
+  outline: none;
+  border-color: var(--color-primary-500);
 }
+
 .promo-detail__comment-readonly {
-  padding: 10px 12px;
-  background: var(--color-bg-app);
-  border-radius: 8px;
+  padding: 14px 16px;
+  border-radius: 12px;
+  background: #faf8ff;
+  border: 1px solid #dcd6ff;
   font-size: var(--font-size-sm);
   color: var(--color-primary-800);
-  line-height: 1.5;
+  line-height: 1.7;
   min-height: 56px;
 }
 
-/* 이전 이력 */
-.promo-detail__history {
-  background: var(--color-bg-app);
-  border-radius: 8px;
-  padding: 10px 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-.promo-detail__history-item {
-  font-size: var(--font-size-sm);
+.promo-detail__reviewed-at {
+  margin: 0;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 
-/* 액션 버튼 */
+/* 액션 */
 .promo-detail__actions {
   display: flex;
   gap: 10px;
+  justify-content: flex-end;
   margin-top: auto;
 }
+
 .promo-detail__btn {
-  flex: 1;
-  height: 40px;
-  border-radius: 8px;
-  font-size: var(--font-size-sm);
+  height: 42px;
+  padding: 0 24px;
+  border-radius: 12px;
+  font-size: var(--font-size-base);
   font-weight: var(--font-weight-bold);
   cursor: pointer;
   border: none;
 }
+
 .promo-detail__btn--hold {
-  background: var(--color-bg-app);
-  color: var(--color-primary-600);
-  border: 1.5px solid var(--color-border-default);
-}
-.promo-detail__btn--confirm {
-  background: var(--color-mint-500);
-  color: #fff;
-}
-.promo-detail__btn--confirm:disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
+  background: var(--color-bg-surface);
+  color: #92400e;
+  border: 1.5px solid #fbbf24;
 }
 
+.promo-detail__btn--hold:hover { background: #fef3c7; }
+
+.promo-detail__btn--confirm {
+  background: var(--color-primary-600);
+  color: #fff;
+  border: 1.5px solid var(--color-primary-500);
+}
+
+.promo-detail__btn--confirm:hover { background: var(--color-primary-700); }
+
+/* 처리 결과 */
 .promo-detail__processed {
   padding: 14px;
-  border-radius: 10px;
+  border-radius: 12px;
   text-align: center;
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-bold);
   margin-top: auto;
 }
-.promo-detail__processed--confirm {
-  background: #e3fbef;
-  color: #007a60;
-  border: 1px solid var(--color-mint-500);
+
+.promo-detail__processed--CONFIRMATION_OF_PROMOTION,
+.promo-detail__processed--TIER_APPLIED {
+  background: #d1fae5;
+  color: #065f46;
+  border: 1px solid #6ee7b7;
 }
-.promo-detail__processed--hold {
+
+.promo-detail__processed--SUSPENSION {
   background: #fef3c7;
   color: #92400e;
   border: 1px solid #fbbf24;

--- a/src/components/hr/hrmanager/promotion-review/HRMPromotionList.vue
+++ b/src/components/hr/hrmanager/promotion-review/HRMPromotionList.vue
@@ -1,270 +1,344 @@
 <script setup>
-import BaseFilterTabs from '@/components/common/base/navigation/BaseFilterTabs.vue'
+import { ref, computed, watch } from 'vue'
+import { BaseEmptyState } from '@/components/common/base'
+import EvaluationMemberCard from '@/components/hr/common/evaluation/EvaluationMemberCard.vue'
 
-defineProps({
+const props = defineProps({
   list:       { type: Array,  required: true },
-  tabs:       { type: Array,  required: true },
-  activeTab:  { type: String, required: true },
   selectedId: { default: null },
+  pageSize:   { type: Number, default: 6 },
 })
-defineEmits(['tab-change', 'select', 'confirm'])
+const emit = defineEmits(['select'])
 
-const RESULT_STYLE = {
-  '보류':     { bg: '#f0eeff', color: '#7468e2' },
-  '승급 권장': { bg: '#fff3cd', color: '#b07800' },
-  '승급 가능': { bg: '#e3fbef', color: '#007a60' },
-  '승급 확정': { bg: '#00bf95', color: '#fff' },
-}
+const search       = ref('')
+const currentPage  = ref(1)
+const tierFilter   = ref('전체')
+const statusFilter = ref('전체')
+const tierDropdownOpen   = ref(false)
+const statusDropdownOpen = ref(false)
 
-function resultStyle(result) {
-  return RESULT_STYLE[result] ?? RESULT_STYLE['보류']
+const tierOptions = [
+  { value: '전체', label: '전체' },
+  { value: 'S',    label: 'S-Tier' },
+  { value: 'A',    label: 'A-Tier' },
+]
+
+const statusOptions = [
+  { value: '전체',                    label: '전체' },
+  { value: 'UNDER_REVIEW',            label: '검토 대기' },
+  { value: 'CONFIRMATION_OF_PROMOTION', label: '승급 확정' },
+  { value: 'TIER_APPLIED',            label: '적용 완료' },
+  { value: 'SUSPENSION',              label: '보류' },
+]
+
+const tierFilterLabel   = computed(() => tierOptions.find(o => o.value === tierFilter.value)?.label   ?? '전체')
+const statusFilterLabel = computed(() => statusOptions.find(o => o.value === statusFilter.value)?.label ?? '전체')
+
+function selectTier(v)   { tierFilter.value   = v; tierDropdownOpen.value   = false }
+function selectStatus(v) { statusFilter.value = v; statusDropdownOpen.value = false }
+function closeAll()      { tierDropdownOpen.value = false; statusDropdownOpen.value = false }
+
+const filteredList = computed(() => {
+  const keyword = search.value.trim().toLowerCase()
+  return props.list.filter(item => {
+    const matchTier   = tierFilter.value   === '전체' || item.targetTier === tierFilter.value
+    const matchStatus = statusFilter.value === '전체' || item.rawStatus  === statusFilter.value
+    const matchSearch = !keyword || item.name?.toLowerCase().includes(keyword)
+    return matchTier && matchStatus && matchSearch
+  })
+})
+
+const totalPages = computed(() => Math.max(1, Math.ceil(filteredList.value.length / props.pageSize)))
+const pagedList  = computed(() => {
+  const start = (currentPage.value - 1) * props.pageSize
+  return filteredList.value.slice(start, start + props.pageSize)
+})
+
+watch([search, tierFilter, statusFilter], () => { currentPage.value = 1 })
+watch(totalPages, (n) => { if (currentPage.value > n) currentPage.value = n })
+
+const statusConfig = {
+  UNDER_REVIEW:              { label: '검토 대기', cardStatus: 'in_progress' },
+  CONFIRMATION_OF_PROMOTION: { label: '승급 확정', cardStatus: 'submitted' },
+  TIER_APPLIED:              { label: '적용 완료', cardStatus: 'submitted' },
+  SUSPENSION:                { label: '보류',      cardStatus: 'not_started' },
 }
 </script>
 
 <template>
-  <article class="promo-list">
-    <p class="promo-list__title">🏆 승급 심사 대상자 ({{ list.length }}명)</p>
-
-    <BaseFilterTabs
-      :items="tabs"
-      :modelValue="activeTab"
-      variant="chip"
-      show-count
-      @change="$emit('tab-change', $event)"
-    />
-
-    <table class="promo-table">
-      <thead>
-        <tr>
-          <th>이름</th>
-          <th>현재Tier</th>
-          <th>종합점수</th>
-          <th>요건충족</th>
-          <th>미달항목</th>
-          <th>성장추이</th>
-          <th>예상결과</th>
-          <th>처리결과</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr
-          v-for="item in list"
-          :key="item.id"
-          :class="{ 'promo-table__row--selected': selectedId === item.id }"
-          @click="$emit('select', item.id)"
-        >
-          <td>
-            <div class="promo-table__name">
-              <span class="promo-table__avatar" :style="{ background: item.avatarColor }">
-                {{ item.name[0] }}
-              </span>
-              {{ item.name }}
-            </div>
-          </td>
-          <td>
-            <span class="promo-table__tier">{{ item.currentTier }}→{{ item.targetTier }}</span>
-          </td>
-          <td class="promo-table__score">{{ item.totalScore }}</td>
-          <td>
-            <div class="promo-table__bar-wrap">
-              <div
-                class="promo-table__bar"
-                :class="item.fulfillRate === 100 ? 'promo-table__bar--full' : item.fulfillRate >= 70 ? 'promo-table__bar--high' : 'promo-table__bar--low'"
-                :style="{ width: item.fulfillRate + '%' }"
-              />
-            </div>
-          </td>
-          <td :class="{ 'promo-table__missing--red': item.missingCount > 0 }">
-            {{ item.missingCount }}개
-          </td>
-          <td class="promo-table__trend">
-            ▲{{ item.growthTrend }} {{ item.growthArrows }}
-          </td>
-          <td>
-            <span class="promo-table__result" :style="{ background: resultStyle(item.result).bg, color: resultStyle(item.result).color }">
-              {{ item.result }}
-            </span>
-          </td>
-          <td>
-            <span
-              class="promo-table__process"
-              :class="{
-                'promo-table__process--confirm': item.processedStatus === 'confirm',
-                'promo-table__process--hold':    item.processedStatus === 'hold',
-                'promo-table__process--none':    !item.processedStatus,
-              }"
-            >
-              {{ item.processedStatus === 'confirm' ? '승급확정' : item.processedStatus === 'hold' ? '보류' : '미처리' }}
-            </span>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    <div class="promo-list__actions">
-      <button class="promo-list__btn promo-list__btn--excel">Excel 내보내기</button>
+  <article class="promo-panel">
+    <div class="promo-panel__header">
+      <div>
+        <p class="promo-panel__eyebrow">승급 심사 현황</p>
+        <h3 class="promo-panel__title">대상자 목록</h3>
+      </div>
+      <span class="promo-panel__total">총 {{ list.length }}명</span>
     </div>
+
+    <div class="promo-panel__filters">
+      <!-- Tier 필터 -->
+      <div class="promo-panel__dropdown-wrap">
+        <button class="promo-panel__filter-btn" @click="tierDropdownOpen = !tierDropdownOpen; statusDropdownOpen = false">
+          <span class="promo-panel__filter-label">Tier: {{ tierFilterLabel }}</span>
+          <span class="promo-panel__filter-chevron">▾</span>
+        </button>
+        <ul v-if="tierDropdownOpen" class="promo-panel__dropdown" @click.stop>
+          <li
+            v-for="o in tierOptions"
+            :key="o.value"
+            class="promo-panel__dropdown-item"
+            :class="{ 'promo-panel__dropdown-item--active': tierFilter === o.value }"
+            @click="selectTier(o.value)"
+          >{{ o.label }}</li>
+        </ul>
+      </div>
+
+      <!-- 상태 필터 -->
+      <div class="promo-panel__dropdown-wrap">
+        <button class="promo-panel__filter-btn" @click="statusDropdownOpen = !statusDropdownOpen; tierDropdownOpen = false">
+          <span class="promo-panel__filter-label">상태: {{ statusFilterLabel }}</span>
+          <span class="promo-panel__filter-chevron">▾</span>
+        </button>
+        <ul v-if="statusDropdownOpen" class="promo-panel__dropdown" @click.stop>
+          <li
+            v-for="o in statusOptions"
+            :key="o.value"
+            class="promo-panel__dropdown-item"
+            :class="{ 'promo-panel__dropdown-item--active': statusFilter === o.value }"
+            @click="selectStatus(o.value)"
+          >{{ o.label }}</li>
+        </ul>
+      </div>
+    </div>
+
+    <label class="promo-panel__search" aria-label="대상자 검색">
+      <span class="promo-panel__search-icon" aria-hidden="true">⌕</span>
+      <input
+        v-model="search"
+        type="text"
+        class="promo-panel__search-input"
+        placeholder="이름으로 검색"
+        @focus="closeAll"
+      />
+    </label>
+
+    <template v-if="filteredList.length">
+      <div class="promo-eval-list">
+        <EvaluationMemberCard
+          v-for="item in pagedList"
+          :key="item.id"
+          :member-id="item.id"
+          :name="item.name"
+          :avatar="item.avatar"
+          :avatar-tone="item.avatarTone"
+          :tier="item.tierBadge"
+          :meta="item.meta"
+          :status="statusConfig[item.rawStatus]?.cardStatus ?? 'not_started'"
+          :status-label="statusConfig[item.rawStatus]?.label"
+          :status-date="item.statusDate"
+          :selected="selectedId === item.id"
+          @select="emit('select', item.id)"
+        />
+      </div>
+
+      <div v-if="totalPages > 1" class="promo-panel__pagination">
+        <button
+          v-for="page in totalPages"
+          :key="page"
+          type="button"
+          class="promo-panel__page"
+          :class="{ 'promo-panel__page--active': page === currentPage }"
+          @click="currentPage = page"
+        >{{ page }}</button>
+      </div>
+    </template>
+
+    <BaseEmptyState
+      v-else
+      icon="⌕"
+      title="조건에 맞는 대상자가 없습니다."
+      description="검색어나 필터를 조정해보세요."
+      class="promo-panel__empty"
+    />
   </article>
 </template>
 
 <style scoped>
-.promo-list {
-  flex: 1;
+.promo-panel {
+  display: grid;
+  grid-template-rows: auto auto auto minmax(0, 1fr) auto;
+  gap: 12px;
   background: var(--color-bg-surface);
-  border: 1px solid var(--color-border-default);
-  border-radius: 16px;
+  border: 1.5px solid var(--color-border-default);
+  border-radius: 24px;
   padding: 20px;
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-  min-width: 0;
+  height: 100%;
+  min-height: 0;
+  box-sizing: border-box;
+  overflow: hidden;
 }
-.promo-list__title {
-  font-size: var(--font-size-sm);
+
+.promo-panel__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.promo-panel__eyebrow {
+  margin: 0 0 4px;
+  font-size: var(--font-size-xs-plus);
   font-weight: var(--font-weight-bold);
   color: var(--color-primary-500);
 }
 
-/* 테이블 */
-.promo-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: var(--font-size-sm);
-}
-.promo-table th {
-  text-align: left;
-  padding: 8px 10px;
-  font-size: var(--font-size-sm);
+.promo-panel__title {
+  margin: 0;
+  font-size: var(--font-size-lg);
   font-weight: var(--font-weight-bold);
-  color: var(--color-text-muted);
-  border-bottom: 1.5px solid var(--color-border-default);
+  color: var(--color-primary-800);
 }
-.promo-table td {
-  padding: 10px 10px;
-  border-bottom: 1px solid var(--color-border-default);
-  vertical-align: middle;
-}
-.promo-table tbody tr {
-  cursor: pointer;
-}
-.promo-table tbody tr:hover { background: var(--color-primary-100); }
-.promo-table__row--selected { background: var(--color-primary-100); }
 
-.promo-table__name {
+.promo-panel__total {
+  display: inline-flex;
+  align-items: center;
+  min-height: 32px;
+  padding: 0 12px;
+  border-radius: 999px;
+  background: var(--color-primary-100);
+  color: var(--color-primary-700);
+  font-size: var(--font-size-xs-plus);
+  font-weight: var(--font-weight-semibold);
+  white-space: nowrap;
+}
+
+.promo-panel__filters {
+  display: flex;
+  gap: 8px;
+}
+
+.promo-panel__dropdown-wrap {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+}
+
+.promo-panel__filter-btn {
+  width: 100%;
+  height: 38px;
+  padding: 0 36px 0 14px;
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-default);
+  border-radius: 12px;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-primary-700);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  position: relative;
+  box-sizing: border-box;
+}
+
+.promo-panel__filter-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.promo-panel__filter-chevron {
+  position: absolute;
+  right: 10px;
+  color: var(--color-text-muted);
+}
+
+.promo-panel__dropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 10;
+  list-style: none;
+  width: 100%;
+  padding: 0;
+  margin: 0;
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-default);
+  border-radius: 14px;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+  overflow: hidden;
+}
+
+.promo-panel__dropdown-item {
+  padding: 10px 14px;
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  color: var(--color-text-default);
+}
+
+.promo-panel__dropdown-item:hover { background: var(--color-primary-100); }
+.promo-panel__dropdown-item--active { font-weight: var(--font-weight-bold); color: var(--color-primary-700); }
+
+.promo-panel__search {
   display: flex;
   align-items: center;
   gap: 8px;
-  font-weight: var(--font-weight-bold);
-  color: var(--color-primary-800);
+  padding: 10px 12px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 14px;
+  background: var(--color-bg-surface-muted);
 }
-.promo-table__avatar {
-  width: 26px;
-  height: 26px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: var(--font-size-xs);
-  font-weight: 900;
-  color: #fff;
+
+.promo-panel__search-icon {
   flex-shrink: 0;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-base-plus);
 }
-.promo-table__tier {
+
+.promo-panel__search-input {
+  width: 100%;
+  border: none;
+  background: transparent;
+  outline: none;
   font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-bold);
-  color: var(--color-primary-600);
-}
-.promo-table__score {
-  font-weight: var(--font-weight-bold);
   color: var(--color-primary-800);
 }
-.promo-table__bar-wrap {
-  width: 80px;
-  height: 6px;
-  background: var(--color-border-default);
-  border-radius: 3px;
-  overflow: hidden;
-}
-.promo-table__bar {
-  height: 100%;
-  border-radius: 3px;
-  transition: width 0.3s;
-}
-.promo-table__bar--full  { background: var(--color-mint-500); }
-.promo-table__bar--high  { background: var(--color-mint-500); }
-.promo-table__bar--low   { background: #ffd166; }
 
-.promo-table__missing--red { color: var(--color-danger); font-weight: var(--font-weight-bold); }
-.promo-table__trend { color: var(--color-mint-500); font-weight: var(--font-weight-bold); }
+.promo-panel__search-input::placeholder { color: var(--color-text-muted); }
 
-.promo-table__result {
-  display: inline-flex;
-  align-items: center;
-  height: 20px;
-  padding: 0 8px;
-  border-radius: 10px;
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-bold);
-  white-space: nowrap;
+.promo-eval-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 4px;
 }
-.promo-table__process {
-  display: inline-flex;
-  align-items: center;
-  height: 22px;
-  padding: 0 10px;
-  border-radius: 6px;
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-bold);
-  white-space: nowrap;
-}
-.promo-table__process--none    { background: var(--color-bg-app);  color: #a89ed8; border: 1px solid var(--color-border-default); }
-.promo-table__process--confirm { background: #e3fbef; color: #007a60; border: 1px solid var(--color-mint-500); }
-.promo-table__process--hold    { background: #fef3c7; color: #92400e; border: 1px solid #fbbf24; }
 
-/* 필터 탭 */
-:deep(.base-filter-tabs--chip .base-filter-tabs__item) {
-  height: 30px;
-  padding: 0 12px;
-  font-size: var(--font-size-xs-plus);
-}
-:deep(.base-filter-tabs__count) {
-  display: inline-flex;
+.promo-panel__pagination {
+  display: flex;
   align-items: center;
   justify-content: center;
-  min-width: 18px;
-  height: 18px;
-  padding: 0 5px;
-  border-radius: 999px;
-  background: var(--color-primary-200);
-  color: var(--color-primary-700);
-  font-size: 11px;
-  font-weight: var(--font-weight-bold);
-  line-height: 1;
-}
-:deep(.base-filter-tabs__item--active .base-filter-tabs__count) {
-  background: var(--color-primary-600);
-  color: var(--color-white);
+  gap: 8px;
+  min-height: 34px;
 }
 
-/* 하단 액션 */
-.promo-list__actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 10px;
-  margin-top: 4px;
-}
-.promo-list__btn {
-  height: 38px;
-  padding: 0 20px;
-  border-radius: 8px;
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-bold);
+.promo-panel__page {
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-surface);
+  color: var(--color-primary-700);
+  font-size: var(--font-size-xs-plus);
+  font-weight: var(--font-weight-semibold);
   cursor: pointer;
-  border: none;
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
 }
-.promo-list__btn--excel {
-  background: var(--color-bg-app);
-  color: var(--color-primary-600);
-  border: 1.5px solid var(--color-border-default);
+
+.promo-panel__page--active {
+  border-color: var(--color-primary-600);
+  background: var(--color-primary-600);
+  color: var(--color-text-inverse);
 }
+
+.promo-panel__empty { align-self: center; }
 </style>

--- a/src/components/hr/teamleader/qualitative-evaluation/TeamLeaderAiEvaluationMemberListPanel.vue
+++ b/src/components/hr/teamleader/qualitative-evaluation/TeamLeaderAiEvaluationMemberListPanel.vue
@@ -1,7 +1,8 @@
-﻿<script setup>
+<script setup>
 import { computed, ref, watch } from 'vue'
-import { BaseEmptyState, BaseFilterTabs } from '@/components/common/base'
 import EvaluationMemberCard from '@/components/hr/common/evaluation/EvaluationMemberCard.vue'
+import ListPagination from '@/components/hr/common/evaluation/ListPagination.vue'
+import EvalListLayout from '@/components/hr/common/evaluation/EvalListLayout.vue'
 
 const props = defineProps({
   members: {
@@ -23,32 +24,23 @@ const emit = defineEmits(['select-member'])
 const search = ref('')
 const statusFilter = ref('all')
 const currentPage = ref(1)
+const statusDropdownOpen = ref(false)
 
-const statusConfig = {
-  submitted: { label: '제출 완료' },
-  in_progress: { label: '작성 중' },
-  not_started: { label: '미작성' },
-}
+const fixedTeamLabel = computed(() =>
+  props.members.find((member) => member.teamName || member.team || member.departmentName)?.teamName
+  ?? props.members.find((member) => member.teamName || member.team || member.departmentName)?.team
+  ?? props.members.find((member) => member.teamName || member.team || member.departmentName)?.departmentName
+  ?? '현재 팀'
+)
 
-const statusTabs = computed(() => {
-  const counts = props.members.reduce(
-    (acc, member) => {
-      acc.all += 1
-      if (acc[member.status] !== undefined) {
-        acc[member.status] += 1
-      }
-      return acc
-    },
-    { all: 0, submitted: 0, in_progress: 0, not_started: 0 },
-  )
+const statusOptions = [
+  { value: 'all', label: '전체' },
+  { value: 'submitted', label: '제출 완료' },
+  { value: 'in_progress', label: '작성 중' },
+  { value: 'not_started', label: '미작성' },
+]
 
-  return [
-    { key: 'all', label: '전체', count: counts.all },
-    { key: 'submitted', label: '제출 완료', count: counts.submitted },
-    { key: 'in_progress', label: '작성 중', count: counts.in_progress },
-    { key: 'not_started', label: '미작성', count: counts.not_started },
-  ]
-})
+const statusFilterLabel = computed(() => statusOptions.find((option) => option.value === statusFilter.value)?.label ?? '전체')
 
 const filteredMembers = computed(() => {
   const keyword = search.value.trim().toLowerCase()
@@ -88,206 +80,177 @@ function selectMember(memberId) {
 function goToPage(page) {
   currentPage.value = page
 }
+
+function selectStatus(value) {
+  statusFilter.value = value
+  statusDropdownOpen.value = false
+}
 </script>
 
 <template>
-  <section class="member-list-panel">
-    <div class="member-list-panel__header">
-      <div>
-        <p class="member-list-panel__eyebrow">평가 대상 현황</p>
-        <h3 class="member-list-panel__title">대상자 목록</h3>
-      </div>
-      <span class="member-list-panel__count">총 {{ members.length }}명</span>
-    </div>
-
-    <BaseFilterTabs
-      v-model="statusFilter"
-      :items="statusTabs"
-      variant="chip"
-      size="sm"
-      :show-count="true"
-      class="member-list-panel__tabs"
-    />
-
-    <label class="member-list-panel__search" aria-label="평가 대상 검색">
-      <span class="member-list-panel__search-icon" aria-hidden="true">⌕</span>
-      <input
-        v-model="search"
-        type="text"
-        class="member-list-panel__search-input"
-        placeholder="이름 또는 사번으로 검색"
-      />
-    </label>
-
-    <template v-if="filteredMembers.length">
-      <div class="member-list-panel__list">
-        <EvaluationMemberCard
-          v-for="member in pagedMembers"
-          :key="member.id"
-          :member-id="member.id"
-          :name="member.name"
-          :avatar="member.avatar"
-          :avatar-tone="member.avatarTone"
-          :tier="member.tier"
-          :meta="member.code"
-          :status="member.status"
-          :status-date="member.statusDate"
-          :selected="String(member.id) === selectedId"
-          @select="selectMember"
-        />
-      </div>
-
-      <div v-if="filteredMembers.length > 0" class="member-list-panel__pagination">
-        <button
-          v-for="page in totalPages"
-          :key="page"
-          type="button"
-          class="member-list-panel__page"
-          :class="{ 'member-list-panel__page--active': page === currentPage }"
-          @click="goToPage(page)"
-        >
-          {{ page }}
+  <EvalListLayout
+    eyebrow="평가 대상 현황"
+    title="대상자 목록"
+    :total-label="`총 ${members.length}명`"
+    search-aria-label="평가 대상 검색"
+    search-placeholder="이름으로 검색"
+    :search-value="search"
+    :has-items="filteredMembers.length > 0"
+    empty-title="조건에 맞는 평가 대상이 없습니다."
+    empty-description="검색어나 상태 필터를 조정해 다른 대상을 확인해보세요."
+    @update:search-value="search = $event"
+  >
+    <template #filters>
+      <div class="hrm-panel__dropdown-wrap">
+        <button type="button" class="hrm-panel__filter-btn hrm-panel__filter-btn--disabled" disabled>
+          <span class="hrm-panel__filter-label">팀: {{ fixedTeamLabel }}</span>
+          <span class="hrm-panel__filter-chevron">▾</span>
         </button>
+      </div>
+
+      <div class="hrm-panel__dropdown-wrap">
+        <button
+          type="button"
+          class="hrm-panel__filter-btn"
+          @click="statusDropdownOpen = !statusDropdownOpen"
+        >
+          <span class="hrm-panel__filter-label">상태: {{ statusFilterLabel }}</span>
+          <span
+            class="hrm-panel__filter-chevron"
+            :class="{ 'hrm-panel__filter-chevron--open': statusDropdownOpen }"
+          >▾</span>
+        </button>
+        <ul v-if="statusDropdownOpen" class="hrm-panel__dropdown">
+          <li
+            v-for="option in statusOptions"
+            :key="option.value"
+            class="hrm-panel__dropdown-item"
+            :class="{ 'hrm-panel__dropdown-item--active': statusFilter === option.value }"
+            @click="selectStatus(option.value)"
+          >
+            {{ option.label }}
+          </li>
+        </ul>
       </div>
     </template>
 
-    <BaseEmptyState
-      v-else
-      icon="⌕"
-      title="조건에 맞는 평가 대상이 없습니다."
-      description="검색어나 상태 필터를 조정해 다른 대상을 확인해보세요."
-      class="member-list-panel__empty"
-    />
-  </section>
+    <template #default>
+      <EvaluationMemberCard
+        v-for="member in pagedMembers"
+        :key="member.id"
+        :member-id="member.id"
+        :name="member.name"
+        :avatar="member.avatar"
+        :avatar-tone="member.avatarTone"
+        :tier="member.tier"
+        :meta="member.meta"
+        :status="member.status"
+        :status-date="member.statusDate"
+        :selected="String(member.id) === selectedId"
+        @select="selectMember"
+      />
+    </template>
+
+    <template v-if="totalPages > 1" #pagination>
+      <ListPagination
+        :current-page="currentPage"
+        :total-pages="totalPages"
+        @change="goToPage"
+      />
+    </template>
+  </EvalListLayout>
 </template>
 
 <style scoped>
-.member-list-panel {
-  display: grid;
-  grid-template-rows: auto auto auto minmax(0, 1fr) auto;
-  gap: 12px;
-  padding: 20px;
-  border: 1px solid var(--color-border-default);
-  border-radius: 24px;
-  background: var(--color-bg-surface);
-  height: 100%;
-  min-height: 600px;
-  overflow: hidden;
-  box-sizing: border-box;
-}
-
-.member-list-panel__header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.member-list-panel__eyebrow {
-  margin: 0 0 4px;
-  font-size: var(--font-size-xs-plus);
-  font-weight: var(--font-weight-bold);
-  color: var(--color-primary-500);
-}
-
-.member-list-panel__title {
-  margin: 0;
-  font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-bold);
-  color: var(--color-primary-800);
-}
-
-.member-list-panel__count {
-  display: inline-flex;
-  align-items: center;
-  min-height: 32px;
-  padding: 0 12px;
-  border-radius: 999px;
-  background: var(--color-primary-100);
-  color: var(--color-primary-700);
-  font-size: var(--font-size-xs-plus);
-  font-weight: var(--font-weight-semibold);
-  white-space: nowrap;
-}
-
-.member-list-panel__search {
-  display: flex;
-  align-items: center;
-  gap: 8px;
+.hrm-panel__dropdown-wrap {
+  position: relative;
+  flex: 1;
   min-width: 0;
-  padding: 10px 12px;
+}
+
+.hrm-panel__filter-btn {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 100%;
+  height: 38px;
+  padding: 0 36px 0 14px;
+  background: var(--color-bg-surface);
   border: 1px solid var(--color-border-default);
-  border-radius: 14px;
+  border-radius: 12px;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-primary-700);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  position: relative;
+  box-sizing: border-box;
+  outline: none;
+}
+
+.hrm-panel__filter-btn:hover:not(:disabled) {
+  border-color: var(--color-border-strong);
+}
+
+.hrm-panel__filter-btn:focus-visible:not(:disabled) {
+  border-color: var(--color-primary-500);
+  box-shadow: 0 0 0 3px rgba(91, 80, 214, 0.08);
+}
+
+.hrm-panel__filter-btn--disabled {
+  cursor: not-allowed;
+  color: var(--color-text-muted);
   background: var(--color-bg-surface-muted);
 }
 
-.member-list-panel__search-icon {
+.hrm-panel__filter-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hrm-panel__filter-chevron {
+  position: absolute;
+  right: 10px;
   flex-shrink: 0;
   color: var(--color-text-muted);
-  font-size: var(--font-size-base-plus);
+  transition: transform 0.2s ease;
 }
 
-.member-list-panel__search-input {
+.hrm-panel__filter-chevron--open {
+  transform: rotate(180deg);
+}
+
+.hrm-panel__dropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 10;
+  list-style: none;
   width: 100%;
-  min-width: 0;
-  border: none;
-  background: transparent;
-  outline: none;
-  font-size: var(--font-size-sm);
-  color: var(--color-primary-800);
-}
-
-.member-list-panel__search-input::placeholder {
-  color: var(--color-text-muted);
-}
-
-.member-list-panel__list {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  min-height: 0;
-  overflow-y: auto;
-  padding-right: 4px;
-}
-
-.member-list-panel__pagination {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  min-height: 34px;
-}
-
-.member-list-panel__page {
-  border: 1px solid var(--color-border-default);
+  padding: 0;
+  margin: 0;
   background: var(--color-bg-surface);
-  color: var(--color-primary-700);
-  font-size: var(--font-size-xs-plus);
-  font-weight: var(--font-weight-semibold);
+  border: 1px solid var(--color-border-default);
+  border-radius: 14px;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+  overflow: hidden;
+}
+
+.hrm-panel__dropdown-item {
+  list-style: none;
+  padding: 10px 14px;
+  font-size: var(--font-size-sm);
   cursor: pointer;
-  width: 34px;
-  height: 34px;
-  border-radius: 10px;
+  color: var(--color-text-default);
 }
 
-.member-list-panel__page--active {
-  border-color: var(--color-primary-600);
-  background: var(--color-primary-600);
-  color: var(--color-text-inverse);
+.hrm-panel__dropdown-item:hover {
+  background: var(--color-primary-100);
 }
 
-@media (max-width: 720px) {
-  .member-list-panel {
-    padding: 16px;
-  }
-
-  .member-list-panel__header {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .member-list-panel__pagination {
-    flex-wrap: wrap;
-  }
+.hrm-panel__dropdown-item--active {
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary-700);
 }
 </style>

--- a/src/components/hr/teamleader/qualitative-evaluation/TeamLeaderAiEvaluationPanel.vue
+++ b/src/components/hr/teamleader/qualitative-evaluation/TeamLeaderAiEvaluationPanel.vue
@@ -1,6 +1,6 @@
 <script setup>
-import AiEvaluationFormPanel from '@/components/hr/common/evaluation/AiEvaluationFormPanel.vue'
 import EvaluationGuideModal from '@/components/hr/common/evaluation/EvaluationGuideModal.vue'
+import EvalDetailLayout from '@/components/hr/common/evaluation/EvalDetailLayout.vue'
 import TeamLeaderAiEvaluationActionBar from './TeamLeaderAiEvaluationActionBar.vue'
 
 defineProps({
@@ -10,6 +10,8 @@ defineProps({
   uploadedFileName: { type: String, default: '' },
   actionDisabled: { type: Boolean, default: false },
   readonly: { type: Boolean, default: false },
+  appealInfo: { type: Object, default: null },
+  progressLabel: { type: String, default: '1차 평가 작성 현황' },
 })
 
 const emit = defineEmits([
@@ -26,18 +28,19 @@ const emit = defineEmits([
 </script>
 
 <template>
-  <AiEvaluationFormPanel
-    class="tl-evaluation-form-panel"
-    :title="selectedTarget.voiceLabel"
-    :description="selectedTarget.voiceDescription"
-    :model-value="selectedTarget.convertedText"
-    :readonly="readonly"
-    :notice-text="'음성 인식 결과가 누락되거나 문장이 비문으로 바뀔 수 있습니다. 변환 결과는 초안으로만 사용하고 아래 패널에서 최종 평가 문장을 직접 수정하세요.'"
-    :recording-state="recordingState"
-    :uploaded-file-name="uploadedFileName"
-    :show-replay-button="true"
-    :show-guide-button="true"
-    :guide-active="guideOpen"
+  <EvalDetailLayout
+    :panel-props="{
+      title: selectedTarget.voiceLabel,
+      description: selectedTarget.voiceDescription,
+      modelValue: selectedTarget.convertedText,
+      readonly,
+      noticeText: '음성 인식 결과가 누락되거나 문장이 비문으로 바뀔 수 있습니다. 변환 결과는 초안으로만 사용하고 아래 패널에서 최종 평가 문장을 직접 수정하세요.',
+      recordingState,
+      uploadedFileName,
+      showReplayButton: true,
+      showGuideButton: true,
+      guideActive: guideOpen,
+    }"
     @update:model-value="emit('update:converted-text', $event)"
     @voice-input="emit('voice-input')"
     @file-selected="emit('file-selected', $event)"
@@ -45,10 +48,36 @@ const emit = defineEmits([
     @replay-audio="emit('replay-audio')"
     @toggle-guide="emit('toggle-guide')"
   >
+    <template #summary>
+      <section v-if="selectedTarget.summaryComment || appealInfo" class="eval-form__summary-stack">
+        <div v-if="selectedTarget.summaryComment" class="eval-form__summary-card">
+          <p class="eval-form__summary-eyebrow">{{ selectedTarget.summaryTitle || '이전 평가 내용' }}</p>
+          <p class="eval-form__summary-copy">{{ selectedTarget.summaryComment }}</p>
+        </div>
+        <div v-if="appealInfo" class="eval-form__summary-card eval-form__summary-card--appeal">
+          <div class="eval-form__appeal-meta">
+            <div class="eval-form__appeal-meta-item">
+              <p class="eval-form__summary-eyebrow">대상 평가기간</p>
+              <strong>{{ appealInfo.periodLabel }}</strong>
+            </div>
+            <div class="eval-form__appeal-meta-item">
+              <p class="eval-form__summary-eyebrow">이의 유형</p>
+              <strong>{{ appealInfo.typeLabel }}</strong>
+            </div>
+          </div>
+          <div class="eval-form__appeal-body">
+            <p class="eval-form__summary-eyebrow">이의신청 내용</p>
+            <strong>{{ appealInfo.title }}</strong>
+            <p class="eval-form__summary-copy">{{ appealInfo.content }}</p>
+          </div>
+        </div>
+      </section>
+    </template>
+
     <template #footer>
       <div class="eval-form__actions">
         <div class="eval-form__submit-hint" :class="{ 'eval-form__submit-hint--submitted': readonly }">
-          <strong>1차 평가 작성 현황</strong>
+          <strong>{{ progressLabel }}</strong>
           <span>{{ `${(selectedTarget.convertedText ?? '').trim().length}자 입력 완료` }}</span>
           <span v-if="selectedTarget.expectedScore != null" class="eval-form__score-hint">
             예상 점수: {{ selectedTarget.expectedScore }}점
@@ -62,24 +91,80 @@ const emit = defineEmits([
         />
       </div>
     </template>
-  </AiEvaluationFormPanel>
+  </EvalDetailLayout>
 
   <EvaluationGuideModal :open="guideOpen" @close="emit('toggle-guide')" />
 </template>
 
 <style scoped>
-.tl-evaluation-form-panel {
-  overflow-y: auto;
-  min-height: 600px;
-  max-height: calc(100vh - 200px);
-}
-
 .eval-form__actions {
   display: flex;
   align-items: center;
   justify-content: flex-end;
   gap: 12px;
   flex-wrap: wrap;
+}
+
+.eval-form__summary-stack {
+  display: grid;
+  gap: 14px;
+  margin-bottom: 16px;
+}
+
+.eval-form__summary-card {
+  display: grid;
+  gap: 8px;
+  padding: 16px 18px;
+  border-radius: 18px;
+  border: 1px solid #e8e2ff;
+  background: #faf8ff;
+}
+
+.eval-form__summary-card--appeal {
+  gap: 14px;
+}
+
+.eval-form__summary-eyebrow {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--color-text-muted);
+}
+
+.eval-form__summary-copy {
+  margin: 0;
+  line-height: 1.7;
+  color: var(--color-primary-800);
+  white-space: pre-wrap;
+}
+
+.eval-form__appeal-meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.eval-form__appeal-meta-item {
+  display: grid;
+  gap: 6px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid var(--color-border-soft);
+}
+
+.eval-form__appeal-meta-item strong,
+.eval-form__appeal-body strong {
+  color: var(--color-primary-800);
+}
+
+.eval-form__appeal-body {
+  display: grid;
+  gap: 8px;
+  padding: 16px 18px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid var(--color-border-soft);
 }
 
 .eval-form__submit-hint {
@@ -105,5 +190,11 @@ const emit = defineEmits([
 .eval-form__score-hint {
   color: var(--color-primary-700);
   font-weight: var(--font-weight-semibold);
+}
+
+@media (max-width: 900px) {
+  .eval-form__appeal-meta {
+    grid-template-columns: 1fr;
+  }
 }
 </style>

--- a/src/components/hr/worker/appeal-request/WorkerAppealForm.vue
+++ b/src/components/hr/worker/appeal-request/WorkerAppealForm.vue
@@ -12,6 +12,7 @@ const emit = defineEmits(['cancel', 'submit'])
 const appealTitle = ref(props.appealData.title || '')
 const selectedType = ref(props.appealData.appealType || 'SCORE_ERRORS')
 const appealContent = ref(props.appealData.content || '')
+const selectedFiles = ref([])
 
 watch(
   () => props.appealData,
@@ -19,6 +20,7 @@ watch(
     appealTitle.value = data.title || ''
     selectedType.value = data.appealType || 'SCORE_ERRORS'
     appealContent.value = data.content || ''
+    selectedFiles.value = []
   },
 )
 
@@ -64,11 +66,29 @@ const typeLabel = computed(() => typeLabelMap[selectedType.value] ?? '기타')
 const statusLabel = computed(() => statusLabelMap[props.appealData.status] ?? '이의 신청 작성')
 const reviewResultLabel = computed(() => reviewResultLabelMap[props.appealData.reviewResult] ?? props.appealData.reviewResult)
 
+function formatFileSize(size) {
+  if (size == null || Number.isNaN(Number(size))) return ''
+  const value = Number(size)
+  if (value < 1024) return `${value}B`
+  if (value < 1024 * 1024) return `${(value / 1024).toFixed(1)}KB`
+  return `${(value / (1024 * 1024)).toFixed(1)}MB`
+}
+
+function handleFileChange(event) {
+  const files = Array.from(event.target.files ?? [])
+  selectedFiles.value = files
+}
+
+function removeSelectedFile(index) {
+  selectedFiles.value = selectedFiles.value.filter((_, fileIndex) => fileIndex !== index)
+}
+
 function handleSubmit() {
   const payload = {
     title: appealTitle.value,
     appealType: selectedType.value,
     content: appealContent.value,
+    files: selectedFiles.value,
   }
   emit('submit', payload)
   if (props.appealData.processStatus >= 1) {
@@ -146,6 +166,37 @@ function handleSubmit() {
           placeholder="이의 제기 내용을 입력해주세요."
           :disabled="isReadonly"
         ></textarea>
+      </div>
+
+      <div class="af__section">
+        <label class="af__section-title" for="appeal-files">첨부파일</label>
+        <input
+          v-if="!isReadonly"
+          id="appeal-files"
+          class="af__input"
+          type="file"
+          multiple
+          @change="handleFileChange"
+        />
+        <div v-if="selectedFiles.length" class="af__file-list">
+          <div v-for="(file, index) in selectedFiles" :key="`${file.name}-${index}`" class="af__file-item">
+            <span>{{ file.name }}</span>
+            <button type="button" class="af__file-remove" @click="removeSelectedFile(index)">삭제</button>
+          </div>
+        </div>
+        <div v-else-if="isReadonly && appealData.attachments?.length" class="af__file-list">
+          <div
+            v-for="attachment in appealData.attachments"
+            :key="attachment.attachmentId"
+            class="af__file-item"
+          >
+            <span>{{ attachment.fileName }}</span>
+            <span class="af__file-size">{{ formatFileSize(attachment.fileSize) }}</span>
+          </div>
+        </div>
+        <span class="af__summary-meta">
+          근거 자료가 있으면 PDF, 이미지, 엑셀 파일 등을 함께 첨부할 수 있습니다.
+        </span>
       </div>
 
       <div v-if="appealData.reviewResult" class="af__section af__section--result">
@@ -368,6 +419,38 @@ function handleSubmit() {
   outline: none;
   border-color: var(--color-primary-300);
   box-shadow: 0 0 0 3px rgba(91, 80, 214, 0.08);
+}
+
+.af__file-list {
+  display: grid;
+  gap: 8px;
+}
+
+.af__file-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--color-border-soft);
+  border-radius: 12px;
+  background: #faf8ff;
+  font-size: 13px;
+  color: var(--color-text-default);
+}
+
+.af__file-remove {
+  border: 0;
+  background: transparent;
+  color: #b91c1c;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.af__file-size {
+  color: var(--color-text-muted);
+  white-space: nowrap;
 }
 
 .af__section-title {

--- a/src/components/hr/worker/appeal-request/WorkerAppealForm.vue
+++ b/src/components/hr/worker/appeal-request/WorkerAppealForm.vue
@@ -3,38 +3,53 @@ import { ref, computed, watch } from 'vue'
 
 const props = defineProps({
   appealData: { type: Object, required: true },
-  statusBadge: { type: String, default: null },
 })
 
-const isConfirmed = computed(() => props.statusBadge === '확정')
+const isReadonly = computed(() => props.appealData.status !== 'NONE')
 
 const emit = defineEmits(['cancel', 'submit'])
 
 const appealTitle = ref(props.appealData.title || '')
-const selectedType = ref(props.appealData.appealType || 'QUANTITATIVE_ERROR')
+const selectedType = ref(props.appealData.appealType || 'SCORE_ERRORS')
 const appealContent = ref(props.appealData.content || '')
 
 watch(
   () => props.appealData,
   (data) => {
     appealTitle.value = data.title || ''
-    selectedType.value = data.appealType || 'QUANTITATIVE_ERROR'
+    selectedType.value = data.appealType || 'SCORE_ERRORS'
     appealContent.value = data.content || ''
   },
 )
 
 const typeOptions = [
-  { value: 'QUANTITATIVE_ERROR', label: '정량 평가 점수 오류' },
-  { value: 'QUALITATIVE_ERROR', label: '정성 평가 항목 이의' },
-  { value: 'EQUIPMENT_ERROR', label: '설비 보정 계수 오류' },
-  { value: 'ETC', label: '기타' },
+  { value: 'SCORE_ERRORS', label: '점수 오류' },
+  { value: 'MISSING_ITEMS', label: '평가 항목 누락' },
+  { value: 'EVALUATION_PROCEDURES', label: '평가 절차 이의' },
+  { value: 'OTHERS', label: '기타' },
 ]
+
+const typeLabelMap = Object.fromEntries(typeOptions.map((option) => [option.value, option.label]))
+
+const statusLabelMap = {
+  NONE: '작성 전',
+  SUBMITTED: 'HR 접수 대기',
+  RECEIVING: 'TL 검토 진행',
+  REVIEWING: 'DL 검토 진행',
+  COMPLETED: '처리 완료',
+}
+
+const reviewResultLabelMap = {
+  ACKNOWLEDGE: '인용',
+  ACKNOWLEDGE_IN_PART: '일부 인용',
+  DISMISS: '기각',
+}
 
 const processSteps = computed(() => {
   const s = props.appealData.processStatus
   return [
-    { label: '제출완료', active: s >= 1, current: s === 1 },
-    { label: 'HR 검토중', active: s >= 2, current: s === 2 },
+    { label: '이의 신청 제출', active: s >= 1, current: s === 1 },
+    { label: '담당자 검토', active: s >= 2, current: s === 2 },
     { label: '결과 통보', active: s >= 3, current: s === 3 },
   ]
 })
@@ -44,6 +59,10 @@ const showToast = ref(false)
 const submitLabel = computed(() => {
   return props.appealData.processStatus >= 1 ? '수정 제출' : '제출'
 })
+
+const typeLabel = computed(() => typeLabelMap[selectedType.value] ?? '기타')
+const statusLabel = computed(() => statusLabelMap[props.appealData.status] ?? '이의 신청 작성')
+const reviewResultLabel = computed(() => reviewResultLabelMap[props.appealData.reviewResult] ?? props.appealData.reviewResult)
 
 function handleSubmit() {
   const payload = {
@@ -60,132 +79,264 @@ function handleSubmit() {
 </script>
 
 <template>
-  <div class="af">
-    <div class="af__header">
-      <span class="af__icon">✋</span>
-      <h3 class="af__title">이의 신청 — {{ appealData.quarter }}</h3>
-    </div>
+  <section class="af">
+    <header class="af__header">
+      <div class="af__header-copy">
+        <span class="af__eyebrow">Worker Appeal</span>
+        <div class="af__title-row">
+          <span class="af__icon">✋</span>
+          <h3 class="af__title">이의 신청서</h3>
+        </div>
+        <p class="af__description">
+          선택한 평가 이력에 대해 근거와 함께 이의 신청을 제출할 수 있습니다. 접수 후 HR, TL, DL 검토 절차에 따라 처리됩니다.
+        </p>
+      </div>
+      <div class="af__status-chip" :class="{ 'af__status-chip--done': props.appealData.status === 'COMPLETED' }">
+        {{ statusLabel }}
+      </div>
+    </header>
 
-    <!-- Title -->
-    <div class="af__section">
-      <h4 class="af__section-title">제목</h4>
-      <input
-        v-model="appealTitle"
-        class="af__input"
-        type="text"
-        placeholder="이의 신청 제목을 입력해주세요."
-        :disabled="isConfirmed"
-      />
-    </div>
-
-    <!-- Appeal Type -->
-    <div class="af__section">
-      <h4 class="af__section-title">이의 제기 항목</h4>
-      <select
-        v-model="selectedType"
-        class="af__select"
-        :disabled="isConfirmed"
-      >
-        <option v-for="opt in typeOptions" :key="opt.value" :value="opt.value">
-          {{ opt.label }}
-        </option>
-      </select>
-    </div>
-
-    <!-- Content -->
-    <div class="af__section">
-      <h4 class="af__section-title">이의 제기 내용</h4>
-      <textarea
-        v-model="appealContent"
-        class="af__textarea"
-        rows="4"
-        placeholder="이의 제기 내용을 입력해주세요."
-        :disabled="isConfirmed"
-      ></textarea>
-    </div>
-
-    <!-- Review Result (if available) -->
-    <div v-if="appealData.reviewResult" class="af__section af__section--result">
-      <h4 class="af__section-title">검토 결과</h4>
-      <div class="af__result-box">
-        {{ appealData.reviewResult }}
+    <div class="af__summary">
+      <div class="af__summary-card">
+        <span class="af__summary-label">대상 평가기간</span>
+        <strong class="af__summary-value">{{ appealData.quarter || '-' }}</strong>
+        <span class="af__summary-meta">현재 선택된 평가 결과를 기준으로 신청합니다.</span>
+      </div>
+      <div class="af__summary-card">
+        <span class="af__summary-label">이의 유형</span>
+        <select
+          v-if="!isReadonly"
+          id="appeal-type"
+          v-model="selectedType"
+          class="af__select"
+        >
+          <option v-for="opt in typeOptions" :key="opt.value" :value="opt.value">
+            {{ opt.label }}
+          </option>
+        </select>
+        <strong v-else class="af__summary-value af__summary-value--compact">{{ typeLabel }}</strong>
+        <span class="af__summary-meta">
+          {{ appealData.submittedDate !== '-' ? `최종 제출일 ${appealData.submittedDate}` : '아직 제출되지 않았습니다.' }}
+        </span>
       </div>
     </div>
 
-    <!-- Process Status -->
-    <div class="af__process">
-      <div class="af__process-steps">
-        <template v-for="(step, i) in processSteps" :key="step.label">
-          <span
-            class="af__step"
-            :class="{
-              'af__step--done': step.active && !step.current,
-              'af__step--current': step.current,
-            }"
-          >
-            {{ step.label }}
-            <span v-if="step.active && !step.current" class="af__step-check">✓</span>
-            <span v-else-if="step.current" class="af__step-dot">●</span>
-            <span v-else class="af__step-dot af__step-dot--empty">○</span>
-          </span>
-          <span v-if="i < processSteps.length - 1" class="af__step-arrow">→</span>
-        </template>
+    <div class="af__body">
+      <div class="af__field-grid">
+        <div class="af__section">
+          <label class="af__section-title" for="appeal-title">제목</label>
+          <input
+            id="appeal-title"
+          v-model="appealTitle"
+          class="af__input"
+          type="text"
+          placeholder="이의 신청 제목을 입력해주세요."
+          :disabled="isReadonly"
+          />
+        </div>
       </div>
-      <span class="af__process-meta">
-        제출일: {{ appealData.submittedDate }} · 예상 처리: 영업일 5일 이내
-      </span>
+
+      <div class="af__section">
+        <label class="af__section-title" for="appeal-content">이의 제기 내용</label>
+        <textarea
+          id="appeal-content"
+          v-model="appealContent"
+          class="af__textarea"
+          rows="8"
+          placeholder="이의 제기 내용을 입력해주세요."
+          :disabled="isReadonly"
+        ></textarea>
+      </div>
+
+      <div v-if="appealData.reviewResult" class="af__section af__section--result">
+        <span class="af__section-title">검토 결과</span>
+        <div class="af__result-box">
+          <strong class="af__result-title">{{ reviewResultLabel }}</strong>
+          <span class="af__result-text">담당자 검토 결과가 반영되었습니다.</span>
+        </div>
+      </div>
     </div>
 
-    <!-- Actions -->
-    <div v-if="!isConfirmed" class="af__actions">
-      <button class="af__btn af__btn--cancel" @click="emit('cancel')">취소</button>
-      <button class="af__btn af__btn--submit" @click="handleSubmit">
-        {{ submitLabel }}
-      </button>
+    <div class="af__footer">
+      <div class="af__process">
+        <div class="af__process-head">
+          <strong>처리 단계</strong>
+          <span>예상 처리: 영업일 5일 이내</span>
+        </div>
+        <div class="af__process-steps">
+          <template v-for="(step, i) in processSteps" :key="step.label">
+            <span
+              class="af__step"
+              :class="{
+                'af__step--done': step.active && !step.current,
+                'af__step--current': step.current,
+              }"
+            >
+              <span class="af__step-mark">
+                <span v-if="step.active && !step.current" class="af__step-check">✓</span>
+                <span v-else-if="step.current" class="af__step-dot">●</span>
+                <span v-else class="af__step-dot af__step-dot--empty">○</span>
+              </span>
+              <span>{{ step.label }}</span>
+            </span>
+            <span v-if="i < processSteps.length - 1" class="af__step-arrow">→</span>
+          </template>
+        </div>
+        <span class="af__process-meta">
+          제출일: {{ appealData.submittedDate }} · 접수 이후 단계별 검토 상태가 반영됩니다.
+        </span>
+      </div>
+
+      <div v-if="!isReadonly" class="af__actions">
+        <button class="af__btn af__btn--cancel" @click="emit('cancel')">취소</button>
+        <button class="af__btn af__btn--submit" @click="handleSubmit">
+          {{ submitLabel }}
+        </button>
+      </div>
     </div>
 
     <Transition name="af__toast-fade">
       <div v-if="showToast" class="af__toast">수정되었습니다</div>
     </Transition>
-  </div>
+  </section>
 </template>
 
 <style scoped>
 .af {
   background: var(--color-bg-surface);
   border: 1px solid var(--color-border-default);
-  border-radius: var(--radius-card);
+  border-radius: 24px;
   padding: 24px;
   display: flex;
   flex-direction: column;
   gap: 20px;
+  min-height: 600px;
 }
 
 .af__header {
   display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--color-border-soft);
+}
+
+.af__header-copy {
+  display: grid;
+  gap: 8px;
+}
+
+.af__eyebrow {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-primary-500);
+}
+
+.af__title-row {
+  display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
 }
 
 .af__icon {
-  font-size: 16px;
+  font-size: 18px;
 }
 
 .af__title {
-  font-size: 16px;
+  font-size: 24px;
   font-weight: 700;
-  color: var(--color-text-strong);
+  color: var(--color-primary-800);
   margin: 0;
 }
 
-/* ── Form Elements ─────────────────────────────────────── */
+.af__description {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--color-text-muted);
+}
+
+.af__status-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  align-self: flex-start;
+  min-height: 38px;
+  padding: 0 14px;
+  border-radius: 999px;
+  background: var(--color-primary-100);
+  color: var(--color-primary-700);
+  font-size: 13px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.af__status-chip--done {
+  background: var(--color-success-soft);
+  color: #166534;
+}
+
+.af__summary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.af__summary-card {
+  display: grid;
+  gap: 6px;
+  padding: 18px 20px;
+  border: 1px solid var(--color-border-soft);
+  border-radius: 18px;
+  background: #faf8ff;
+}
+
+.af__summary-label {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--color-text-muted);
+}
+
+.af__summary-value {
+  font-size: 18px;
+  color: var(--color-primary-800);
+}
+
+.af__summary-value--compact {
+  font-size: 16px;
+}
+
+.af__summary-meta {
+  font-size: 13px;
+  color: var(--color-text-muted);
+}
+
+.af__body {
+  display: grid;
+  gap: 18px;
+}
+
+.af__field-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+}
+
+.af__section {
+  display: grid;
+  gap: 10px;
+}
+
 .af__input,
 .af__select {
   box-sizing: border-box;
   width: 100%;
   border: 1px solid var(--color-border-default);
-  border-radius: var(--radius-base);
-  padding: 10px 14px;
+  border-radius: 14px;
+  padding: 12px 14px;
   font-size: 14px;
   color: var(--color-text-default);
   background: var(--color-bg-surface);
@@ -195,62 +346,97 @@ function handleSubmit() {
 .af__select:focus {
   outline: none;
   border-color: var(--color-primary-300);
+  box-shadow: 0 0 0 3px rgba(91, 80, 214, 0.08);
 }
 
 .af__textarea {
   box-sizing: border-box;
   width: 100%;
   border: 1px solid var(--color-border-default);
-  border-radius: var(--radius-base);
+  border-radius: 18px;
   padding: 16px 18px;
   font-size: 14px;
   color: var(--color-text-default);
   line-height: 1.7;
   resize: vertical;
   font-family: inherit;
+  min-height: 220px;
+  background: var(--color-bg-surface);
 }
 
 .af__textarea:focus {
   outline: none;
   border-color: var(--color-primary-300);
-  box-shadow: var(--shadow-focus);
+  box-shadow: 0 0 0 3px rgba(91, 80, 214, 0.08);
 }
 
-.af__section--result {
-  margin-top: 10px;
-}
-
-.af__result-box {
-  background: var(--color-primary-100);
-  border: 1px solid var(--color-primary-200);
-  border-radius: var(--radius-base);
-  padding: 16px;
-  font-size: 14px;
-  color: var(--color-primary-800);
-  line-height: 1.6;
-}
-
-/* ── Sections ───────────────────────────────────────────── */
 .af__section-title {
   font-size: 14px;
   font-weight: 700;
   color: var(--color-text-strong);
-  margin: 0 0 10px;
+  margin: 0;
 }
 
-/* ── Process Status ─────────────────────────────────────── */
+.af__result-box {
+  display: grid;
+  gap: 4px;
+  background: #f7f4ff;
+  border: 1px solid #d9d1ff;
+  border-radius: 16px;
+  padding: 16px;
+  color: var(--color-primary-800);
+}
+
+.af__result-title {
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.af__result-text {
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.af__footer {
+  display: grid;
+  gap: 16px;
+  margin-top: auto;
+  padding-top: 18px;
+  border-top: 1px solid var(--color-border-soft);
+}
+
 .af__process {
-  background: #fef9e7;
+  display: grid;
+  gap: 12px;
+  padding: 18px 20px;
   border: 1px solid #f5e6a3;
-  border-radius: var(--radius-base);
-  padding: 16px 20px;
+  border-radius: 18px;
+  background: #fff8e7;
+}
+
+.af__process-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.af__process-head strong {
+  font-size: 14px;
+  color: #8a5a00;
+}
+
+.af__process-head span {
+  font-size: 12px;
+  color: #a27000;
 }
 
 .af__process-steps {
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-bottom: 8px;
+  flex-wrap: wrap;
 }
 
 .af__step {
@@ -259,7 +445,17 @@ function handleSubmit() {
   color: var(--color-text-muted);
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 8px;
+}
+
+.af__step-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.7);
 }
 
 .af__step--done {
@@ -292,7 +488,6 @@ function handleSubmit() {
   color: var(--color-text-muted);
 }
 
-/* ── Actions ────────────────────────────────────────────── */
 .af__actions {
   display: flex;
   justify-content: flex-end;
@@ -300,8 +495,9 @@ function handleSubmit() {
 }
 
 .af__btn {
-  padding: 10px 28px;
-  border-radius: var(--radius-sm);
+  min-width: 96px;
+  padding: 11px 22px;
+  border-radius: 14px;
   font-size: 14px;
   font-weight: 700;
   cursor: pointer;
@@ -347,5 +543,30 @@ function handleSubmit() {
 .af__toast-fade-leave-to {
   opacity: 0;
   transform: translateX(-50%) translateY(10px);
+}
+
+@media (max-width: 1080px) {
+  .af__summary,
+  .af__field-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .af {
+    padding: 20px;
+  }
+
+  .af__header {
+    flex-direction: column;
+  }
+
+  .af__actions {
+    justify-content: stretch;
+  }
+
+  .af__btn {
+    flex: 1;
+  }
 }
 </style>

--- a/src/components/hr/worker/appeal-request/WorkerAppealHistory.vue
+++ b/src/components/hr/worker/appeal-request/WorkerAppealHistory.vue
@@ -13,26 +13,25 @@ function tierClass(tier) {
   return 'tier--c'
 }
 
-function diffClass(val) {
-  return val > 0 ? 'diff--up' : val < 0 ? 'diff--down' : ''
+function periodLabel(item) {
+  const raw = String(item.evalYear ?? '')
+  if (raw.length === 6) {
+    const year = raw.slice(0, 4)
+    const month = Number(raw.slice(4, 6))
+    return `${year}년 ${month}월 ${item.evalSequence}차`
+  }
+  return `${item.evalYear}년 ${item.evalSequence}차`
 }
 
-function diffText(val) {
-  if (val > 0) return `▲${val}`
-  if (val < 0) return `▼${Math.abs(val)}`
-  return '—'
-}
-
-function statusBadgeClass(status) {
-  if (status === '검토중') return 'badge--review'
-  return 'badge--confirmed'
+function fmt(val) {
+  if (val == null) return '—'
+  return Number(val).toFixed(1)
 }
 </script>
 
 <template>
   <div class="ah">
     <div class="ah__header">
-      <span class="ah__icon">📊</span>
       <h3 class="ah__title">내 평가 이력</h3>
     </div>
 
@@ -45,14 +44,34 @@ function statusBadgeClass(status) {
         @click="emit('select', item.id)"
       >
         <div class="ah__card-top">
-          <span class="ah__quarter">{{ item.quarter }}</span>
-          <span class="ah__badge" :class="statusBadgeClass(item.statusBadge)">
-            {{ item.statusBadge }}
-          </span>
+          <span class="ah__period">{{ periodLabel(item) }}</span>
+          <span v-if="item.underReview" class="ah__badge badge--review">검토중</span>
+          <span v-else-if="item.appealable" class="ah__badge badge--appealable">이의신청 가능</span>
+          <span v-else class="ah__badge badge--confirmed">확정</span>
         </div>
-        <div class="ah__card-score">
-          <span class="ah__score">{{ item.score }}</span>
-          <span class="ah__tier" :class="tierClass(item.tier)">{{ item.tier }}</span>
+
+        <div class="ah__scores">
+          <div class="ah__score-item">
+            <span class="ah__score-label">1차</span>
+            <span class="ah__score-value">{{ fmt(item.firstScore) }}</span>
+          </div>
+          <div class="ah__score-divider" />
+          <div class="ah__score-item">
+            <span class="ah__score-label">2차</span>
+            <span class="ah__score-value">{{ fmt(item.secondScore) }}</span>
+          </div>
+          <div class="ah__score-divider" />
+          <div class="ah__score-item">
+            <span class="ah__score-label">정량</span>
+            <span class="ah__score-value">{{ fmt(item.quantScore) }}</span>
+          </div>
+        </div>
+
+        <div class="ah__card-bottom">
+          <span v-if="item.grade" class="ah__tier" :class="tierClass(item.grade)">
+            {{ item.grade }}
+          </span>
+          <span class="ah__final-score">최종 {{ fmt(item.score) }}점</span>
         </div>
       </div>
     </div>
@@ -73,11 +92,6 @@ function statusBadgeClass(status) {
 .ah__header {
   display: flex;
   align-items: center;
-  gap: 6px;
-}
-
-.ah__icon {
-  font-size: 16px;
 }
 
 .ah__title {
@@ -96,9 +110,12 @@ function statusBadgeClass(status) {
 .ah__card {
   border: 1px solid var(--color-border-default);
   border-radius: var(--radius-md);
-  padding: 20px 22px;
+  padding: 18px 20px;
   cursor: pointer;
   transition: all 0.15s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .ah__card:hover {
@@ -109,23 +126,23 @@ function statusBadgeClass(status) {
   background: var(--color-primary-100);
   border-color: var(--color-primary-700);
   border-width: 2px;
-  padding: 19px 21px;
+  padding: 17px 19px;
 }
 
 .ah__card-top {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 6px;
 }
 
-.ah__quarter {
+.ah__period {
   font-size: 13px;
+  font-weight: 600;
   color: var(--color-text-muted);
 }
 
 .ah__badge {
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 700;
   padding: 3px 10px;
   border-radius: var(--radius-2xs);
@@ -136,69 +153,69 @@ function statusBadgeClass(status) {
   color: #92400e;
 }
 
+.badge--appealable {
+  background: var(--color-primary-100);
+  color: var(--color-primary-700);
+}
+
 .badge--confirmed {
   background: var(--color-success-soft);
   color: #166534;
 }
 
-.ah__card-score {
+.ah__scores {
   display: flex;
-  align-items: baseline;
-  gap: 8px;
-  margin-bottom: 6px;
+  align-items: center;
+  gap: 12px;
 }
 
-.ah__score {
-  font-size: 36px;
-  font-weight: 800;
+.ah__score-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  flex: 1;
+}
+
+.ah__score-label {
+  font-size: 11px;
+  color: var(--color-text-muted);
+  font-weight: 500;
+}
+
+.ah__score-value {
+  font-size: 20px;
+  font-weight: 700;
   color: var(--color-text-strong);
-  line-height: 1;
+}
+
+.ah__score-divider {
+  width: 1px;
+  height: 32px;
+  background: var(--color-border-default);
+}
+
+.ah__card-bottom {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .ah__tier {
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 800;
   color: var(--color-white);
   padding: 2px 8px;
   border-radius: var(--radius-2xs);
 }
 
-.tier--s {
-  background: var(--tier-s);
-}
+.tier--s { background: var(--tier-s); }
+.tier--a { background: var(--color-primary-700); }
+.tier--b { background: var(--tier-b); color: #92400e; }
+.tier--c { background: var(--tier-c); }
 
-.tier--a {
-  background: var(--color-primary-700);
-}
-
-.tier--b {
-  background: var(--tier-b);
-  color: #92400e;
-}
-
-.tier--c {
-  background: var(--tier-c);
-}
-
-.ah__diff {
-  font-size: 14px;
-  font-weight: 700;
-}
-
-.diff--up {
-  color: var(--tier-s);
-}
-
-.diff--down {
-  color: var(--color-danger);
-}
-
-.ah__status-text {
+.ah__final-score {
   font-size: 13px;
   color: var(--color-text-muted);
-}
-
-.ah__card--selected .ah__status-text {
-  color: var(--color-primary-700);
 }
 </style>

--- a/src/components/hr/worker/appeal-request/WorkerAppealHistory.vue
+++ b/src/components/hr/worker/appeal-request/WorkerAppealHistory.vue
@@ -6,6 +6,14 @@ const props = defineProps({
 
 const emit = defineEmits(['select'])
 
+function badgeClass(item) {
+  if (item.displayBadgeTone === 'appeal') return 'badge--appeal'
+  if (item.displayBadgeTone === 'completed') return 'badge--completed'
+  if (item.displayBadgeTone === 'review') return 'badge--review'
+  if (item.displayBadgeTone === 'appealable') return 'badge--appealable'
+  return 'badge--confirmed'
+}
+
 function tierClass(tier) {
   if (tier === 'S') return 'tier--s'
   if (tier === 'A') return 'tier--a'
@@ -32,7 +40,7 @@ function fmt(val) {
 <template>
   <div class="ah">
     <div class="ah__header">
-      <h3 class="ah__title">내 평가 이력</h3>
+      <h3 class="ah__title">내 이의신청 / 평가 이력</h3>
     </div>
 
     <div class="ah__list">
@@ -45,9 +53,7 @@ function fmt(val) {
       >
         <div class="ah__card-top">
           <span class="ah__period">{{ periodLabel(item) }}</span>
-          <span v-if="item.underReview" class="ah__badge badge--review">검토중</span>
-          <span v-else-if="item.appealable" class="ah__badge badge--appealable">이의신청 가능</span>
-          <span v-else class="ah__badge badge--confirmed">확정</span>
+          <span class="ah__badge" :class="badgeClass(item)">{{ item.displayBadge }}</span>
         </div>
 
         <div class="ah__scores">
@@ -153,9 +159,19 @@ function fmt(val) {
   color: #92400e;
 }
 
+.badge--appeal {
+  background: #e0f2fe;
+  color: #075985;
+}
+
 .badge--appealable {
   background: var(--color-primary-100);
   color: var(--color-primary-700);
+}
+
+.badge--completed {
+  background: var(--color-success-soft);
+  color: #166534;
 }
 
 .badge--confirmed {

--- a/src/services/departmentleader/evaluationApi.js
+++ b/src/services/departmentleader/evaluationApi.js
@@ -24,3 +24,23 @@ export function updateDlEvaluation(employeeId, { status, evaluationPeriodId, eva
     inputMethod,
   })
 }
+
+/** DL 이의신청 목록 조회 */
+export function fetchDlAppeals() {
+  return hrApi.get('/api/v1/hr/department-leader/appeals')
+}
+
+/** DL 이의신청 상세 조회 */
+export function fetchDlAppealDetail(appealId) {
+  return hrApi.get(`/api/v1/hr/appeals/${appealId}`)
+}
+
+/** DL 이의신청 최종 인용 */
+export function approveDlAppeal(appealId, payload = {}) {
+  return hrApi.patch(`/api/v1/hr/department-leader/appeals/${appealId}/approve`, payload)
+}
+
+/** DL 이의신청 일부 인용 종료 */
+export function rejectDlAppeal(appealId, payload = {}) {
+  return hrApi.patch(`/api/v1/hr/department-leader/appeals/${appealId}/reject`, payload)
+}

--- a/src/services/hrApprovalApi.js
+++ b/src/services/hrApprovalApi.js
@@ -13,6 +13,14 @@ const hrApprovalApi = {
     return hrApi.patch(`/api/v1/hr/appeals/${appealId}`, payload)
   },
 
+  receiveAppeal(appealId) {
+    return hrApi.patch(`/api/v1/hr/appeals/${appealId}/receive`)
+  },
+
+  rejectAppeal(appealId, payload = {}) {
+    return hrApi.patch(`/api/v1/hr/appeals/${appealId}/reject`, payload)
+  },
+
   getEvaluationApprovals(params = {}) {
     return hrApi.get('/api/v1/hr/evaluations', { params })
   },

--- a/src/services/hrApprovalApi.js
+++ b/src/services/hrApprovalApi.js
@@ -1,0 +1,33 @@
+import hrApi from './hrApi.js'
+
+const hrApprovalApi = {
+  getAppeals(params = {}) {
+    return hrApi.get('/api/v1/hr/appeals', { params })
+  },
+
+  getAppealById(appealId) {
+    return hrApi.get(`/api/v1/hr/appeals/${appealId}`)
+  },
+
+  updateAppealStatus(appealId, payload) {
+    return hrApi.patch(`/api/v1/hr/appeals/${appealId}`, payload)
+  },
+
+  getEvaluationApprovals(params = {}) {
+    return hrApi.get('/api/v1/hr/evaluations', { params })
+  },
+
+  getEvaluationPeriods(params = {}) {
+    return hrApi.get('/api/v1/hr/evaluation-periods', { params })
+  },
+
+  getEvaluationApprovalDetail(evalId) {
+    return hrApi.get(`/api/v1/hr/evaluations/${evalId}`)
+  },
+
+  confirmEvaluation(employeeId, payload) {
+    return hrApi.patch(`/api/v1/hr/hr-manager/evaluations/${employeeId}`, payload)
+  },
+}
+
+export default hrApprovalApi

--- a/src/services/hrmanager/promotionApi.js
+++ b/src/services/hrmanager/promotionApi.js
@@ -1,0 +1,21 @@
+import hrApi from '../hrApi.js'
+
+const promotionApi = {
+  getSummary() {
+    return hrApi.get('/api/v1/hr/promotions/summary')
+  },
+
+  getCandidates(params = {}) {
+    return hrApi.get('/api/v1/hr/promotions/candidates', { params })
+  },
+
+  getCandidateDetail(candidateId) {
+    return hrApi.get(`/api/v1/hr/promotions/${candidateId}`)
+  },
+
+  updateStatus(candidateId, status) {
+    return hrApi.patch(`/api/v1/hr/promotions/${candidateId}`, { status })
+  },
+}
+
+export default promotionApi

--- a/src/services/teamleader/evaluationApi.js
+++ b/src/services/teamleader/evaluationApi.js
@@ -17,3 +17,23 @@ export function updateTlEvaluation(evaluateeId, { status, evaluationPeriodId, ev
     inputMethod,
   })
 }
+
+/** TL 이의신청 목록 조회 */
+export function fetchTlAppeals() {
+  return hrApi.get('/api/v1/hr/team-leader/appeals')
+}
+
+/** TL 이의신청 상세 조회 */
+export function fetchTlAppealDetail(appealId) {
+  return hrApi.get(`/api/v1/hr/appeals/${appealId}`)
+}
+
+/** TL 이의신청 승인 후 DL 단계로 전달 */
+export function approveTlAppeal(appealId, payload = {}) {
+  return hrApi.patch(`/api/v1/hr/team-leader/appeals/${appealId}/approve`, payload)
+}
+
+/** TL 이의신청 기각 */
+export function rejectTlAppeal(appealId, payload = {}) {
+  return hrApi.patch(`/api/v1/hr/team-leader/appeals/${appealId}/reject`, payload)
+}

--- a/src/services/workerHrApi.js
+++ b/src/services/workerHrApi.js
@@ -310,41 +310,42 @@ export async function getWorkerSkillGap(targetTier = 'S+') {
 
 function toEvalHistoryViewModel(item) {
   return {
-    id: item.qualitativeEvaluationId, // Backend uses qualitativeEvaluationId as the key for appeal
+    id: item.qualitativeEvaluationId,
+    qualitativeEvaluationId: item.qualitativeEvaluationId,
     evalPeriodId: item.evalPeriodId,
-    quarter: `${item.evalYear}-${item.evalSequence}`,
+    evalYear: item.evalYear,
+    evalSequence: item.evalSequence,
+    grade: normalizeTier(item.grade),
     statusBadge: item.status === 'CONFIRMED' ? '확정' : '검토중',
     score: toNumber(item.score),
-    tier: normalizeTier(item.grade),
+    firstScore: toNumber(item.firstScore),
+    secondScore: toNumber(item.secondScore),
+    quantScore: toNumber(item.quantScore),
+    underReview: !!item.underReview,
     appealable: !!item.appealable,
-    // diff: Deleted as backend doesn't provide
-    // statusText: Deleted as backend doesn't provide
   }
 }
 
 function toAppealDetailViewModel(appeal) {
   if (!appeal) return null
 
-  // Process status mapping: PENDING=1, REVIEWING=2, COMPLETED=3
   const statusStepMap = {
-    PENDING: 1,
+    SUBMITTED: 1,
+    RECEIVING: 2,
     REVIEWING: 2,
     COMPLETED: 3,
   }
 
   return {
     appealId: appeal.appealId,
-    evalHistoryId: appeal.qualitativeEvaluationId,
+    evalPeriodId: appeal.evaluationPeriodId,
     title: appeal.title ?? '-',
     content: appeal.content ?? '',
-    appealType: appeal.appealType ?? 'ETC',
-    status: appeal.status ?? 'PENDING',
+    appealType: appeal.appealType ?? 'OTHERS',
+    status: appeal.status ?? 'SUBMITTED',
     processStatus: statusStepMap[appeal.status] ?? 1,
     submittedDate: formatDate(appeal.filedAt),
     reviewResult: appeal.reviewResult ?? '',
-    // quarter: Missing in backend
-    // scores: Missing in backend
-    // attachments: Missing in backend
   }
 }
 

--- a/src/services/workerHrApi.js
+++ b/src/services/workerHrApi.js
@@ -326,6 +326,13 @@ function toEvalHistoryViewModel(item) {
   }
 }
 
+const appealStatusLabelMap = {
+  SUBMITTED: '제출됨',
+  RECEIVING: '접수중',
+  REVIEWING: '검토중',
+  COMPLETED: '처리완료',
+}
+
 function toAppealDetailViewModel(appeal) {
   if (!appeal) return null
 
@@ -339,24 +346,142 @@ function toAppealDetailViewModel(appeal) {
   return {
     appealId: appeal.appealId,
     evalPeriodId: appeal.evaluationPeriodId,
+    evalYear: appeal.evalYear,
+    evalSequence: appeal.evalSequence,
     title: appeal.title ?? '-',
     content: appeal.content ?? '',
     appealType: appeal.appealType ?? 'OTHERS',
     status: appeal.status ?? 'SUBMITTED',
     processStatus: statusStepMap[appeal.status] ?? 1,
     submittedDate: formatDate(appeal.filedAt),
+    filedAt: appeal.filedAt ?? null,
     reviewResult: appeal.reviewResult ?? '',
+    attachments: (appeal.attachments ?? []).map((attachment) => ({
+      attachmentId: attachment.attachmentId,
+      fileName: attachment.fileName,
+      fileSize: toNumber(attachment.fileSize, null),
+    })),
   }
+}
+
+function toComparablePeriod(item) {
+  const year = String(item?.evalYear ?? '')
+  const sequence = String(item?.evalSequence ?? '').padStart(2, '0')
+  return `${year}${sequence}`
+}
+
+async function fetchAllWorkerEvalHistory(pageSize = 100) {
+  const history = []
+  let page = 0
+  let totalPages = 1
+
+  while (page < totalPages) {
+    const response = await hrApi.get('/api/v1/hr/workers/me/evaluations/history', {
+      params: { page, size: pageSize },
+    })
+    const data = unwrap(response) ?? {}
+    history.push(...(data.content ?? []).map(toEvalHistoryViewModel))
+    totalPages = data.totalPages ?? 0
+    page += 1
+  }
+
+  return history
+}
+
+function mergeAppealHistory(history, appeals) {
+  const appealByPeriodId = new Map(
+    appeals
+      .filter((appeal) => appeal?.evalPeriodId != null)
+      .map((appeal) => [appeal.evalPeriodId, appeal]),
+  )
+
+  const mergedHistory = history
+    .map((item) => {
+      const appeal = appealByPeriodId.get(item.evalPeriodId)
+
+      if (!appeal) {
+        return {
+          ...item,
+          hasAppeal: false,
+          displayBadge: item.underReview ? '검토중' : item.appealable ? '이의신청 가능' : '확정',
+          displayBadgeTone: item.underReview ? 'review' : item.appealable ? 'appealable' : 'confirmed',
+        }
+      }
+
+      const status = appeal.status ?? 'SUBMITTED'
+
+      return {
+        ...item,
+        hasAppeal: true,
+        appealId: appeal.appealId,
+        appealStatus: status,
+        appealFiledAt: appeal.filedAt,
+        displayBadge: appealStatusLabelMap[status] ?? status,
+        displayBadgeTone: status === 'COMPLETED' ? 'completed' : 'appeal',
+      }
+    })
+
+  const historyPeriodIds = new Set(history.map((item) => item.evalPeriodId))
+  const appealOnlyHistory = appeals
+    .filter((appeal) => appeal?.evalPeriodId != null && !historyPeriodIds.has(appeal.evalPeriodId))
+    .map((appeal) => {
+      const status = appeal.status ?? 'SUBMITTED'
+
+      return {
+        id: -(appeal.appealId ?? appeal.evalPeriodId),
+        qualitativeEvaluationId: null,
+        evalPeriodId: appeal.evalPeriodId,
+        evalYear: appeal.evalYear,
+        evalSequence: appeal.evalSequence,
+        grade: null,
+        statusBadge: null,
+        score: null,
+        firstScore: null,
+        secondScore: null,
+        quantScore: null,
+        underReview: false,
+        appealable: false,
+        hasAppeal: true,
+        appealId: appeal.appealId,
+        appealStatus: status,
+        appealFiledAt: appeal.filedAt,
+        displayBadge: appealStatusLabelMap[status] ?? status,
+        displayBadgeTone: status === 'COMPLETED' ? 'completed' : 'appeal',
+      }
+    })
+
+  return [...mergedHistory, ...appealOnlyHistory].sort((a, b) => {
+    if (a.hasAppeal && b.hasAppeal) {
+      return String(b.appealFiledAt ?? '').localeCompare(String(a.appealFiledAt ?? ''))
+    }
+    if (a.hasAppeal !== b.hasAppeal) {
+      return a.hasAppeal ? -1 : 1
+    }
+    return toComparablePeriod(b).localeCompare(toComparablePeriod(a))
+  })
 }
 
 export async function getWorkerAppealRequestData() {
   const [historyResponse, appealsResponse] = await Promise.all([
-    hrApi.get('/api/v1/hr/workers/me/evaluations/history'),
+    fetchAllWorkerEvalHistory(),
     hrApi.get('/api/v1/hr/appeals/me'),
   ])
 
-  const history = (unwrap(historyResponse)?.content ?? []).map(toEvalHistoryViewModel)
-  const appeals = (unwrap(appealsResponse) ?? []).map(toAppealDetailViewModel)
+  const appealSummaries = unwrap(appealsResponse) ?? []
+  const appealDetails = await Promise.all(
+    appealSummaries.map(async (appeal) => {
+      const detailResponse = await hrApi.get(`/api/v1/hr/appeals/${appeal.appealId}`)
+      return toAppealDetailViewModel({
+        ...appeal,
+        ...(unwrap(detailResponse) ?? {}),
+      })
+    }),
+  )
+  const appeals = appealDetails.filter(Boolean)
+  const history = mergeAppealHistory(
+    historyResponse,
+    appeals,
+  )
 
   return {
     history,
@@ -367,6 +492,19 @@ export async function getWorkerAppealRequestData() {
 export async function registerAppeal(payload) {
   const response = await hrApi.post('/api/v1/hr/appeals', payload)
   return unwrap(response)
+}
+
+export async function uploadAppealAttachments(appealId, files = []) {
+  if (!appealId || !files.length) return
+
+  const formData = new FormData()
+  files.forEach((file) => formData.append('files', file))
+
+  await hrApi.post(`/api/v1/hr/appeals/${appealId}/attachments`, formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  })
 }
 
 export async function updateAppeal(appealId, payload) {

--- a/src/utils/hrListFormat.js
+++ b/src/utils/hrListFormat.js
@@ -1,0 +1,4 @@
+export function formatMemberMeta(employeeCode, departmentName, teamName) {
+  const org = [departmentName, teamName].filter(Boolean).join(' > ') || teamName || departmentName || ''
+  return [employeeCode, org].filter(Boolean).join(' · ')
+}

--- a/src/views/departmentleader/DepartmentLeaderSecondEvaluationView.vue
+++ b/src/views/departmentleader/DepartmentLeaderSecondEvaluationView.vue
@@ -1,10 +1,13 @@
 <script setup>
 import { ref, computed, onBeforeUnmount, onMounted } from 'vue'
-import { BaseProgressBar } from '@/components/common/base'
+import { BaseFilterTabs, BaseProgressBar } from '@/components/common/base'
 import { BaseToast } from '@/components/common/base/overlay'
+import ReviewerAppealDetailPanel from '@/components/hr/common/appeal/ReviewerAppealDetailPanel.vue'
+import ReviewerAppealListPanel from '@/components/hr/common/appeal/ReviewerAppealListPanel.vue'
 import DepartmentLeaderEvalMemberListPanel from '@/components/hr/departmentleader/second-evaluation/DepartmentLeaderEvalMemberListPanel.vue'
 import DepartmentLeaderEvalFormPanel from '@/components/hr/departmentleader/second-evaluation/DepartmentLeaderEvalFormPanel.vue'
-import { fetchDlTargets, fetchDlEvaluationDetail, updateDlEvaluation } from '@/services/departmentleader/evaluationApi'
+import { approveDlAppeal, fetchDlAppealDetail, fetchDlAppeals, fetchDlTargets, fetchDlEvaluationDetail, rejectDlAppeal, updateDlEvaluation } from '@/services/departmentleader/evaluationApi'
+import { formatMemberMeta } from '@/utils/hrListFormat'
 import { mapStatus, statusToLabel } from '@/utils/evaluationStatus'
 
 const members = ref([])
@@ -12,6 +15,113 @@ const selectedMember = ref(null)
 const evalPeriodId = ref(null)
 const periodInfo = ref(null)
 const toast = ref({ show: false, message: '', type: 'success' })
+const activeTab = ref('evaluation')
+const modeTabs = [
+  { key: 'evaluation', label: '평가 관리' },
+  { key: 'appeal', label: '이의신청' },
+]
+const appealSummaries = ref([])
+const selectedAppealId = ref(null)
+const selectedAppealDetail = ref(null)
+const appealActionLoading = ref(false)
+const appealReviewing = ref(false)
+const appealDraftMember = ref(null)
+const APPEAL_TYPE_LABEL = {
+  SCORE_ERRORS: '점수 오류',
+  MISSING_ITEMS: '평가 항목 누락',
+  EVALUATION_PROCEDURES: '평가 절차 이의',
+  OTHERS: '기타',
+}
+const APPEAL_STATUS_LABEL = {
+  SUBMITTED: '제출',
+  RECEIVING: '접수',
+  REVIEWING: '검토중',
+  COMPLETED: '완료',
+}
+const REVIEW_RESULT_LABEL = {
+  ACKNOWLEDGE: '인용',
+  ACKNOWLEDGE_IN_PART: '일부 인용',
+  DISMISS: '기각',
+}
+
+function unwrap(response) {
+  return response.data?.data ?? response.data
+}
+
+function formatShortDate(value) {
+  if (!value) return '-'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return '-'
+  return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, '0')}.${String(date.getDate()).padStart(2, '0')}`
+}
+
+function formatScore(value) {
+  const numeric = Number(value)
+  return Number.isFinite(numeric) ? `${numeric.toFixed(1)}점` : '-'
+}
+
+function formatPeriodText(evalYear, evalSequence) {
+  if (!evalYear) return '평가기간 미지정'
+  const raw = String(evalYear)
+  const year = raw.slice(0, 4)
+  const month = raw.length >= 6 ? String(parseInt(raw.slice(4), 10)) : null
+  return month
+    ? `${year}년 ${month}월 ${evalSequence}차`
+    : `${year}년 ${evalSequence}차`
+}
+
+function mapAppealSummary(appeal) {
+  return {
+    appealId: appeal.appealId,
+    appealEmployeeId: appeal.appealEmployeeId,
+    evaluationPeriodId: appeal.evaluationPeriodId,
+    employeeName: appeal.employeeName ?? '-',
+    employeeCode: appeal.employeeCode ?? '',
+    departmentName: appeal.departmentName ?? '',
+    teamName: appeal.teamName ?? '',
+    title: appeal.title ?? '제목 없음',
+    content: appeal.content ?? '내용이 없습니다.',
+    status: appeal.status ?? 'RECEIVING',
+    statusLabel: APPEAL_STATUS_LABEL[appeal.status] ?? (appeal.status ?? '-'),
+    appealTypeLabel: APPEAL_TYPE_LABEL[appeal.appealType] ?? (appeal.appealType ?? '-'),
+    filedAtLabel: formatShortDate(appeal.filedAt),
+    quantScoreLabel: '-',
+    firstScoreLabel: formatScore(appeal.firstScore),
+    secondScoreLabel: formatScore(appeal.secondScore),
+    averageScoreLabel: formatScore(appeal.averageScore),
+    periodLabel: formatPeriodText(appeal.evalYear, appeal.evalSequence),
+    firstStageComment: '',
+    secondStageComment: '',
+  }
+}
+
+function mapAppealDetail(appeal) {
+  if (!appeal) return null
+  return {
+    appealId: appeal.appealId,
+    appealEmployeeId: appeal.appealEmployeeId,
+    evaluationPeriodId: appeal.evaluationPeriodId,
+    employeeName: appeal.employeeName ?? '-',
+    employeeCode: appeal.employeeCode ?? '',
+    departmentName: appeal.departmentName ?? '',
+    teamName: appeal.teamName ?? '',
+    title: appeal.title ?? '제목 없음',
+    content: appeal.content ?? '내용이 없습니다.',
+    status: appeal.status ?? 'RECEIVING',
+    statusLabel: APPEAL_STATUS_LABEL[appeal.status] ?? (appeal.status ?? '-'),
+    appealTypeLabel: APPEAL_TYPE_LABEL[appeal.appealType] ?? (appeal.appealType ?? '-'),
+    reviewResultLabel: REVIEW_RESULT_LABEL[appeal.reviewResult] ?? '미처리',
+    filedAtLabel: formatShortDate(appeal.filedAt),
+    reviewedAtLabel: formatShortDate(appeal.reviewedAt),
+    quantScoreLabel: '-',
+    firstScoreLabel: formatScore(appeal.firstScore),
+    secondScoreLabel: formatScore(appeal.secondScore),
+    averageScoreLabel: formatScore(appeal.averageScore),
+    periodLabel: formatPeriodText(appeal.evalYear, appeal.evalSequence),
+    firstStageComment: appeal.firstStageComment ?? '',
+    secondStageComment: appeal.secondStageComment ?? '',
+  }
+}
 
 const periodLabel = computed(() => {
   if (!periodInfo.value?.evalYear) return null
@@ -48,7 +158,9 @@ function mapTarget(t) {
     avatarColor: avatarColor(t.employeeName),
     tier: t.employeeTier ?? '—',
     code: t.employeeCode ?? '',
+    departmentName: t.departmentName ?? '',
     team: t.teamName ?? '',
+    meta: formatMemberMeta(t.employeeCode ?? '', t.departmentName ?? '', t.teamName ?? ''),
     experience: '',
     status,
     statusDate: statusToLabel(status, t.status),
@@ -69,7 +181,7 @@ function showToast(message, type = 'success') {
 async function loadTargets() {
   try {
     const res = await fetchDlTargets()
-    const data = res.data.data
+    const data = unwrap(res)
     evalPeriodId.value = data.evalPeriodId
     periodInfo.value = {
       evalYear: data.evalYear,
@@ -83,6 +195,19 @@ async function loadTargets() {
     }
   } catch {
     showToast('평가 대상 목록을 불러오지 못했습니다.', 'error')
+  }
+}
+
+async function loadAppeals() {
+  try {
+    const res = await fetchDlAppeals()
+    const appeals = (unwrap(res) ?? []).map(mapAppealSummary)
+    appealSummaries.value = appeals
+    if (appeals.length) {
+      await handleSelectAppeal(appeals[0].appealId)
+    }
+  } catch {
+    showToast('이의신청 목록을 불러오지 못했습니다.', 'error')
   }
 }
 
@@ -111,6 +236,124 @@ async function handleSelect(member) {
     }
   } catch {
     // 1차 평가 상세가 없으면 summary null 유지 (v-if로 처리)
+  }
+}
+
+async function handleSelectAppeal(appealId) {
+  appealReviewing.value = false
+  appealDraftMember.value = null
+  selectedAppealId.value = appealId
+  const summary = appealSummaries.value.find((item) => item.appealId === appealId)
+  if (summary) {
+    selectedAppealDetail.value = { ...summary }
+  }
+  try {
+    const res = await fetchDlAppealDetail(appealId)
+    selectedAppealDetail.value = {
+      ...(summary ?? {}),
+      ...mapAppealDetail(unwrap(res)),
+    }
+  } catch {
+    selectedAppealDetail.value = null
+    showToast('이의신청 상세를 불러오지 못했습니다.', 'error')
+  }
+}
+
+function buildAppealDraftMember(detail, firstEvaluationSummary) {
+  return {
+    id: detail.appealEmployeeId,
+    evaluationPeriodId: detail.evaluationPeriodId,
+    name: detail.employeeName,
+    code: detail.employeeCode ?? '',
+    departmentName: detail.departmentName ?? '',
+    team: detail.teamName ?? '',
+    secondEvaluationDraft: detail.secondStageComment || '',
+    firstEvaluationSummary,
+    expectedScore: null,
+  }
+}
+
+async function handleStartAppealReview() {
+  const detail = selectedAppealDetail.value
+  if (!detail?.appealEmployeeId || !detail.evaluationPeriodId) return
+  try {
+    const res = await fetchDlEvaluationDetail(detail.appealEmployeeId, detail.evaluationPeriodId)
+    const evaluationDetail = unwrap(res)
+    appealDraftMember.value = buildAppealDraftMember(detail, {
+      quantitativeScore: null,
+      qualitativeScore: evaluationDetail.firstStageScore ?? null,
+      compositeScore: null,
+      qualitativeComment: evaluationDetail.evalComment ?? detail.firstStageComment ?? '',
+    })
+  } catch {
+    appealDraftMember.value = buildAppealDraftMember(detail, {
+      quantitativeScore: null,
+      qualitativeScore: null,
+      compositeScore: null,
+      qualitativeComment: detail.firstStageComment || '',
+    })
+  }
+  appealReviewing.value = true
+}
+
+const selectedAppealInfo = computed(() => {
+  const detail = selectedAppealDetail.value
+  if (!detail) return null
+  return {
+    periodLabel: detail.periodLabel,
+    typeLabel: detail.appealTypeLabel,
+    title: detail.title,
+    content: detail.content,
+  }
+})
+
+async function handleApproveAppeal(payload) {
+  if (!selectedAppealId.value || !appealDraftMember.value) return
+  try {
+    appealActionLoading.value = true
+    await updateDlEvaluation(appealDraftMember.value.id, {
+      status: 'SUBMITTED',
+      evaluationPeriodId: appealDraftMember.value.evaluationPeriodId,
+      evalComment: payload?.draftText ?? appealDraftMember.value.secondEvaluationDraft ?? '',
+      inputMethod: payload?.inputMethod ?? 'TEXT',
+    })
+    await approveDlAppeal(selectedAppealId.value, {})
+    const appeals = (unwrap(await fetchDlAppeals()) ?? []).map(mapAppealSummary)
+    appealSummaries.value = appeals
+    selectedAppealDetail.value = null
+    appealDraftMember.value = null
+    appealReviewing.value = false
+    selectedAppealId.value = appeals[0]?.appealId ?? null
+    if (selectedAppealId.value) {
+      await handleSelectAppeal(selectedAppealId.value)
+    }
+    showToast('이의신청을 인용 완료 처리했습니다.')
+  } catch {
+    showToast('이의신청 처리에 실패했습니다.', 'error')
+  } finally {
+    appealActionLoading.value = false
+  }
+}
+
+async function handleRejectAppeal() {
+  if (!selectedAppealId.value) return
+  try {
+    appealActionLoading.value = true
+    await rejectDlAppeal(selectedAppealId.value, { reason: '부서장 단계에서 일부 인용으로 종료되었습니다.' })
+    const appeals = (unwrap(await fetchDlAppeals()) ?? []).map(mapAppealSummary)
+    appealSummaries.value = appeals
+    selectedAppealDetail.value = null
+    appealDraftMember.value = null
+    appealReviewing.value = false
+    selectedAppealId.value = appeals[0]?.appealId ?? null
+    if (selectedAppealId.value) {
+      await handleSelectAppeal(selectedAppealId.value)
+    }
+    showToast('이의신청을 일부 인용으로 종료했습니다.')
+  } catch {
+    showToast('이의신청 처리에 실패했습니다.', 'error')
+  } finally {
+    appealActionLoading.value = false
   }
 }
 
@@ -165,7 +408,10 @@ async function handleSubmit(payload) {
   }
 }
 
-onMounted(loadTargets)
+onMounted(async () => {
+  await loadTargets()
+  await loadAppeals()
+})
 onBeforeUnmount(() => {
   if (toastTimer) clearTimeout(toastTimer)
 })
@@ -173,32 +419,38 @@ onBeforeUnmount(() => {
 
 <template>
   <section class="dl-eval-view">
-    <!-- Progress card -->
-    <section class="dl-eval-view__progress-card">
-      <div class="dl-eval-view__progress-copy">
-        <div>
-          <p class="dl-eval-view__progress-eyebrow">제출 완료 현황</p>
-          <strong class="dl-eval-view__progress-title">
-            {{ submittedCount }} / {{ totalCount }}명 제출 완료
-          </strong>
-        </div>
-        <div v-if="periodLabel" class="dl-eval-view__period-info">
-          <span class="dl-eval-view__period-badge">{{ periodLabel }}</span>
-          <span class="dl-eval-view__period-dates">
-            {{ periodInfo.startDate }} ~ {{ periodInfo.endDate }}
-          </span>
-        </div>
-      </div>
-      <BaseProgressBar
-        :value="progressPercent"
-        tone="success"
-        size="md"
-        label="평가 제출 진행률"
-      />
-    </section>
+    <BaseFilterTabs
+      v-model="activeTab"
+      :items="modeTabs"
+      variant="chip"
+      size="md"
+      class="dl-eval-view__tabs"
+    />
 
-    <!-- Content -->
-    <div class="dl-eval-view__content">
+    <div v-if="activeTab === 'evaluation'" class="dl-eval-view__content">
+      <section class="dl-eval-view__progress-card dl-eval-view__progress-card--full">
+        <div class="dl-eval-view__progress-copy">
+          <div>
+            <p class="dl-eval-view__progress-eyebrow">제출 완료 현황</p>
+            <strong class="dl-eval-view__progress-title">
+              {{ submittedCount }} / {{ totalCount }}명 제출 완료
+            </strong>
+          </div>
+          <div v-if="periodLabel" class="dl-eval-view__period-info">
+            <span class="dl-eval-view__period-badge">{{ periodLabel }}</span>
+            <span class="dl-eval-view__period-dates">
+              {{ periodInfo.startDate }} ~ {{ periodInfo.endDate }}
+            </span>
+          </div>
+        </div>
+        <BaseProgressBar
+          :value="progressPercent"
+          tone="success"
+          size="md"
+          label="평가 제출 진행률"
+        />
+      </section>
+
       <DepartmentLeaderEvalMemberListPanel
         :members="members"
         :selected-id="selectedMember?.id ?? null"
@@ -209,6 +461,34 @@ onBeforeUnmount(() => {
         :readonly="isSubmitted"
         @save="handleSave"
         @submit="handleSubmit"
+      />
+    </div>
+
+    <div v-else class="dl-eval-view__appeal-content">
+      <ReviewerAppealListPanel
+        :appeals="appealSummaries"
+        :selected-id="selectedAppealId"
+        role-label="DL"
+        @select="handleSelectAppeal"
+      />
+      <DepartmentLeaderEvalFormPanel
+        v-if="appealReviewing"
+        :member="appealDraftMember"
+        :appeal-info="selectedAppealInfo"
+        :readonly="false"
+        progress-label="이의신청 검토 작성 현황"
+        submit-label="검토 제출"
+        @save="handleSaveAppealDraft"
+        @submit="handleApproveAppeal"
+      />
+      <ReviewerAppealDetailPanel
+        v-else
+        :detail="selectedAppealDetail"
+        role-label="DL"
+        action-mode="dl"
+        :loading="appealActionLoading"
+        @review="handleStartAppealReview"
+        @reject="handleRejectAppeal"
       />
     </div>
     <BaseToast :show="toast.show" :message="toast.message" :type="toast.type" />
@@ -236,10 +516,55 @@ onBeforeUnmount(() => {
   display: grid;
   gap: 10px;
   padding: 14px 18px;
-  margin-bottom: 12px;
   border: 1px solid var(--color-border-default);
   border-radius: 20px;
   background: var(--color-bg-surface);
+}
+
+.dl-eval-view__progress-card--full {
+  grid-column: 1 / -1;
+  margin-bottom: 12px;
+}
+
+.dl-eval-view__tabs {
+  align-self: flex-start;
+  margin-bottom: 12px;
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  padding-bottom: 4px;
+  background: var(--color-bg-app);
+}
+
+.dl-eval-view__tabs :deep(.base-filter-tabs__count) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+}
+
+.dl-eval-view__tabs :deep(.base-filter-tabs__item:nth-child(2)) {
+  border-color: #f3c3cb;
+  color: #c24157;
+  background: #fff5f6;
+}
+
+.dl-eval-view__tabs :deep(.base-filter-tabs__item:nth-child(2) .base-filter-tabs__count) {
+  background: rgba(194, 65, 87, 0.12);
+  color: #c24157;
+}
+
+.dl-eval-view__tabs :deep(.base-filter-tabs__item:nth-child(2).base-filter-tabs__item--active) {
+  background: #ffe7eb;
+  border-color: #e88998;
+  color: #a61d38;
+}
+
+.dl-eval-view__tabs :deep(.base-filter-tabs__item:nth-child(2).base-filter-tabs__item--active .base-filter-tabs__count) {
+  background: #c24157;
+  color: #fff;
 }
 
 .dl-eval-view__progress-copy {
@@ -297,8 +622,20 @@ onBeforeUnmount(() => {
   min-height: 0;
 }
 
+.dl-eval-view__appeal-content {
+  display: grid;
+  grid-template-columns: minmax(270px, 0.72fr) minmax(0, 1.6fr);
+  gap: 18px;
+  align-items: stretch;
+  min-height: 0;
+}
+
 @media (max-width: 900px) {
   .dl-eval-view__content {
+    grid-template-columns: 1fr;
+  }
+
+  .dl-eval-view__appeal-content {
     grid-template-columns: 1fr;
   }
 }
@@ -317,3 +654,26 @@ onBeforeUnmount(() => {
   }
 }
 </style>
+async function handleSaveAppealDraft(payload) {
+  if (!appealDraftMember.value) return
+  try {
+    await updateDlEvaluation(appealDraftMember.value.id, {
+      status: 'DRAFT',
+      evaluationPeriodId: appealDraftMember.value.evaluationPeriodId,
+      evalComment: payload?.draftText ?? appealDraftMember.value.secondEvaluationDraft ?? '',
+      inputMethod: payload?.inputMethod ?? 'TEXT',
+    })
+    appealDraftMember.value = {
+      ...appealDraftMember.value,
+      secondEvaluationDraft: payload?.draftText ?? '',
+    }
+    showToast('검토 초안을 임시저장했습니다.')
+  } catch {
+    showToast('검토 초안 저장에 실패했습니다.', 'error')
+  }
+}
+
+function handleCloseAppealReview() {
+  appealReviewing.value = false
+  appealDraftMember.value = null
+}

--- a/src/views/hrmanager/HRMApprovalView.vue
+++ b/src/views/hrmanager/HRMApprovalView.vue
@@ -1,245 +1,574 @@
 <script setup>
-import { ref, computed, onMounted } from 'vue'
-import { API_BASE, AI_TAG_LIMIT, TYPE_STYLE, GRADE_STYLE, EVAL_TYPE_LABEL, scoreToGrade } from '@/constants'
-import HRMApprovalBanner  from '@/components/hr/hrmanager/evaluation-approval/HRMApprovalBanner.vue'
-import HRMApprovalList    from '@/components/hr/hrmanager/evaluation-approval/HRMApprovalList.vue'
-import HRMApprovalDetail  from '@/components/hr/hrmanager/evaluation-approval/HRMApprovalDetail.vue'
+import { ref, computed, onMounted, watch } from 'vue'
+import { TYPE_STYLE } from '@/constants'
+import { BaseProgressBar } from '@/components/common/base'
+import BaseFilterTabs from '@/components/common/base/navigation/BaseFilterTabs.vue'
+import HRMApprovalBanner from '@/components/hr/hrmanager/evaluation-approval/HRMApprovalBanner.vue'
+import HRMApprovalList from '@/components/hr/hrmanager/evaluation-approval/HRMApprovalList.vue'
+import HRMApprovalDetail from '@/components/hr/hrmanager/evaluation-approval/HRMApprovalDetail.vue'
 import { BaseConfirmModal, BaseToast } from '@/components/common/base/overlay'
-
-// ── 유틸 함수 ─────────────────────────────────────────────────────
-function gradeStyle(grade) {
-  const key = grade?.includes('→') ? grade.slice(-1) : grade
-  return GRADE_STYLE[key] ?? GRADE_STYLE['B']
-}
+import hrApprovalApi from '@/services/hrApprovalApi.js'
 
 function shortDate(dateStr) {
   if (!dateStr) return '-'
-  const parts = dateStr.split('.')
-  return parts.length >= 3 ? `${parts[1]}.${parts[2]}` : dateStr
+  const date = new Date(dateStr)
+  if (Number.isNaN(date.getTime())) return '-'
+  return `${String(date.getMonth() + 1).padStart(2, '0')}.${String(date.getDate()).padStart(2, '0')}`
 }
 
-function calcQualScore(categories) {
-  return Math.round(categories.reduce((s, c) => s + c.score, 0) / categories.length)
+function formatDate(dateStr) {
+  if (!dateStr) return '-'
+  const date = new Date(dateStr)
+  if (Number.isNaN(date.getTime())) return '-'
+  return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, '0')}.${String(date.getDate()).padStart(2, '0')}`
 }
 
-function calcQuantScore(steps) {
-  return parseFloat(steps[steps.length - 1].value)
+function formatPercent(done, total) {
+  if (!total) return 0
+  return Math.round((done / total) * 100)
 }
 
-function calcTotalScore(quantScore, qualScore) {
-  if (quantScore != null && qualScore != null)
-    return (quantScore * SCORE_WEIGHT_QUANT + qualScore * SCORE_WEIGHT_QUAL).toFixed(1)
-  const score = qualScore ?? quantScore
-  return score != null ? score.toFixed(1) : '-'
+const AVATAR_TONES = ['purple', 'green', 'gold']
+
+const approvalMode = ref('evaluation')
+
+const STATUS_BADGE_STYLE = {
+  RECEIVING: { label: '접수', bg: '#eef2ff', color: '#4f46e5' },
+  REVIEWING: { label: '보류', bg: '#fef3c7', color: '#92400e' },
+  COMPLETED: { label: '완료', bg: '#dcfce7', color: '#166534' },
 }
 
-function extractAiTags(categories) {
-  return categories.flatMap(c => c.tags).slice(0, AI_TAG_LIMIT)
+const REVIEW_RESULT_STYLE = {
+  ACKNOWLEDGE: { label: '승인', bg: '#d1fae5', color: '#065f46' },
+  ACKNOWLEDGE_IN_PART: { label: '부분 인정', bg: '#e0f2fe', color: '#0c4a6e' },
+  DISMISS: { label: '반려', bg: '#fee2e2', color: '#991b1b' },
 }
 
-// ── 상태 ──────────────────────────────────────────────────────────
-const approvalList   = ref([])
-const heldList       = ref([])
-const processedList  = ref([])
-const loading        = ref(true)
-const error          = ref(null)
-const activeTab      = ref('대기중')
-const tabs           = ['대기중', '보류', '처리 완료']
-const selectedId     = ref(null)
-
-const PROCESSED_STATUS_STYLE = {
-  approve: { label: '승인', bg: '#d1fae5', color: '#065f46' },
-  reject:  { label: '반려', bg: '#fee2e2', color: '#991b1b' },
-  hold:    { label: '보류', bg: '#fef3c7', color: '#92400e' },
+const EVALUATION_STATUS_STYLE = {
+  NO_INPUT: { label: '미작성', bg: '#f3f4f6', color: '#6b7280' },
+  DRAFT: { label: '작성중', bg: '#ede9fe', color: '#6d28d9' },
+  SUBMITTED: { label: '검토 대기', bg: '#dbeafe', color: '#1d4ed8' },
+  CONFIRMED: { label: '확정 완료', bg: '#d1fae5', color: '#065f46' },
 }
 
-// ── 데이터 로딩 ───────────────────────────────────────────────────
-onMounted(async () => {
+function getAppealStatusBadge(status) {
+  return STATUS_BADGE_STYLE[status] ?? { label: status ?? '-', bg: '#f3f4f6', color: '#6b7280' }
+}
+
+function getAppealProcessedBadge(reviewResult, status) {
+  if (status === 'REVIEWING') {
+    return { label: '보류', bg: '#fef3c7', color: '#92400e' }
+  }
+  return REVIEW_RESULT_STYLE[reviewResult] ?? { label: '처리 완료', bg: '#e5e7eb', color: '#4b5563' }
+}
+
+function getEvaluationBadge(status) {
+  return EVALUATION_STATUS_STYLE[status] ?? { label: status ?? '-', bg: '#f3f4f6', color: '#6b7280' }
+}
+
+function normalizeEvaluationLevel(level) {
+  const numeric = Number(level)
+  if (!Number.isNaN(numeric)) return numeric
+
+  const matched = String(level ?? '').match(/\d+/)
+  return matched ? Number(matched[0]) : null
+}
+
+function defaultAppealDetail(summary) {
+  return {
+    avatar: summary.employeeName?.[0] ?? '?',
+    dept: '-',
+    evalType: '이의신청',
+    quarter: '-',
+    reason: summary.title || '사유 없음',
+    content: '내용 없음',
+    attachments: [],
+    quantScore: '-',
+    qualScore: '-',
+    totalScore: '-',
+    quantDiff: '',
+    qualDiff: '',
+    totalDiff: '',
+    aiTags: [],
+    dataTrust: '-',
+    aiAnalysis: '',
+    inputMethod: 'TEXT',
+  }
+}
+
+function defaultEvaluationDetail(summary) {
+  return {
+    avatar: summary.employeeName?.[0] ?? '?',
+    dept: summary.employeeTier ?? '-',
+    evalType: '평가 승인',
+    quarter: `${summary.evaluationLevel ?? 2}차 평가`,
+    reason: summary.inputMethod ?? 'TEXT',
+    content: '내용 없음',
+    attachments: [],
+    quantScore: '-',
+    qualScore: summary.score != null ? summary.score.toFixed(1) : '-',
+    totalScore: summary.score != null ? summary.score.toFixed(1) : '-',
+    quantDiff: '',
+    qualDiff: '',
+    totalDiff: '',
+    aiTags: [],
+    dataTrust: '-',
+    aiAnalysis: '',
+    inputMethod: summary.inputMethod ?? 'TEXT',
+    firstStageScore: null,
+    firstStageComment: '',
+    secondStageScore: null,
+    secondStageComment: '',
+  }
+}
+
+function mapAppealSummaryToItem(summary) {
+  const typeStyle = TYPE_STYLE['이의신청']
+  const statusBadge = getAppealStatusBadge(summary.status)
+  const processedBadge = getAppealProcessedBadge(summary.reviewResult, summary.status)
+
+  return {
+    id: `appeal-${summary.appealId}`,
+    appealId: summary.appealId,
+    rawStatus: summary.status,
+    type: '이의신청',
+    typeBg: typeStyle.bg,
+    typeColor: typeStyle.color,
+    name: summary.employeeName,
+    grade: statusBadge.label,
+    gradeBg: statusBadge.bg,
+    gradeColor: statusBadge.color,
+    desc: summary.title || '제목 없음',
+    date: shortDate(summary.filedAt),
+    processedLabel: summary.status === 'COMPLETED' || summary.status === 'REVIEWING' ? processedBadge.label : null,
+    processedBg: processedBadge.bg,
+    processedColor: processedBadge.color,
+    processedReason: null,
+    detail: defaultAppealDetail(summary),
+  }
+}
+
+function mapEvaluationSummaryToItem(summary, index) {
+  const badge = getEvaluationBadge(summary.status)
+  const frontendStatus = summary.status === 'CONFIRMED' ? 'submitted' : 'in_progress'
+  return {
+    id: `evaluation-${summary.evalId}`,
+    evalId: summary.evalId,
+    evaluateeId: summary.evaluateeId,
+    evaluationPeriodId: summary.evaluationPeriodId,
+    rawStatus: summary.status,
+    type: '평가승인',
+    typeBg: '#ece8ff',
+    typeColor: '#6a4cd8',
+    name: summary.employeeName,
+    avatar: (summary.employeeName ?? '?')[0],
+    avatarTone: AVATAR_TONES[index % AVATAR_TONES.length],
+    tier: summary.employeeTier ?? '',
+    team: summary.teamName ?? '',
+    department: summary.departmentName ?? '',
+    meta: [summary.departmentName, summary.teamName].filter(Boolean).join(' > ') || `${summary.evaluationLevel ?? 2}차 평가`,
+    status: frontendStatus,
+    statusLabel: summary.status === 'CONFIRMED' ? '확정 완료' : '검토 대기',
+    statusDate: summary.status === 'CONFIRMED' ? '확정 완료' : '검토 대기',
+    grade: summary.employeeTier ?? '-',
+    gradeBg: '#f5f3ff',
+    gradeColor: '#6d28d9',
+    desc: `${summary.evaluationLevel ?? 2}차 평가 ${badge.label}`,
+    date: `${summary.evaluationLevel ?? 2}차`,
+    processedLabel: summary.status === 'CONFIRMED' ? '확정 완료' : null,
+    processedBg: '#d1fae5',
+    processedColor: '#065f46',
+    processedReason: null,
+    detail: defaultEvaluationDetail(summary),
+  }
+}
+
+function mergeAppealDetail(item, detail) {
+  return {
+    ...item,
+    detail: {
+      ...item.detail,
+      avatar: detail.employeeName?.[0] ?? item.detail.avatar,
+      quarter: formatDate(detail.filedAt),
+      reason: detail.title || '사유 없음',
+      content: detail.content || '내용 없음',
+    },
+  }
+}
+
+function mergeEvaluationDetail(item, detail) {
+  return {
+    ...item,
+    evaluateeId: detail.evaluateeId,
+    evaluationPeriodId: detail.evaluationPeriodId,
+    detail: {
+      ...item.detail,
+      avatar: detail.employeeName?.[0] ?? item.detail.avatar,
+      dept: detail.employeeTier ?? '-',
+      quarter: `${detail.evaluationLevel ?? 2}차 평가`,
+      content: detail.evalComment || '내용 없음',
+      qualScore: detail.score != null ? detail.score.toFixed(1) : '-',
+      totalScore: detail.score != null ? detail.score.toFixed(1) : '-',
+      firstStageScore: detail.firstStageScore != null ? detail.firstStageScore.toFixed(1) : '-',
+      firstStageComment: detail.firstStageComment || '',
+      secondStageScore: detail.secondStageScore != null ? detail.secondStageScore.toFixed(1) : '-',
+      secondStageComment: detail.secondStageComment || '',
+    },
+  }
+}
+
+const loading = ref(true)
+const error = ref(null)
+
+const appealPendingList = ref([])
+const appealHeldList = ref([])
+const appealProcessedList = ref([])
+const appealActiveTab = ref('대기중')
+const appealTabs = ['대기중', '보류', '처리 완료']
+const selectedAppealId = ref(null)
+const appealDetails = ref({})
+const appealPendingTotalCount = ref(0)
+const appealHeldTotalCount = ref(0)
+const appealProcessedTotalCount = ref(0)
+
+const evaluationPendingList = ref([])
+const evaluationProcessedList = ref([])
+const evaluationAllList = computed(() => [...evaluationPendingList.value, ...evaluationProcessedList.value])
+const selectedEvaluationId = ref(null)
+const evaluationDetails = ref({})
+const evaluationPendingTotalCount = ref(0)
+const evaluationProcessedTotalCount = ref(0)
+const evaluationPeriodSummary = ref(null)
+
+const confirmModal = ref({ show: false, action: null, title: '', message: '', confirmText: '' })
+const confirmReason = ref('')
+const evaluationConfirmComment = ref('')
+const toast = ref({ show: false, message: '' })
+let toastTimer = null
+
+const filteredList = computed(() => {
+  if (approvalMode.value === 'appeal') {
+    return [...appealPendingList.value, ...appealHeldList.value, ...appealProcessedList.value]
+  }
+  return evaluationAllList.value
+})
+
+const selectedItem = computed(() => {
+  if (approvalMode.value === 'appeal') {
+    return appealPendingList.value.find(item => item.id === selectedAppealId.value)
+      ?? appealHeldList.value.find(item => item.id === selectedAppealId.value)
+      ?? appealProcessedList.value.find(item => item.id === selectedAppealId.value)
+  }
+
+  return evaluationAllList.value.find(item => item.id === selectedEvaluationId.value)
+})
+
+const isSelectedProcessed = computed(() => {
+  if (approvalMode.value === 'appeal') {
+    return appealProcessedList.value.some(item => item.id === selectedAppealId.value)
+  }
+  return evaluationProcessedList.value.some(item => item.id === selectedEvaluationId.value)  // CONFIRMED 상태
+})
+
+const isSelectedHeld = computed(() =>
+  approvalMode.value === 'appeal' && appealHeldList.value.some(item => item.id === selectedAppealId.value)
+)
+
+const bannerLabel = computed(() => approvalMode.value === 'appeal' ? '이의신청' : '평가')
+const evaluationTotalCount = computed(() => evaluationPendingTotalCount.value + evaluationProcessedTotalCount.value)
+const evaluationProgressPercent = computed(() => formatPercent(evaluationProcessedTotalCount.value, evaluationTotalCount.value))
+const modeTabs = computed(() => [
+  { key: 'evaluation', label: '평가 승인', count: evaluationPendingTotalCount.value },
+  { key: 'appeal', label: '이의신청 승인', count: appealPendingTotalCount.value },
+])
+
+const isConfirmDisabled = computed(() => {
+  if (approvalMode.value === 'evaluation') return false
+  return confirmModal.value.action !== 'approve' && confirmReason.value.trim().length < 10
+})
+
+async function loadAppeals() {
+  const status = appealActiveTab.value === '보류'
+    ? 'REVIEWING'
+    : appealActiveTab.value === '처리 완료'
+      ? 'COMPLETED'
+      : 'RECEIVING'
+
+  const response = await hrApprovalApi.getAppeals({ page: 0, size: 100, status })
+  const content = response.data?.data?.content ?? []
+  const totalCount = response.data?.data?.totalCount ?? 0
+  const mapped = content.map(mapAppealSummaryToItem)
+  if (status === 'RECEIVING') {
+    appealPendingList.value = mapped
+    appealPendingTotalCount.value = totalCount
+  } else if (status === 'REVIEWING') {
+    appealHeldList.value = mapped
+    appealHeldTotalCount.value = totalCount
+  } else {
+    appealProcessedList.value = mapped
+    appealProcessedTotalCount.value = totalCount
+  }
+  selectedAppealId.value = mapped[0]?.id ?? null
+}
+
+async function loadEvaluations() {
+      const [pendingResponse, processedResponse, periodResponse] = await Promise.all([
+    hrApprovalApi.getEvaluationApprovals({ page: 0, size: 200, status: 'SUBMITTED' }),
+    hrApprovalApi.getEvaluationApprovals({ page: 0, size: 200, status: 'CONFIRMED' }),
+    hrApprovalApi.getEvaluationPeriods({ status: 'IN_PROGRESS', page: 0, size: 1 }),
+  ])
+
+  const pendingContent = pendingResponse.data?.data?.content ?? []
+  const processedContent = processedResponse.data?.data?.content ?? []
+  evaluationPeriodSummary.value = periodResponse.data?.data?.content?.[0] ?? null
+
+  evaluationPendingList.value = pendingContent
+    .filter(item => normalizeEvaluationLevel(item.evaluationLevel) === 2)
+    .map((item, i) => mapEvaluationSummaryToItem(item, i))
+
+  evaluationProcessedList.value = processedContent
+    .filter(item => normalizeEvaluationLevel(item.evaluationLevel) === 3)
+    .map((item, i) => mapEvaluationSummaryToItem(item, i))
+
+  evaluationPendingTotalCount.value = evaluationPendingList.value.length
+  evaluationProcessedTotalCount.value = evaluationProcessedList.value.length
+  selectedEvaluationId.value = evaluationPendingList.value[0]?.id ?? evaluationProcessedList.value[0]?.id ?? null
+}
+
+async function loadCurrentMode() {
+  loading.value = true
+  error.value = null
   try {
-    const fetchJson = url => fetch(url).then(r => r.json())
-    const [empData, qualData, teamData, appealData] = await Promise.all([
-      fetchJson(`${API_BASE}/employees`),
-      fetchJson(`${API_BASE}/qualitativeEval`),
-      fetchJson(`${API_BASE}/teamStats`),
-      fetchJson(`${API_BASE}/appealForms`),
-    ])
-
-    // processStatus === 2 : HRM 검토 대기 중인 이의신청만
-    const pending = appealData.filter(a => a.processStatus === 2)
-    const result  = []
-
-    for (const appeal of pending) {
-      const emp  = empData.find(e => e.employee_id === appeal.employee_id)
-      if (!emp) continue
-      const team = teamData.find(t => t.id === emp.team_id)
-      const qual = qualData.find(q => q.employee_id === emp.employee_id)
-
-      const grade  = emp.employee_current_tier ?? scoreToGrade(appeal.scores.composite)
-      const aiTags = qual
-        ? extractAiTags(qual.categories).slice(0, 3).concat(['재검토요청'])
-        : [appeal.reason, '재검토요청'].filter(Boolean)
-
-      result.push({
-        id: `appeal-${appeal.id}`,
-        type: '이의신청',
-        ...TYPE_STYLE['이의신청'],
-        name: emp.employee_name,
-        grade,
-        ...gradeStyle(grade),
-        desc: appeal.reason || appeal.quarter,
-        date: shortDate(appeal.submittedDate),
-        detail: {
-          avatar: emp.employee_name[0],
-          dept: team?.team ?? '-',
-          evalType: EVAL_TYPE_LABEL['이의신청'],
-          quarter: appeal.quarter,
-          reason: appeal.reason || '사유 없음',
-          content: appeal.content || '내용 없음',
-          attachments: appeal.attachments ?? [],
-          quantScore: appeal.scores.quantitative.toFixed(1),
-          qualScore:  appeal.scores.qualitative.toFixed(1),
-          totalScore: appeal.scores.composite.toFixed(1),
-          aiTags,
-          dataTrust: qual ? `${(qual.nlpConfidence * 100).toFixed(0)}%` : '-',
-          aiAnalysis: qual?.aiAnalysis ?? '',
-        },
-      })
+    if (approvalMode.value === 'appeal') {
+      await loadAppeals()
+    } else {
+      await loadEvaluations()
     }
-
-    approvalList.value = result
-    if (result.length > 0) selectedId.value = result[0].id
   } catch (e) {
     console.error(e)
     error.value = '데이터를 불러오는 중 오류가 발생했습니다.'
   } finally {
     loading.value = false
   }
+}
+
+async function loadAppealDetail(itemId) {
+  const appealId = Number(String(itemId).replace('appeal-', ''))
+  if (!appealId || appealDetails.value[appealId]) return
+
+  const response = await hrApprovalApi.getAppealById(appealId)
+  const detail = response.data?.data
+  if (!detail) return
+  appealDetails.value = { ...appealDetails.value, [appealId]: detail }
+  const mergeIntoList = (list) => list.map(item => item.appealId === appealId ? mergeAppealDetail(item, detail) : item)
+  appealPendingList.value = mergeIntoList(appealPendingList.value)
+  appealHeldList.value = mergeIntoList(appealHeldList.value)
+  appealProcessedList.value = mergeIntoList(appealProcessedList.value)
+}
+
+async function loadEvaluationDetail(itemId) {
+  const evalId = Number(String(itemId).replace('evaluation-', ''))
+  if (!evalId || evaluationDetails.value[evalId]) return
+
+  const response = await hrApprovalApi.getEvaluationApprovalDetail(evalId)
+  const detail = response.data?.data
+  if (!detail) return
+  evaluationDetails.value = { ...evaluationDetails.value, [evalId]: detail }
+  const mergeIntoList = (list) => list.map(item => item.evalId === evalId ? mergeEvaluationDetail(item, detail) : item)
+  evaluationPendingList.value = mergeIntoList(evaluationPendingList.value)
+  evaluationProcessedList.value = mergeIntoList(evaluationProcessedList.value)
+}
+
+onMounted(loadCurrentMode)
+
+watch(approvalMode, () => {
+  loadCurrentMode()
 })
 
-// ── computed ──────────────────────────────────────────────────────
-const filteredList = computed(() => {
-  if (activeTab.value === '처리 완료') return processedList.value
-  if (activeTab.value === '보류')      return heldList.value
-  return approvalList.value
+watch(selectedAppealId, (newId) => {
+  if (approvalMode.value === 'appeal' && newId) {
+    loadAppealDetail(newId)
+  }
 })
 
-const selectedItem = computed(() =>
-  approvalList.value.find(item => item.id === selectedId.value) ??
-  heldList.value.find(item => item.id === selectedId.value) ??
-  processedList.value.find(item => item.id === selectedId.value)
-)
-
-const isSelectedProcessed = computed(() =>
-  processedList.value.some(item => item.id === selectedId.value)
-)
-
-const isSelectedHeld = computed(() =>
-  heldList.value.some(item => item.id === selectedId.value)
-)
-
-const isConfirmDisabled = computed(() =>
-  confirmModal.value.action !== 'approve' && !confirmReason.value.trim()
-)
-
-// ── 확인 모달 / 토스트 상태 ───────────────────────────────────────
-const confirmModal  = ref({ show: false, action: null, title: '', message: '', confirmText: '' })
-const confirmReason = ref('')
-const toast         = ref({ show: false, message: '' })
-let toastTimer = null
-
-const ACTION_CONFIG = {
-  approve: { title: '최종 승인', message: '해당 평가를 최종 승인하시겠습니까?',  confirmText: '승인', toastMsg: '승인되었습니다.' },
-  reject:  { title: '반려',     message: '해당 평가를 반려 처리하시겠습니까?',  confirmText: '반려', toastMsg: '반려되었습니다.' },
-  hold:    { title: '보류',     message: '해당 평가를 보류 처리하시겠습니까?',  confirmText: '보류', toastMsg: '보류되었습니다.' },
-}
-
-// ── 액션 핸들러 ───────────────────────────────────────────────────
-function handleApprove() { openConfirm('approve') }
-function handleReject()  { openConfirm('reject') }
-function handleHold()    { openConfirm('hold') }
-
-function openConfirm(action) {
-  const cfg = ACTION_CONFIG[action]
-  confirmReason.value = ''
-  confirmModal.value = {
-    show: true, action,
-    title: cfg.title,
-    message: `${selectedItem.value.name}님 — ${cfg.message}`,
-    confirmText: cfg.confirmText,
+watch(selectedEvaluationId, (newId) => {
+  if (approvalMode.value === 'evaluation' && newId) {
+    loadEvaluationDetail(newId)
   }
-}
-
-function handleConfirm() {
-  const { action } = confirmModal.value
-  const name  = selectedItem.value.name
-  const style = PROCESSED_STATUS_STYLE[action]
-
-  // source 목록을 추가 전에 먼저 확정
-  const sourceList = heldList.value.some(i => i.id === selectedId.value)
-    ? heldList.value
-    : approvalList.value
-
-  if (action === 'hold') {
-    heldList.value.unshift({
-      ...selectedItem.value,
-      processedStatus: 'hold',
-      processedLabel:  style.label,
-      processedBg:     style.bg,
-      processedColor:  style.color,
-      processedReason: confirmReason.value.trim() || null,
-    })
-  } else {
-    processedList.value.unshift({
-      ...selectedItem.value,
-      processedStatus: action,
-      processedLabel:  style.label,
-      processedBg:     style.bg,
-      processedColor:  style.color,
-      processedReason: confirmReason.value.trim() || null,
-    })
-  }
-
-  confirmModal.value.show = false
-  removeAndSelectNext(sourceList)
-  showToast(`${name}님의 평가가 ${ACTION_CONFIG[action].toastMsg}`)
-}
-
-function removeAndSelectNext(sourceList) {
-  const idx  = sourceList.findIndex(i => i.id === selectedId.value)
-  sourceList.splice(idx, 1)
-  const next = sourceList[idx] ?? sourceList[idx - 1]
-  selectedId.value = next?.id ?? null
-}
+})
 
 function showToast(message) {
   if (toastTimer) clearTimeout(toastTimer)
   toast.value = { show: true, message }
   toastTimer = setTimeout(() => { toast.value.show = false }, 2500)
 }
+
+function handleApprove(comment = '') {
+  if (!selectedItem.value) return
+  const isEvaluation = approvalMode.value === 'evaluation'
+  confirmReason.value = ''
+  if (isEvaluation) evaluationConfirmComment.value = typeof comment === 'string' ? comment : (comment?.value ?? '')
+  confirmModal.value = {
+    show: true,
+    action: 'approve',
+    title: isEvaluation ? '최종 확정' : '최종 승인',
+    message: `${selectedItem.value.name}님 — ${isEvaluation ? '해당 평가를 최종 확정하시겠습니까?' : '해당 평가를 최종 승인하시겠습니까?'}`,
+    confirmText: isEvaluation ? '확정' : '승인',
+  }
+}
+
+function handleReject() {
+  confirmReason.value = ''
+  confirmModal.value = {
+    show: true,
+    action: 'reject',
+    title: '반려',
+    message: `${selectedItem.value.name}님 — 해당 평가를 반려 처리하시겠습니까?`,
+    confirmText: '반려',
+  }
+}
+
+function handleHold() {
+  confirmReason.value = ''
+  confirmModal.value = {
+    show: true,
+    action: 'hold',
+    title: '보류',
+    message: `${selectedItem.value.name}님 — 해당 평가를 보류 처리하시겠습니까?`,
+    confirmText: '보류',
+  }
+}
+
+function handleInnerTabChange(tab) {
+  appealActiveTab.value = tab
+  loadAppeals()
+}
+
+async function handleConfirm() {
+  if (!selectedItem.value) return
+
+  try {
+    if (approvalMode.value === 'evaluation') {
+      await hrApprovalApi.confirmEvaluation(selectedItem.value.evaluateeId, {
+        evaluationPeriodId: selectedItem.value.evaluationPeriodId,
+        evalComment: evaluationConfirmComment.value || selectedItem.value.detail.content,
+        inputMethod: selectedItem.value.detail.inputMethod ?? 'TEXT',
+      })
+      confirmModal.value.show = false
+      await loadEvaluations()
+      showToast(`${selectedItem.value.name}님의 평가가 최종 확정되었습니다.`)
+      return
+    }
+
+    const action = confirmModal.value.action
+    const payload = action === 'hold'
+      ? {
+          status: 'REVIEWING',
+          reviewResult: null,
+          modifiedScore: null,
+          reason: confirmReason.value.trim(),
+        }
+      : {
+          status: 'COMPLETED',
+          reviewResult: action === 'reject' ? 'DISMISS' : 'ACKNOWLEDGE',
+          modifiedScore: null,
+          reason: action === 'approve' ? null : confirmReason.value.trim(),
+        }
+
+    const targetName = selectedItem.value.name
+    await hrApprovalApi.updateAppealStatus(selectedItem.value.appealId, payload)
+    confirmModal.value.show = false
+    confirmReason.value = ''
+    await loadAppeals()
+    showToast(`${targetName}님의 평가가 ${action === 'approve' ? '승인되었습니다.' : action === 'reject' ? '반려되었습니다.' : '보류되었습니다.'}`)
+  } catch (e) {
+    console.error(e)
+    showToast('처리 중 오류가 발생했습니다.')
+  }
+}
 </script>
 
 <template>
   <div class="hrm-approval">
+    <BaseFilterTabs
+      class="hrm-approval__mode-tabs"
+      :items="modeTabs"
+      :model-value="approvalMode"
+      variant="chip"
+      :show-count="true"
+      @change="approvalMode = $event"
+    />
+
     <div v-if="loading" class="hrm-approval__loading">불러오는 중...</div>
     <div v-else-if="error" class="hrm-approval__error">{{ error }}</div>
     <template v-else>
-      <HRMApprovalBanner :count="approvalList.length" />
+      <section v-if="approvalMode === 'evaluation'" class="hrm-approval__progress-card">
+        <div class="hrm-approval__progress-copy">
+          <div>
+            <p class="hrm-approval__progress-eyebrow">제출 완료 현황</p>
+            <strong class="hrm-approval__progress-title">
+              {{ evaluationProcessedTotalCount }} / {{ evaluationTotalCount }}명 제출 완료
+            </strong>
+          </div>
+          <div class="hrm-approval__progress-side">
+            <span class="hrm-approval__progress-period-chip">
+              {{ evaluationPeriodSummary?.evalYear ?? '-' }}년 {{ evaluationPeriodSummary?.evalSequence ?? '-' }}차 평가
+            </span>
+            <span class="hrm-approval__progress-range">
+              {{ formatDate(evaluationPeriodSummary?.startDate) }} - {{ formatDate(evaluationPeriodSummary?.endDate) }}
+            </span>
+          </div>
+        </div>
+        <BaseProgressBar
+          :value="evaluationProgressPercent"
+          tone="success"
+          size="md"
+          label="평가 제출 진행률"
+        />
+      </section>
+      <section v-else class="hrm-approval__progress-card">
+        <div class="hrm-approval__progress-copy">
+          <div>
+            <p class="hrm-approval__progress-eyebrow">이의신청 현황</p>
+            <strong class="hrm-approval__progress-title">
+              {{ appealPendingTotalCount }} / {{ appealPendingTotalCount + appealHeldTotalCount + appealProcessedTotalCount }}건 검토 대기
+            </strong>
+          </div>
+          <div class="hrm-approval__progress-side">
+            <span class="hrm-approval__progress-period-chip">이의신청 승인</span>
+            <span class="hrm-approval__progress-range">
+              보류 {{ appealHeldTotalCount }}건 · 처리 완료 {{ appealProcessedTotalCount }}건
+            </span>
+          </div>
+        </div>
+        <BaseProgressBar
+          :value="formatPercent(appealProcessedTotalCount, appealPendingTotalCount + appealHeldTotalCount + appealProcessedTotalCount)"
+          tone="success"
+          size="md"
+          label="이의신청 처리 진행률"
+        />
+      </section>
 
-      <div class="hrm-approval__content">
+      <div class="hrm-approval__content" :class="{ 'hrm-approval__content--evaluation': approvalMode === 'evaluation' || approvalMode === 'appeal' }">
         <HRMApprovalList
           :list="filteredList"
-          :pending-count="approvalList.length"
-          :held-count="heldList.length"
-          :processed-count="processedList.length"
-          :tabs="tabs"
-          :active-tab="activeTab"
-          :selected-id="selectedId"
-          @tab-change="tab => { activeTab = tab; selectedId = filteredList[0]?.id ?? null }"
-          @select="selectedId = $event"
+          :pending-count="approvalMode === 'appeal' ? appealPendingTotalCount : evaluationPendingTotalCount"
+          :held-count="appealHeldTotalCount"
+          :processed-count="approvalMode === 'appeal' ? appealProcessedTotalCount : evaluationProcessedTotalCount"
+          :tabs="approvalMode === 'appeal' ? [] : []"
+          :active-tab="''"
+          :selected-id="approvalMode === 'appeal' ? selectedAppealId : selectedEvaluationId"
+          :pending-label="approvalMode === 'appeal' ? '이의신청 승인 대기' : '평가 승인 대기'"
+          :held-label="'보류'"
+          :processed-label="approvalMode === 'appeal' ? '처리 완료' : '확정 완료'"
+          :empty-text="approvalMode === 'appeal' ? '승인 대기 이의신청이 없습니다.' : '확정 대기 평가가 없습니다.'"
+          :mode="approvalMode"
+          @select="approvalMode === 'appeal' ? selectedAppealId = $event : selectedEvaluationId = $event"
         />
         <HRMApprovalDetail
           v-if="selectedItem"
           :item="selectedItem"
+          :mode="approvalMode"
           :readonly="isSelectedProcessed"
           :held="isSelectedHeld"
           @approve="handleApprove"
@@ -250,7 +579,6 @@ function showToast(message) {
     </template>
   </div>
 
-  <!-- 확인 모달 -->
   <BaseConfirmModal
     v-if="confirmModal.show"
     :title="confirmModal.title"
@@ -263,20 +591,19 @@ function showToast(message) {
     @confirm="handleConfirm"
   >
     <p class="hrm-confirm-message">{{ confirmModal.message }}</p>
-    <div v-if="confirmModal.action !== 'approve'" class="hrm-confirm-reason">
+    <div v-if="approvalMode === 'appeal' && confirmModal.action !== 'approve'" class="hrm-confirm-reason">
       <label class="hrm-confirm-reason__label">
         처리 사유 <span class="hrm-confirm-reason__required">*필수</span>
       </label>
       <textarea
         v-model="confirmReason"
         class="hrm-confirm-reason__input"
-        placeholder="사유를 입력해주세요"
+        placeholder="사유를 10자 이상 입력해주세요"
         rows="3"
       />
     </div>
   </BaseConfirmModal>
 
-  <!-- 토스트 -->
   <BaseToast :show="toast.show" :message="toast.message" />
 </template>
 
@@ -291,9 +618,173 @@ function showToast(message) {
   overflow: auto;
   min-height: 0;
 }
+
+.hrm-approval__mode-tabs {
+  align-self: flex-start;
+}
+
+.hrm-approval__mode-tabs :deep(.base-filter-tabs__count) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 999px;
+  background: rgba(106, 76, 216, 0.12);
+  color: inherit;
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.hrm-approval__mode-tabs :deep(.base-filter-tabs__item:nth-child(2)) {
+  border-color: #f3c3cb;
+  color: #c24157;
+  background: #fff5f6;
+}
+
+.hrm-approval__mode-tabs :deep(.base-filter-tabs__item:nth-child(2) .base-filter-tabs__count) {
+  background: rgba(194, 65, 87, 0.12);
+  color: #c24157;
+}
+
+.hrm-approval__mode-tabs :deep(.base-filter-tabs__item:nth-child(2).base-filter-tabs__item--active) {
+  background: #ffe7eb;
+  border-color: #e88998;
+  color: #a61d38;
+}
+
+.hrm-approval__mode-tabs :deep(.base-filter-tabs__item:nth-child(2).base-filter-tabs__item--active .base-filter-tabs__count) {
+  background: #c24157;
+  color: #fff;
+}
+
 .hrm-approval__loading { color: #a89ed8; font-size: var(--font-size-base); }
-.hrm-approval__error   { color: var(--color-danger); font-size: var(--font-size-base); }
+.hrm-approval__error { color: var(--color-danger); font-size: var(--font-size-base); }
 .hrm-approval__content { display: flex; gap: 16px; align-items: flex-start; flex: 1; min-height: 0; }
+.hrm-approval__content--evaluation {
+  display: grid;
+  grid-template-columns: minmax(270px, 0.72fr) minmax(0, 1.6fr);
+  gap: 18px;
+  align-items: stretch;
+  min-height: 0;
+}
+
+.hrm-approval__progress-card {
+  display: grid;
+  gap: 10px;
+  padding: 14px 18px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 20px;
+  background: var(--color-bg-surface);
+}
+
+.hrm-approval__progress-copy {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.hrm-approval__progress-eyebrow {
+  margin: 0 0 4px;
+  color: var(--color-primary-500);
+  font-size: var(--font-size-xs-plus);
+  font-weight: var(--font-weight-semibold);
+}
+
+.hrm-approval__progress-title {
+  color: var(--color-primary-800);
+  font-size: var(--font-size-base-plus);
+  font-weight: var(--font-weight-bold);
+}
+
+.hrm-approval__progress-side {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.hrm-approval__progress-period-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 30px;
+  padding: 0 14px;
+  border-radius: 999px;
+  background: #f1edff;
+  color: #6c56db;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+  white-space: nowrap;
+}
+
+.hrm-approval__progress-range {
+  font-size: var(--font-size-sm);
+  color: #8d82d8;
+  font-weight: var(--font-weight-medium);
+  white-space: nowrap;
+}
+
+.hrm-approval__progress-card {
+  display: grid;
+  gap: 10px;
+  padding: 14px 18px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 20px;
+  background: var(--color-bg-surface);
+}
+
+.hrm-approval__progress-copy {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.hrm-approval__progress-eyebrow {
+  margin: 0 0 4px;
+  color: var(--color-primary-500);
+  font-size: var(--font-size-xs-plus);
+  font-weight: var(--font-weight-semibold);
+}
+
+.hrm-approval__progress-title {
+  color: var(--color-primary-800);
+  font-size: var(--font-size-base-plus);
+  font-weight: var(--font-weight-bold);
+}
+
+.hrm-approval__progress-side {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.hrm-approval__progress-period-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 30px;
+  padding: 0 14px;
+  border-radius: 999px;
+  background: #f1edff;
+  color: #6c56db;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+  white-space: nowrap;
+}
+
+.hrm-approval__progress-range {
+  font-size: var(--font-size-sm);
+  color: #8d82d8;
+  font-weight: var(--font-weight-medium);
+  white-space: nowrap;
+}
 
 .hrm-confirm-message {
   font-size: var(--font-size-base);

--- a/src/views/hrmanager/HRMApprovalView.vue
+++ b/src/views/hrmanager/HRMApprovalView.vue
@@ -17,6 +17,14 @@ function shortDate(dateStr) {
   return `${String(date.getMonth() + 1).padStart(2, '0')}.${String(date.getDate()).padStart(2, '0')}`
 }
 
+function sortByFiledAtDesc(items) {
+  return [...items].sort((a, b) => {
+    const left = new Date(a?.filedAt ?? 0).getTime()
+    const right = new Date(b?.filedAt ?? 0).getTime()
+    return right - left
+  })
+}
+
 function formatDate(dateStr) {
   if (!dateStr) return '-'
   const date = new Date(dateStr)
@@ -338,21 +346,26 @@ const isConfirmDisabled = computed(() => {
 })
 
 async function loadAppeals() {
-  const [pendingResponse, heldResponse, processedResponse] = await Promise.all([
+  const [pendingResponse, receivingResponse, reviewingResponse, processedResponse] = await Promise.all([
     hrApprovalApi.getAppeals({ page: 0, size: 100, status: 'SUBMITTED' }),
     hrApprovalApi.getAppeals({ page: 0, size: 100, status: 'RECEIVING' }),
+    hrApprovalApi.getAppeals({ page: 0, size: 100, status: 'REVIEWING' }),
     hrApprovalApi.getAppeals({ page: 0, size: 100, status: 'COMPLETED' }),
   ])
 
   const pendingMapped = (pendingResponse.data?.data?.content ?? []).map(mapAppealSummaryToItem)
-  const heldMapped = (heldResponse.data?.data?.content ?? []).map(mapAppealSummaryToItem)
+  const heldMapped = sortByFiledAtDesc([
+    ...(receivingResponse.data?.data?.content ?? []),
+    ...(reviewingResponse.data?.data?.content ?? []),
+  ]).map(mapAppealSummaryToItem)
   const processedMapped = (processedResponse.data?.data?.content ?? []).map(mapAppealSummaryToItem)
 
   appealPendingList.value = pendingMapped
   appealHeldList.value = heldMapped
   appealProcessedList.value = processedMapped
   appealPendingTotalCount.value = pendingResponse.data?.data?.totalCount ?? 0
-  appealHeldTotalCount.value = heldResponse.data?.data?.totalCount ?? 0
+  appealHeldTotalCount.value =
+    (receivingResponse.data?.data?.totalCount ?? 0) + (reviewingResponse.data?.data?.totalCount ?? 0)
   appealProcessedTotalCount.value = processedResponse.data?.data?.totalCount ?? 0
 
   selectedAppealId.value =
@@ -367,14 +380,16 @@ async function loadAppeals() {
 }
 
 async function loadAppealCounts() {
-  const [pendingResponse, heldResponse, processedResponse] = await Promise.all([
+  const [pendingResponse, receivingResponse, reviewingResponse, processedResponse] = await Promise.all([
     hrApprovalApi.getAppeals({ page: 0, size: 1, status: 'SUBMITTED' }),
     hrApprovalApi.getAppeals({ page: 0, size: 1, status: 'RECEIVING' }),
+    hrApprovalApi.getAppeals({ page: 0, size: 1, status: 'REVIEWING' }),
     hrApprovalApi.getAppeals({ page: 0, size: 1, status: 'COMPLETED' }),
   ])
 
   appealPendingTotalCount.value = pendingResponse.data?.data?.totalCount ?? 0
-  appealHeldTotalCount.value = heldResponse.data?.data?.totalCount ?? 0
+  appealHeldTotalCount.value =
+    (receivingResponse.data?.data?.totalCount ?? 0) + (reviewingResponse.data?.data?.totalCount ?? 0)
   appealProcessedTotalCount.value = processedResponse.data?.data?.totalCount ?? 0
 }
 

--- a/src/views/hrmanager/HRMApprovalView.vue
+++ b/src/views/hrmanager/HRMApprovalView.vue
@@ -8,6 +8,7 @@ import HRMApprovalList from '@/components/hr/hrmanager/evaluation-approval/HRMAp
 import HRMApprovalDetail from '@/components/hr/hrmanager/evaluation-approval/HRMApprovalDetail.vue'
 import { BaseConfirmModal, BaseToast } from '@/components/common/base/overlay'
 import hrApprovalApi from '@/services/hrApprovalApi.js'
+import { formatMemberMeta } from '@/utils/hrListFormat'
 
 function shortDate(dateStr) {
   if (!dateStr) return '-'
@@ -29,10 +30,17 @@ function formatPercent(done, total) {
 }
 
 const AVATAR_TONES = ['purple', 'green', 'gold']
+const APPEAL_TYPE_LABEL = {
+  SCORE_ERRORS: '점수 오류',
+  MISSING_ITEMS: '평가 항목 누락',
+  EVALUATION_PROCEDURES: '평가 절차 이의',
+  OTHERS: '기타',
+}
 
 const approvalMode = ref('evaluation')
 
 const STATUS_BADGE_STYLE = {
+  SUBMITTED: { label: '제출', bg: '#f3e8ff', color: '#7c3aed' },
   RECEIVING: { label: '접수', bg: '#eef2ff', color: '#4f46e5' },
   REVIEWING: { label: '보류', bg: '#fef3c7', color: '#92400e' },
   COMPLETED: { label: '완료', bg: '#dcfce7', color: '#166534' },
@@ -74,14 +82,19 @@ function normalizeEvaluationLevel(level) {
   return matched ? Number(matched[0]) : null
 }
 
+function getAppealTypeLabel(type) {
+  return APPEAL_TYPE_LABEL[type] ?? type ?? '-'
+}
+
 function defaultAppealDetail(summary) {
   return {
     avatar: summary.employeeName?.[0] ?? '?',
     dept: '-',
     evalType: '이의신청',
     quarter: '-',
-    reason: summary.title || '사유 없음',
+    reason: getAppealTypeLabel(summary.appealType),
     content: '내용 없음',
+    appealTitle: summary.title || '제목 없음',
     attachments: [],
     quantScore: '-',
     qualScore: '-',
@@ -93,7 +106,16 @@ function defaultAppealDetail(summary) {
     dataTrust: '-',
     aiAnalysis: '',
     inputMethod: 'TEXT',
+    firstStageScore: summary.firstScore != null ? summary.firstScore.toFixed(1) : '-',
+    firstStageComment: '',
+    secondStageScore: summary.secondScore != null ? summary.secondScore.toFixed(1) : '-',
+    secondStageComment: '',
   }
+}
+
+function formatAppealPeriod(evalYear, evalSequence) {
+  if (evalYear == null || evalSequence == null) return '-'
+  return `${evalYear}년 ${evalSequence}차 평가`
 }
 
 function defaultEvaluationDetail(summary) {
@@ -115,9 +137,9 @@ function defaultEvaluationDetail(summary) {
     dataTrust: '-',
     aiAnalysis: '',
     inputMethod: summary.inputMethod ?? 'TEXT',
-    firstStageScore: null,
+    firstStageScore: '-',
     firstStageComment: '',
-    secondStageScore: null,
+    secondStageScore: '-',
     secondStageComment: '',
   }
 }
@@ -126,15 +148,34 @@ function mapAppealSummaryToItem(summary) {
   const typeStyle = TYPE_STYLE['이의신청']
   const statusBadge = getAppealStatusBadge(summary.status)
   const processedBadge = getAppealProcessedBadge(summary.reviewResult, summary.status)
+  const avatarTone = AVATAR_TONES[summary.appealId % AVATAR_TONES.length]
+  const stageLabel = summary.status === 'SUBMITTED'
+    ? '검토 대기'
+    : summary.status === 'RECEIVING'
+      ? '접수 완료'
+      : summary.status === 'REVIEWING'
+        ? '검토중'
+        : '처리 완료'
 
   return {
     id: `appeal-${summary.appealId}`,
     appealId: summary.appealId,
+    evaluateeId: summary.appealEmployeeId,
+    evaluationPeriodId: summary.evaluationPeriodId,
     rawStatus: summary.status,
     type: '이의신청',
     typeBg: typeStyle.bg,
     typeColor: typeStyle.color,
     name: summary.employeeName,
+    avatar: (summary.employeeName ?? '?')[0],
+    avatarTone,
+    tier: summary.employeeTier ?? '',
+    team: summary.teamName ?? '',
+    department: summary.departmentName ?? '',
+    meta: formatMemberMeta(summary.employeeCode, summary.departmentName, summary.teamName),
+    status: summary.status === 'COMPLETED' ? 'submitted' : 'in_progress',
+    statusLabel: statusBadge.label,
+    statusDate: stageLabel,
     grade: statusBadge.label,
     gradeBg: statusBadge.bg,
     gradeColor: statusBadge.color,
@@ -166,7 +207,8 @@ function mapEvaluationSummaryToItem(summary, index) {
     tier: summary.employeeTier ?? '',
     team: summary.teamName ?? '',
     department: summary.departmentName ?? '',
-    meta: [summary.departmentName, summary.teamName].filter(Boolean).join(' > ') || `${summary.evaluationLevel ?? 2}차 평가`,
+    meta: formatMemberMeta(summary.employeeCode, summary.departmentName, summary.teamName)
+      || `${summary.evaluationLevel ?? 2}차 평가`,
     status: frontendStatus,
     statusLabel: summary.status === 'CONFIRMED' ? '확정 완료' : '검토 대기',
     statusDate: summary.status === 'CONFIRMED' ? '확정 완료' : '검토 대기',
@@ -189,9 +231,17 @@ function mergeAppealDetail(item, detail) {
     detail: {
       ...item.detail,
       avatar: detail.employeeName?.[0] ?? item.detail.avatar,
-      quarter: formatDate(detail.filedAt),
-      reason: detail.title || '사유 없음',
+      quarter: formatAppealPeriod(detail.evalYear, detail.evalSequence),
+      reason: getAppealTypeLabel(detail.appealType),
+      appealTitle: detail.title || '제목 없음',
       content: detail.content || '내용 없음',
+      quantScore: '-',
+      qualScore: detail.averageScore != null ? detail.averageScore.toFixed(1) : '-',
+      totalScore: detail.averageScore != null ? detail.averageScore.toFixed(1) : '-',
+      firstStageScore: detail.firstScore != null ? detail.firstScore.toFixed(1) : '-',
+      firstStageComment: detail.firstStageComment || '',
+      secondStageScore: detail.secondScore != null ? detail.secondScore.toFixed(1) : '-',
+      secondStageComment: detail.secondStageComment || '',
     },
   }
 }
@@ -265,7 +315,7 @@ const selectedItem = computed(() => {
 
 const isSelectedProcessed = computed(() => {
   if (approvalMode.value === 'appeal') {
-    return appealProcessedList.value.some(item => item.id === selectedAppealId.value)
+    return false
   }
   return evaluationProcessedList.value.some(item => item.id === selectedEvaluationId.value)  // CONFIRMED 상태
 })
@@ -288,27 +338,44 @@ const isConfirmDisabled = computed(() => {
 })
 
 async function loadAppeals() {
-  const status = appealActiveTab.value === '보류'
-    ? 'REVIEWING'
-    : appealActiveTab.value === '처리 완료'
-      ? 'COMPLETED'
-      : 'RECEIVING'
+  const [pendingResponse, heldResponse, processedResponse] = await Promise.all([
+    hrApprovalApi.getAppeals({ page: 0, size: 100, status: 'SUBMITTED' }),
+    hrApprovalApi.getAppeals({ page: 0, size: 100, status: 'RECEIVING' }),
+    hrApprovalApi.getAppeals({ page: 0, size: 100, status: 'COMPLETED' }),
+  ])
 
-  const response = await hrApprovalApi.getAppeals({ page: 0, size: 100, status })
-  const content = response.data?.data?.content ?? []
-  const totalCount = response.data?.data?.totalCount ?? 0
-  const mapped = content.map(mapAppealSummaryToItem)
-  if (status === 'RECEIVING') {
-    appealPendingList.value = mapped
-    appealPendingTotalCount.value = totalCount
-  } else if (status === 'REVIEWING') {
-    appealHeldList.value = mapped
-    appealHeldTotalCount.value = totalCount
-  } else {
-    appealProcessedList.value = mapped
-    appealProcessedTotalCount.value = totalCount
+  const pendingMapped = (pendingResponse.data?.data?.content ?? []).map(mapAppealSummaryToItem)
+  const heldMapped = (heldResponse.data?.data?.content ?? []).map(mapAppealSummaryToItem)
+  const processedMapped = (processedResponse.data?.data?.content ?? []).map(mapAppealSummaryToItem)
+
+  appealPendingList.value = pendingMapped
+  appealHeldList.value = heldMapped
+  appealProcessedList.value = processedMapped
+  appealPendingTotalCount.value = pendingResponse.data?.data?.totalCount ?? 0
+  appealHeldTotalCount.value = heldResponse.data?.data?.totalCount ?? 0
+  appealProcessedTotalCount.value = processedResponse.data?.data?.totalCount ?? 0
+
+  selectedAppealId.value =
+    pendingMapped[0]?.id
+    ?? heldMapped[0]?.id
+    ?? processedMapped[0]?.id
+    ?? null
+
+  if (selectedAppealId.value) {
+    await loadAppealDetail(selectedAppealId.value)
   }
-  selectedAppealId.value = mapped[0]?.id ?? null
+}
+
+async function loadAppealCounts() {
+  const [pendingResponse, heldResponse, processedResponse] = await Promise.all([
+    hrApprovalApi.getAppeals({ page: 0, size: 1, status: 'SUBMITTED' }),
+    hrApprovalApi.getAppeals({ page: 0, size: 1, status: 'RECEIVING' }),
+    hrApprovalApi.getAppeals({ page: 0, size: 1, status: 'COMPLETED' }),
+  ])
+
+  appealPendingTotalCount.value = pendingResponse.data?.data?.totalCount ?? 0
+  appealHeldTotalCount.value = heldResponse.data?.data?.totalCount ?? 0
+  appealProcessedTotalCount.value = processedResponse.data?.data?.totalCount ?? 0
 }
 
 async function loadEvaluations() {
@@ -333,12 +400,16 @@ async function loadEvaluations() {
   evaluationPendingTotalCount.value = evaluationPendingList.value.length
   evaluationProcessedTotalCount.value = evaluationProcessedList.value.length
   selectedEvaluationId.value = evaluationPendingList.value[0]?.id ?? evaluationProcessedList.value[0]?.id ?? null
+  if (selectedEvaluationId.value) {
+    await loadEvaluationDetail(selectedEvaluationId.value)
+  }
 }
 
 async function loadCurrentMode() {
   loading.value = true
   error.value = null
   try {
+    await loadAppealCounts()
     if (approvalMode.value === 'appeal') {
       await loadAppeals()
     } else {
@@ -354,7 +425,16 @@ async function loadCurrentMode() {
 
 async function loadAppealDetail(itemId) {
   const appealId = Number(String(itemId).replace('appeal-', ''))
-  if (!appealId || appealDetails.value[appealId]) return
+  if (!appealId) return
+
+  const cachedDetail = appealDetails.value[appealId]
+  if (cachedDetail) {
+    const mergeIntoList = (list) => list.map(item => item.appealId === appealId ? mergeAppealDetail(item, cachedDetail) : item)
+    appealPendingList.value = mergeIntoList(appealPendingList.value)
+    appealHeldList.value = mergeIntoList(appealHeldList.value)
+    appealProcessedList.value = mergeIntoList(appealProcessedList.value)
+    return
+  }
 
   const response = await hrApprovalApi.getAppealById(appealId)
   const detail = response.data?.data
@@ -368,7 +448,15 @@ async function loadAppealDetail(itemId) {
 
 async function loadEvaluationDetail(itemId) {
   const evalId = Number(String(itemId).replace('evaluation-', ''))
-  if (!evalId || evaluationDetails.value[evalId]) return
+  if (!evalId) return
+
+  const cachedDetail = evaluationDetails.value[evalId]
+  if (cachedDetail) {
+    const mergeIntoList = (list) => list.map(item => item.evalId === evalId ? mergeEvaluationDetail(item, cachedDetail) : item)
+    evaluationPendingList.value = mergeIntoList(evaluationPendingList.value)
+    evaluationProcessedList.value = mergeIntoList(evaluationProcessedList.value)
+    return
+  }
 
   const response = await hrApprovalApi.getEvaluationApprovalDetail(evalId)
   const detail = response.data?.data
@@ -406,14 +494,19 @@ function showToast(message) {
 function handleApprove(comment = '') {
   if (!selectedItem.value) return
   const isEvaluation = approvalMode.value === 'evaluation'
+  const isAppealFinalConfirm = approvalMode.value === 'appeal' && selectedItem.value.rawStatus === 'COMPLETED'
   confirmReason.value = ''
   if (isEvaluation) evaluationConfirmComment.value = typeof comment === 'string' ? comment : (comment?.value ?? '')
   confirmModal.value = {
     show: true,
     action: 'approve',
-    title: isEvaluation ? '최종 확정' : '최종 승인',
-    message: `${selectedItem.value.name}님 — ${isEvaluation ? '해당 평가를 최종 확정하시겠습니까?' : '해당 평가를 최종 승인하시겠습니까?'}`,
-    confirmText: isEvaluation ? '확정' : '승인',
+    title: isEvaluation || isAppealFinalConfirm ? '최종 확정' : '접수',
+    message: `${selectedItem.value.name}님 — ${
+      isEvaluation || isAppealFinalConfirm
+        ? '해당 내용을 최종 확정하시겠습니까?'
+        : '해당 이의신청을 접수하시겠습니까?'
+    }`,
+    confirmText: isEvaluation || isAppealFinalConfirm ? '확정' : '접수',
   }
 }
 
@@ -422,9 +515,9 @@ function handleReject() {
   confirmModal.value = {
     show: true,
     action: 'reject',
-    title: '반려',
-    message: `${selectedItem.value.name}님 — 해당 평가를 반려 처리하시겠습니까?`,
-    confirmText: '반려',
+    title: approvalMode.value === 'appeal' ? '거절' : '반려',
+    message: `${selectedItem.value.name}님 — ${approvalMode.value === 'appeal' ? '해당 이의신청을 거절하시겠습니까?' : '해당 평가를 반려 처리하시겠습니까?'}`,
+    confirmText: approvalMode.value === 'appeal' ? '거절' : '반려',
   }
 }
 
@@ -461,26 +554,31 @@ async function handleConfirm() {
     }
 
     const action = confirmModal.value.action
-    const payload = action === 'hold'
-      ? {
-          status: 'REVIEWING',
-          reviewResult: null,
-          modifiedScore: null,
-          reason: confirmReason.value.trim(),
-        }
-      : {
-          status: 'COMPLETED',
-          reviewResult: action === 'reject' ? 'DISMISS' : 'ACKNOWLEDGE',
-          modifiedScore: null,
-          reason: action === 'approve' ? null : confirmReason.value.trim(),
-        }
-
     const targetName = selectedItem.value.name
-    await hrApprovalApi.updateAppealStatus(selectedItem.value.appealId, payload)
+    const wasCompletedAppeal = selectedItem.value.rawStatus === 'COMPLETED'
+    if (action === 'approve') {
+      if (wasCompletedAppeal) {
+        await hrApprovalApi.confirmEvaluation(selectedItem.value.evaluateeId, {
+          evaluationPeriodId: selectedItem.value.evaluationPeriodId,
+          evalComment: selectedItem.value.detail.secondStageComment || selectedItem.value.detail.firstStageComment || selectedItem.value.detail.content,
+          inputMethod: selectedItem.value.detail.inputMethod ?? 'TEXT',
+        })
+      } else {
+        await hrApprovalApi.receiveAppeal(selectedItem.value.appealId)
+      }
+    } else {
+      await hrApprovalApi.rejectAppeal(selectedItem.value.appealId, {
+        reason: confirmReason.value.trim(),
+      })
+    }
     confirmModal.value.show = false
     confirmReason.value = ''
     await loadAppeals()
-    showToast(`${targetName}님의 평가가 ${action === 'approve' ? '승인되었습니다.' : action === 'reject' ? '반려되었습니다.' : '보류되었습니다.'}`)
+    showToast(`${targetName}님의 이의신청이 ${
+      action === 'approve'
+        ? (wasCompletedAppeal ? '최종 확정되었습니다.' : '접수되었습니다.')
+        : '거절되었습니다.'
+    }`)
   } catch (e) {
     console.error(e)
     showToast('처리 중 오류가 발생했습니다.')

--- a/src/views/hrmanager/HRMPromotionReviewView.vue
+++ b/src/views/hrmanager/HRMPromotionReviewView.vue
@@ -1,86 +1,109 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
-import { API_BASE } from '@/constants'
 import BaseStatCard        from '@/components/common/base/display/BaseStatCard.vue'
 import HRMPromotionList    from '@/components/hr/hrmanager/promotion-review/HRMPromotionList.vue'
 import HRMPromotionDetail  from '@/components/hr/hrmanager/promotion-review/HRMPromotionDetail.vue'
 import { BaseConfirmModal, BaseToast } from '@/components/common/base/overlay'
+import promotionApi from '@/services/hrmanager/promotionApi.js'
 
-const loading    = ref(true)
-const summary    = ref(null)
-const candidates = ref([])
-const activeTab  = ref('전체')
-const selectedId = ref(null)
+const AVATAR_TONE = { S: 'gold', A: 'purple', B: 'green', C: 'green' }
 
-const tabs = computed(() => {
-  const sTierCount = candidates.value.filter(c => c.targetTier === 'S').length
-  const aTierCount = candidates.value.filter(c => c.targetTier === 'A').length
-  return [
-    { key: '전체',   label: '전체',   count: candidates.value.length },
-    { key: 'S-Tier', label: 'S-Tier', count: sTierCount },
-    { key: 'A-Tier', label: 'A-Tier', count: aTierCount },
-  ]
-})
-
-const filteredList = computed(() => {
-  if (activeTab.value.startsWith('전체')) return candidates.value
-  if (activeTab.value.startsWith('S-Tier')) return candidates.value.filter(c => c.targetTier === 'S')
-  if (activeTab.value.startsWith('A-Tier')) return candidates.value.filter(c => c.targetTier === 'A')
-  return candidates.value
-})
-
-const selectedItem = computed(() =>
-  candidates.value.find(c => c.id === selectedId.value)
-)
-
-async function fetchJson(url) {
-  const res = await fetch(url)
-  return res.json()
+const STATUS_LABEL = {
+  UNDER_REVIEW:              '검토 대기',
+  CONFIRMATION_OF_PROMOTION: '승급 확정',
+  TIER_APPLIED:              '적용 완료',
+  SUSPENSION:                '보류',
 }
 
-onMounted(async () => {
+function mapCandidate(item) {
+  return {
+    id:                   item.tierPromotionId,
+    employeeId:           item.employeeId,
+    name:                 item.employeeName,
+    avatar:               (item.employeeName ?? '?')[0],
+    avatarTone:           AVATAR_TONE[item.targetTier] ?? 'purple',
+    currentTier:          item.currentTier,
+    targetTier:           item.targetTier,
+    tierBadge:            item.targetTier,
+    tierAccumulatedPoint: item.tierAccumulatedPoint,
+    targetPromotionPoint: item.targetPromotionPoint,
+    rawStatus:            item.tierPromoStatus,
+    statusLabel:          STATUS_LABEL[item.tierPromoStatus] ?? item.tierPromoStatus,
+    meta:                 `${item.tierAccumulatedPoint ?? 0} / ${item.targetPromotionPoint ?? 0} pt`,
+    statusDate:           item.tierPromoStatus === 'UNDER_REVIEW' ? '검토 대기' : STATUS_LABEL[item.tierPromoStatus],
+    tierReviewedAt:       item.tierReviewedAt ?? null,
+    reviewComment:        '',
+  }
+}
+
+const loading    = ref(true)
+const error      = ref(null)
+const summary    = ref(null)
+const candidates = ref([])
+const selectedId = ref(null)
+const details    = ref({})
+
+const selectedItem = computed(() => {
+  const base = candidates.value.find(c => c.id === selectedId.value)
+  if (!base) return null
+  const detail = details.value[base.id]
+  return detail ? { ...base, ...detail } : base
+})
+
+const sTierCount = computed(() => candidates.value.filter(c => c.targetTier === 'S').length)
+const aTierCount = computed(() => candidates.value.filter(c => c.targetTier === 'A').length)
+
+async function load() {
+  loading.value = true
+  error.value = null
   try {
-    const [summaryData, candidatesData] = await Promise.all([
-      fetchJson(`${API_BASE}/promotionSummary`),
-      fetchJson(`${API_BASE}/promotionCandidates`),
+    const [summaryRes, candidatesRes] = await Promise.all([
+      promotionApi.getSummary(),
+      promotionApi.getCandidates({ page: 0, size: 200 }),
     ])
-    summary.value    = summaryData[0] ?? null
-    candidates.value = candidatesData
-    if (candidatesData.length > 0) selectedId.value = candidatesData[0].id
+    summary.value    = summaryRes.data?.data ?? null
+    const items      = candidatesRes.data?.data?.items ?? []
+    candidates.value = items.map(mapCandidate)
+    selectedId.value = candidates.value[0]?.id ?? null
   } catch (e) {
-    console.error('승급심사 데이터 로딩 실패:', e)
+    console.error(e)
+    error.value = '데이터를 불러오는 중 오류가 발생했습니다.'
   } finally {
     loading.value = false
   }
-})
+}
 
-// ── 확인 모달 / 토스트 ────────────────────────────────────────────
-const confirmModal = ref({ show: false, action: null, targetId: null, title: '', message: '', confirmText: '', comment: '' })
+async function loadDetail(id) {
+  if (!id || details.value[id]) return
+  try {
+    const res = await promotionApi.getCandidateDetail(id)
+    const d = res.data?.data
+    if (!d) return
+    details.value = {
+      ...details.value,
+      [id]: {
+        tierAccumulatedPoint: d.tierAccumulatedPoint,
+        targetPromotionPoint: d.targetPromotionPoint,
+        tierReviewedAt:       d.tierReviewedAt,
+      },
+    }
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+onMounted(load)
+
+// 선택 변경 시 상세 로드
+function handleSelect(id) {
+  selectedId.value = id
+  loadDetail(id)
+}
+
+// ── 확인 모달 / 토스트 ─────────────────────────────────────────────
+const confirmModal = ref({ show: false, action: null, targetId: null, title: '', message: '', confirmText: '' })
 const toast        = ref({ show: false, message: '' })
 let toastTimer = null
-
-function openConfirm(action, id, comment = '') {
-  const candidate = candidates.value.find(c => c.id === id)
-  const { name, currentTier, targetTier } = candidate
-  const config = {
-    hold:    { title: '보류',     message: `${name}님의 승급 심사를 보류하시겠습니까?`,  confirmText: '보류' },
-    confirm: { title: '승급 확정', message: `${name}님을 ${currentTier}-Tier에서 ${targetTier}-Tier로 승급 확정하시겠습니까?`, confirmText: '확정' },
-  }[action]
-  confirmModal.value = { show: true, action, targetId: id, comment, ...config }
-}
-
-function handleModalConfirm() {
-  const { action, targetId, comment } = confirmModal.value
-  const candidate = candidates.value.find(c => c.id === targetId)
-  const name = candidate?.name
-  if (candidate) {
-    candidate.processedStatus = action
-    candidate.comment = comment
-  }
-  confirmModal.value.show = false
-  const msg = action === 'confirm' ? `${name}님 승급이 확정되었습니다.` : `${name}님이 보류 처리되었습니다.`
-  showToast(msg)
-}
 
 function showToast(message) {
   if (toastTimer) clearTimeout(toastTimer)
@@ -88,38 +111,80 @@ function showToast(message) {
   toastTimer = setTimeout(() => { toast.value.show = false }, 2500)
 }
 
-function handleHold({ id, comment })    { openConfirm('hold',    id, comment) }
-function handleConfirm({ id, comment }) { openConfirm('confirm', id, comment) }
+function handleHold({ id }) {
+  const candidate = candidates.value.find(c => c.id === id)
+  confirmModal.value = {
+    show: true,
+    action: 'hold',
+    targetId: id,
+    title: '보류',
+    message: `${candidate?.name}님의 승급 심사를 보류하시겠습니까?`,
+    confirmText: '보류',
+  }
+}
+
+function handleConfirm({ id }) {
+  const candidate = candidates.value.find(c => c.id === id)
+  confirmModal.value = {
+    show: true,
+    action: 'confirm',
+    targetId: id,
+    title: '승급 확정',
+    message: `${candidate?.name}님을 ${candidate?.currentTier}-Tier에서 ${candidate?.targetTier}-Tier로 승급 확정하시겠습니까?`,
+    confirmText: '확정',
+  }
+}
+
+async function handleModalConfirm() {
+  const { action, targetId } = confirmModal.value
+  const candidate = candidates.value.find(c => c.id === targetId)
+  const status = action === 'confirm' ? 'CONFIRMATION_OF_PROMOTION' : 'SUSPENSION'
+  try {
+    await promotionApi.updateStatus(targetId, status)
+    confirmModal.value.show = false
+    // 로컬 상태 업데이트
+    candidates.value = candidates.value.map(c =>
+      c.id === targetId ? { ...c, rawStatus: status, statusLabel: STATUS_LABEL[status] } : c
+    )
+    details.value = { ...details.value, [targetId]: undefined }
+    showToast(action === 'confirm'
+      ? `${candidate?.name}님 승급이 확정되었습니다.`
+      : `${candidate?.name}님이 보류 처리되었습니다.`
+    )
+  } catch (e) {
+    console.error(e)
+    showToast('처리 중 오류가 발생했습니다.')
+  }
+}
 </script>
 
 <template>
   <section class="promo-view">
     <div v-if="loading" class="promo-view__loading">불러오는 중...</div>
+    <div v-else-if="error" class="promo-view__error">{{ error }}</div>
 
     <template v-else>
       <!-- 지표 카드 -->
-      <section class="promo-view__metrics" v-if="summary">
+      <section class="promo-view__metrics">
         <BaseStatCard
-          label="S-TIER 심사대상"
-          :value="`${summary.sTierCount}명`"
-          :delta="`▲${summary.sTierDelta} 전분기비`"
+          label="전체 심사 대상"
+          :value="`${summary?.totalCandidates ?? 0}명`"
           tone="primary"
         />
         <BaseStatCard
-          label="A-TIER 심사대상"
-          :value="`${summary.aTierCount}명`"
-          :delta="`▲${summary.aTierDelta}`"
+          label="S-Tier 대상"
+          :value="`${sTierCount}명`"
           tone="primary"
         />
         <BaseStatCard
-          label="이번분기 승급확정"
-          :value="`${summary.confirmedCount}명`"
-          tone="success"
+          label="A-Tier 대상"
+          :value="`${aTierCount}명`"
+          tone="primary"
         />
         <BaseStatCard
-          label="승급률"
-          :value="`${summary.promotionRate}%`"
-          :delta="`전분기 ${summary.prevPromotionRate}%`"
+          label="승급 확정"
+          :value="`${summary?.confirmedCount ?? 0}명`"
+          :delta="`승급률 ${summary?.promotionRate?.toFixed(1) ?? 0}%`"
           tone="success"
         />
       </section>
@@ -127,13 +192,9 @@ function handleConfirm({ id, comment }) { openConfirm('confirm', id, comment) }
       <!-- 목록 + 상세 -->
       <div class="promo-view__content">
         <HRMPromotionList
-          :list="filteredList"
-          :tabs="tabs"
-          :active-tab="activeTab"
+          :list="candidates"
           :selected-id="selectedId"
-          @tab-change="activeTab = $event"
-          @select="selectedId = $event"
-          @confirm="handleConfirm"
+          @select="handleSelect"
         />
         <HRMPromotionDetail
           v-if="selectedItem"
@@ -141,6 +202,7 @@ function handleConfirm({ id, comment }) { openConfirm('confirm', id, comment) }
           @hold="handleHold"
           @confirm="handleConfirm"
         />
+        <div v-else class="promo-view__empty">대상자를 선택하세요.</div>
       </div>
     </template>
   </section>
@@ -172,23 +234,41 @@ function handleConfirm({ id, comment }) { openConfirm('confirm', id, comment) }
   overflow: auto;
   min-height: 0;
 }
-.promo-view__loading {
+
+.promo-view__loading,
+.promo-view__error {
   padding: 60px;
   text-align: center;
-  color: var(--color-text-muted);
   font-size: var(--font-size-base);
+  color: var(--color-text-muted);
 }
+
+.promo-view__error { color: var(--color-danger); }
+
 .promo-view__metrics {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 16px;
 }
+
 .promo-view__content {
-  display: flex;
-  gap: 20px;
-  align-items: flex-start;
+  display: grid;
+  grid-template-columns: minmax(270px, 0.72fr) minmax(0, 1.6fr);
+  gap: 18px;
+  align-items: stretch;
   flex: 1;
   min-height: 0;
+}
+
+.promo-view__empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-bg-surface);
+  border: 1.5px solid var(--color-border-default);
+  border-radius: 24px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-base);
 }
 
 .promo-confirm-message {

--- a/src/views/teamleader/TeamLeaderAiEvaluationView.vue
+++ b/src/views/teamleader/TeamLeaderAiEvaluationView.vue
@@ -1,18 +1,129 @@
 ﻿<script setup>
 import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
-import { BaseProgressBar } from '@/components/common/base'
+import { BaseFilterTabs, BaseProgressBar } from '@/components/common/base'
 import { BaseToast } from '@/components/common/base/overlay'
+import ReviewerAppealDetailPanel from '@/components/hr/common/appeal/ReviewerAppealDetailPanel.vue'
+import ReviewerAppealListPanel from '@/components/hr/common/appeal/ReviewerAppealListPanel.vue'
 import TeamLeaderAiEvaluationMemberListPanel from '@/components/hr/teamleader/qualitative-evaluation/TeamLeaderAiEvaluationMemberListPanel.vue'
 import TeamLeaderAiEvaluationPanel from '@/components/hr/teamleader/qualitative-evaluation/TeamLeaderAiEvaluationPanel.vue'
-import { fetchTlTargets, updateTlEvaluation } from '@/services/teamleader/evaluationApi'
+import { approveTlAppeal, fetchTlAppealDetail, fetchTlAppeals, fetchTlTargets, rejectTlAppeal, updateTlEvaluation } from '@/services/teamleader/evaluationApi'
+import { formatMemberMeta } from '@/utils/hrListFormat'
 import { mapStatus, statusToLabel } from '@/utils/evaluationStatus'
 
 const AVATAR_TONES = ['purple', 'green', 'gold']
 const STATUS_MAP = { NO_INPUT: 'not_started', DRAFT: 'in_progress', SUBMITTED: 'submitted' }
+const activeTab = ref('evaluation')
+const modeTabs = [
+  { key: 'evaluation', label: '평가 관리' },
+  { key: 'appeal', label: '이의신청' },
+]
+const APPEAL_TYPE_LABEL = {
+  SCORE_ERRORS: '점수 오류',
+  MISSING_ITEMS: '평가 항목 누락',
+  EVALUATION_PROCEDURES: '평가 절차 이의',
+  OTHERS: '기타',
+}
+const APPEAL_STATUS_LABEL = {
+  SUBMITTED: '제출',
+  RECEIVING: '접수',
+  REVIEWING: '검토중',
+  COMPLETED: '완료',
+}
+const REVIEW_RESULT_LABEL = {
+  ACKNOWLEDGE: '인용',
+  ACKNOWLEDGE_IN_PART: '일부 인용',
+  DISMISS: '기각',
+}
 
 const rawTargets = ref([])
 const evalPeriodId = ref(null)
 const periodInfo = ref(null)
+const appealSummaries = ref([])
+const selectedAppealId = ref(null)
+const selectedAppealDetail = ref(null)
+const appealActionLoading = ref(false)
+const appealReviewing = ref(false)
+const appealDraftText = ref('')
+const appealDraftInputMethod = ref('TEXT')
+
+function unwrap(response) {
+  return response.data?.data ?? response.data
+}
+
+function formatShortDate(value) {
+  if (!value) return '-'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return '-'
+  return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, '0')}.${String(date.getDate()).padStart(2, '0')}`
+}
+
+function formatScore(value) {
+  const numeric = Number(value)
+  return Number.isFinite(numeric) ? `${numeric.toFixed(1)}점` : '-'
+}
+
+function formatPeriodText(evalYear, evalSequence) {
+  if (!evalYear) return '평가기간 미지정'
+  const raw = String(evalYear)
+  const year = raw.slice(0, 4)
+  const month = raw.length >= 6 ? String(parseInt(raw.slice(4), 10)) : null
+  return month
+    ? `${year}년 ${month}월 ${evalSequence}차`
+    : `${year}년 ${evalSequence}차`
+}
+
+function mapAppealSummary(appeal) {
+  return {
+    appealId: appeal.appealId,
+    appealEmployeeId: appeal.appealEmployeeId,
+    evaluationPeriodId: appeal.evaluationPeriodId,
+    employeeName: appeal.employeeName ?? '-',
+    employeeCode: appeal.employeeCode ?? '',
+    departmentName: appeal.departmentName ?? '',
+    teamName: appeal.teamName ?? '',
+    title: appeal.title ?? '제목 없음',
+    content: appeal.content ?? '내용이 없습니다.',
+    status: appeal.status ?? 'RECEIVING',
+    statusLabel: APPEAL_STATUS_LABEL[appeal.status] ?? (appeal.status ?? '-'),
+    appealTypeLabel: APPEAL_TYPE_LABEL[appeal.appealType] ?? (appeal.appealType ?? '-'),
+    filedAtLabel: formatShortDate(appeal.filedAt),
+    quantScoreLabel: '-',
+    firstScoreLabel: formatScore(appeal.firstScore),
+    secondScoreLabel: formatScore(appeal.secondScore),
+    averageScoreLabel: formatScore(appeal.averageScore),
+    periodLabel: formatPeriodText(appeal.evalYear, appeal.evalSequence),
+    firstStageComment: '',
+    secondStageComment: '',
+  }
+}
+
+function mapAppealDetail(appeal) {
+  if (!appeal) return null
+  return {
+    appealId: appeal.appealId,
+    appealEmployeeId: appeal.appealEmployeeId,
+    evaluationPeriodId: appeal.evaluationPeriodId,
+    employeeName: appeal.employeeName ?? '-',
+    employeeCode: appeal.employeeCode ?? '',
+    departmentName: appeal.departmentName ?? '',
+    teamName: appeal.teamName ?? '',
+    title: appeal.title ?? '제목 없음',
+    content: appeal.content ?? '내용이 없습니다.',
+    status: appeal.status ?? 'RECEIVING',
+    statusLabel: APPEAL_STATUS_LABEL[appeal.status] ?? (appeal.status ?? '-'),
+    appealTypeLabel: APPEAL_TYPE_LABEL[appeal.appealType] ?? (appeal.appealType ?? '-'),
+    reviewResultLabel: REVIEW_RESULT_LABEL[appeal.reviewResult] ?? '미처리',
+    filedAtLabel: formatShortDate(appeal.filedAt),
+    reviewedAtLabel: formatShortDate(appeal.reviewedAt),
+    quantScoreLabel: '-',
+    firstScoreLabel: formatScore(appeal.firstScore),
+    secondScoreLabel: formatScore(appeal.secondScore),
+    averageScoreLabel: formatScore(appeal.averageScore),
+    periodLabel: formatPeriodText(appeal.evalYear, appeal.evalSequence),
+    firstStageComment: appeal.firstStageComment ?? '',
+    secondStageComment: appeal.secondStageComment ?? '',
+  }
+}
 
 const periodLabel = computed(() => {
   if (!periodInfo.value?.evalYear) return null
@@ -44,6 +155,7 @@ let speechTargetId = ''
 let speechBaseDraft = ''
 let speechFinalText = ''
 let stoppingSpeech = false
+const APPEAL_SPEECH_KEY = '__appeal__'
 
 function speechRecognitionCtor() {
   if (typeof window === 'undefined') return null
@@ -58,6 +170,8 @@ function mapTarget(target, index) {
     evaluationPeriodId,
     name: target.employeeName,
     code: target.employeeCode,
+    departmentName: target.departmentName ?? '',
+    teamName: target.teamName ?? target.departmentName ?? target.team ?? '',
     tier: target.employeeTier,
     firstStageScore: target.firstStageScore ?? null,
     totalScore: target.totalScore ?? null,
@@ -70,7 +184,7 @@ function mapTarget(target, index) {
 onMounted(async () => {
   try {
     const res = await fetchTlTargets()
-    const data = res.data.data
+    const data = unwrap(res)
     evalPeriodId.value = data.evalPeriodId
     periodInfo.value = {
       evalYear: data.evalYear,
@@ -94,6 +208,17 @@ onMounted(async () => {
   } catch (e) {
     updateFeedback('평가 대상 목록을 불러오지 못했습니다.', 'muted')
   }
+
+  try {
+    const res = await fetchTlAppeals()
+    const appeals = (unwrap(res) ?? []).map(mapAppealSummary)
+    appealSummaries.value = appeals
+    if (appeals.length) {
+      await handleSelectAppeal(appeals[0].appealId)
+    }
+  } catch (e) {
+    updateFeedback('이의신청 목록을 불러오지 못했습니다.', 'muted')
+  }
 })
 
 const memberListItems = computed(() =>
@@ -109,6 +234,7 @@ const memberListItems = computed(() =>
 
     return {
       ...target,
+      meta: formatMemberMeta(target.code, target.departmentName ?? '', target.teamName ?? ''),
       status,
       statusDate: statusToLabel(status, hasConfirmed ? 'CONFIRMED' : hasSubmitted ? 'SUBMITTED' : hasEdited ? 'DRAFT' : 'NO_INPUT'),
     }
@@ -151,11 +277,147 @@ const selectedTarget = computed(() => {
   }
 })
 
+const selectedAppealReviewTarget = computed(() => {
+  const detail = selectedAppealDetail.value
+  if (!detail) return null
+  return {
+    voiceLabel: `${detail.employeeName} 이의신청 검토`,
+    voiceDescription: `${detail.employeeName} (${detail.employeeCode || '-'})의 1차 평가 내용을 수정한 뒤 제출하면 DL 검토 단계로 넘어갑니다.`,
+    convertedText: appealDraftText.value,
+    expectedScore: null,
+    summaryTitle: '이전 1차 평가 내용',
+    summaryComment: detail.firstStageComment || '1차 평가 내용이 없습니다.',
+  }
+})
+
+const selectedAppealInfo = computed(() => {
+  const detail = selectedAppealDetail.value
+  if (!detail) return null
+  return {
+    periodLabel: detail.periodLabel,
+    typeLabel: detail.appealTypeLabel,
+    title: detail.title,
+    content: detail.content,
+  }
+})
+
 function handleSelectTarget(targetId) {
   if (recordingState.value === 'recording') {
     stopSpeechRecognition()
   }
   selectedTargetId.value = targetId
+}
+
+async function handleSelectAppeal(appealId) {
+  appealReviewing.value = false
+  selectedAppealId.value = appealId
+  const summary = appealSummaries.value.find((item) => item.appealId === appealId)
+  if (summary) {
+    selectedAppealDetail.value = { ...summary }
+    appealDraftText.value = summary.firstStageComment || ''
+    appealDraftInputMethod.value = 'TEXT'
+  }
+  try {
+    const res = await fetchTlAppealDetail(appealId)
+    selectedAppealDetail.value = {
+      ...(summary ?? {}),
+      ...mapAppealDetail(unwrap(res)),
+    }
+    appealDraftText.value = selectedAppealDetail.value.firstStageComment || ''
+  } catch (e) {
+    selectedAppealDetail.value = null
+    updateFeedback('이의신청 상세를 불러오지 못했습니다.', 'muted')
+  }
+}
+
+function handleStartAppealReview() {
+  if (!selectedAppealDetail.value) return
+  appealDraftText.value = selectedAppealDetail.value.firstStageComment || ''
+  appealDraftInputMethod.value = 'TEXT'
+  appealReviewing.value = true
+}
+
+function handleUpdateAppealDraft(value) {
+  appealDraftText.value = value
+}
+
+function handleCloseAppealReview() {
+  appealDraftText.value = selectedAppealDetail.value?.firstStageComment || ''
+  appealDraftInputMethod.value = 'TEXT'
+  appealReviewing.value = false
+}
+
+async function handleSaveAppealDraft() {
+  const detail = selectedAppealDetail.value
+  if (!detail?.appealEmployeeId || !detail.evaluationPeriodId) return
+  try {
+    await updateTlEvaluation(detail.appealEmployeeId, {
+      status: 'DRAFT',
+      evaluationPeriodId: detail.evaluationPeriodId,
+      evalComment: appealDraftText.value || null,
+      inputMethod: appealDraftInputMethod.value,
+    })
+    selectedAppealDetail.value = {
+      ...detail,
+      firstStageComment: appealDraftText.value,
+    }
+    updateFeedback('검토 초안을 임시 저장했습니다.', 'draft')
+  } catch (e) {
+    updateFeedback('검토 초안 저장에 실패했습니다.', 'muted')
+  }
+}
+
+async function handleSubmitAppealReview() {
+  const detail = selectedAppealDetail.value
+  if (!selectedAppealId.value || !detail?.appealEmployeeId || !detail.evaluationPeriodId) return
+  if (!appealDraftText.value || appealDraftText.value.trim().length < 20) {
+    updateFeedback('평가 코멘트는 20자 이상 입력해야 합니다.', 'muted')
+    return
+  }
+  try {
+    appealActionLoading.value = true
+    await updateTlEvaluation(detail.appealEmployeeId, {
+      status: 'SUBMITTED',
+      evaluationPeriodId: detail.evaluationPeriodId,
+      evalComment: appealDraftText.value,
+      inputMethod: appealDraftInputMethod.value,
+    })
+    await approveTlAppeal(selectedAppealId.value, {})
+    const appeals = (unwrap(await fetchTlAppeals()) ?? []).map(mapAppealSummary)
+    appealSummaries.value = appeals
+    selectedAppealDetail.value = null
+    appealReviewing.value = false
+    selectedAppealId.value = appeals[0]?.appealId ?? null
+    if (selectedAppealId.value) {
+      await handleSelectAppeal(selectedAppealId.value)
+    }
+    updateFeedback('검토 내용을 제출하고 DL 검토 단계로 전달했습니다.', 'submitted')
+  } catch (e) {
+    updateFeedback('이의신청 처리에 실패했습니다.', 'muted')
+  } finally {
+    appealActionLoading.value = false
+  }
+}
+
+async function handleRejectAppeal() {
+  if (!selectedAppealId.value) return
+  try {
+    appealActionLoading.value = true
+    await rejectTlAppeal(selectedAppealId.value, { reason: '팀리더 단계에서 기각되었습니다.' })
+    const appeals = (unwrap(await fetchTlAppeals()) ?? []).map(mapAppealSummary)
+    appealSummaries.value = appeals
+    selectedAppealDetail.value = null
+    appealReviewing.value = false
+    selectedAppealId.value = appeals[0]?.appealId ?? null
+    if (selectedAppealId.value) {
+      await handleSelectAppeal(selectedAppealId.value)
+    }
+    updateFeedback('이의신청을 기각 처리했습니다.', 'submitted')
+  } catch (e) {
+    updateFeedback('이의신청 처리에 실패했습니다.', 'muted')
+  } finally {
+    appealActionLoading.value = false
+  }
 }
 
 function handleUpdateConvertedText(value) {
@@ -271,7 +533,9 @@ function ensureSpeechRecognition() {
     }
 
     const composed = [speechBaseDraft, speechFinalText, interimText].filter(Boolean).join(' ').trim()
-    if (speechTargetId) {
+    if (speechTargetId === APPEAL_SPEECH_KEY) {
+      appealDraftText.value = composed
+    } else if (speechTargetId) {
       evaluationDrafts[speechTargetId] = composed
     }
   }
@@ -286,7 +550,10 @@ function ensureSpeechRecognition() {
     const hasTranscript = speechFinalText.trim().length > 0
     recordingState.value = hasTranscript ? 'ready' : 'idle'
 
-    if (speechTargetId && hasTranscript) {
+    if (speechTargetId === APPEAL_SPEECH_KEY && hasTranscript) {
+      appealDraftInputMethod.value = 'VOICE_STT'
+      updateFeedback('음성 초안을 검토 편집 영역에 반영했습니다.', 'draft')
+    } else if (speechTargetId && hasTranscript) {
       draftInputMethods[speechTargetId] = 'VOICE_STT'
       updateFeedback('음성 초안을 편집 영역에 바로 반영했습니다.', 'draft')
     } else if (!stoppingSpeech) {
@@ -300,6 +567,32 @@ function ensureSpeechRecognition() {
 }
 
 function handleVoiceInput() {
+  if (appealReviewing.value) {
+    const recognizer = ensureSpeechRecognition()
+    if (!recognizer) {
+      updateFeedback('현재 브라우저는 음성 인식을 지원하지 않습니다.', 'muted')
+      return
+    }
+    if (recordingState.value === 'recording') {
+      stopSpeechRecognition()
+      return
+    }
+    speechTargetId = APPEAL_SPEECH_KEY
+    speechBaseDraft = (appealDraftText.value ?? '').trim()
+    speechFinalText = ''
+    stoppingSpeech = false
+    uploadedText.value = ''
+    uploadedFileName.value = ''
+    recordingState.value = 'recording'
+    try {
+      recognizer.start()
+      updateFeedback('이의신청 검토 음성 인식 중입니다.', 'draft')
+    } catch {
+      updateFeedback('음성 인식을 시작하지 못했습니다.', 'muted')
+    }
+    return
+  }
+
   if (!selectedTargetId.value) return
   if (submittedEvaluations[selectedTargetId.value]) {
     updateFeedback('제출 완료된 평가는 수정할 수 없습니다.', 'muted')
@@ -342,7 +635,11 @@ async function handleFileSelected(file) {
 
   if (file.type.startsWith('text/') || /\.(txt|md|log)$/i.test(file.name)) {
     uploadedText.value = await file.text()
-    draftInputMethods[selectedTargetId.value] = 'TEXT'
+    if (appealReviewing.value) {
+      appealDraftInputMethod.value = 'TEXT'
+    } else {
+      draftInputMethods[selectedTargetId.value] = 'TEXT'
+    }
     updateFeedback(`${file.name} 파일을 불러왔습니다. 텍스트 변환 버튼으로 초안에 반영하세요.`, 'draft')
     return
   }
@@ -352,15 +649,20 @@ async function handleFileSelected(file) {
 }
 
 function handleConvertText() {
-  if (!selectedTargetId.value) return
+  if (!selectedTargetId.value && !appealReviewing.value) return
 
   if (!uploadedText.value) {
     updateFeedback('변환할 음성 또는 업로드 텍스트가 없습니다.', 'muted')
     return
   }
 
-  evaluationDrafts[selectedTargetId.value] = uploadedText.value
-  draftInputMethods[selectedTargetId.value] = 'TEXT'
+  if (appealReviewing.value) {
+    appealDraftText.value = uploadedText.value
+    appealDraftInputMethod.value = 'TEXT'
+  } else {
+    evaluationDrafts[selectedTargetId.value] = uploadedText.value
+    draftInputMethods[selectedTargetId.value] = 'TEXT'
+  }
   updateFeedback('텍스트 변환 결과를 편집 영역에 반영했습니다.', 'draft')
 }
 
@@ -385,32 +687,40 @@ onBeforeUnmount(() => {
 
 <template>
   <section class="teamleader-ai-evaluation-view">
-    <section class="teamleader-ai-evaluation-view__progress-card">
-      <div class="teamleader-ai-evaluation-view__progress-copy">
-        <div>
-          <p class="teamleader-ai-evaluation-view__progress-eyebrow">제출 완료 현황</p>
-          <strong class="teamleader-ai-evaluation-view__progress-title">
-            {{ submittedCount }} / {{ memberListItems.length }}명 제출 완료
-          </strong>
-        </div>
-        <div v-if="periodLabel" class="teamleader-ai-evaluation-view__period-info">
-          <span class="teamleader-ai-evaluation-view__period-badge">
-            {{ periodLabel }}
-          </span>
-          <span class="teamleader-ai-evaluation-view__period-dates">
-            {{ periodInfo.startDate }} ~ {{ periodInfo.endDate }}
-          </span>
-        </div>
-      </div>
-      <BaseProgressBar
-        :value="evaluationCompletionRate"
-        tone="success"
-        size="md"
-        label="평가 제출 진행률"
-      />
-    </section>
+    <BaseFilterTabs
+      v-model="activeTab"
+      :items="modeTabs"
+      variant="chip"
+      size="md"
+      class="teamleader-ai-evaluation-view__tabs"
+    />
 
-    <section class="teamleader-ai-evaluation-view__content">
+    <section v-if="activeTab === 'evaluation'" class="teamleader-ai-evaluation-view__content">
+      <section class="teamleader-ai-evaluation-view__progress-card teamleader-ai-evaluation-view__progress-card--full">
+        <div class="teamleader-ai-evaluation-view__progress-copy">
+          <div>
+            <p class="teamleader-ai-evaluation-view__progress-eyebrow">제출 완료 현황</p>
+            <strong class="teamleader-ai-evaluation-view__progress-title">
+              {{ submittedCount }} / {{ memberListItems.length }}명 제출 완료
+            </strong>
+          </div>
+          <div v-if="periodLabel" class="teamleader-ai-evaluation-view__period-info">
+            <span class="teamleader-ai-evaluation-view__period-badge">
+              {{ periodLabel }}
+            </span>
+            <span class="teamleader-ai-evaluation-view__period-dates">
+              {{ periodInfo.startDate }} ~ {{ periodInfo.endDate }}
+            </span>
+          </div>
+        </div>
+        <BaseProgressBar
+          :value="evaluationCompletionRate"
+          tone="success"
+          size="md"
+          label="평가 제출 진행률"
+        />
+      </section>
+
       <TeamLeaderAiEvaluationMemberListPanel
         :members="memberListItems"
         :selected-id="selectedTargetId"
@@ -433,6 +743,45 @@ onBeforeUnmount(() => {
         @close="handleCloseEditor"
         @save-draft="handleSaveDraft"
         @submit="handleSubmitEvaluation"
+      />
+    </section>
+
+    <section v-else class="teamleader-ai-evaluation-view__appeal-content">
+      <ReviewerAppealListPanel
+        :appeals="appealSummaries"
+        :selected-id="selectedAppealId"
+        role-label="TL"
+        @select="handleSelectAppeal"
+      />
+      <template v-if="appealReviewing">
+        <TeamLeaderAiEvaluationPanel
+          :selected-target="selectedAppealReviewTarget ?? { voiceLabel: '', voiceDescription: '', convertedText: '' }"
+          :appeal-info="selectedAppealInfo"
+          progress-label="이의신청 검토 작성 현황"
+          :readonly="false"
+          :guide-open="guideOpen"
+          :recording-state="recordingState"
+          :uploaded-file-name="uploadedFileName"
+          :action-disabled="appealActionLoading || !selectedAppealReviewTarget"
+          @update:converted-text="handleUpdateAppealDraft"
+          @voice-input="handleVoiceInput"
+          @file-selected="handleFileSelected"
+          @convert-text="handleConvertText"
+          @replay-audio="handleReplayAudio"
+          @toggle-guide="handleToggleGuide"
+          @close="handleCloseAppealReview"
+          @save-draft="handleSaveAppealDraft"
+          @submit="handleSubmitAppealReview"
+        />
+      </template>
+      <ReviewerAppealDetailPanel
+        v-else
+        :detail="selectedAppealDetail"
+        role-label="TL"
+        action-mode="tl"
+        :loading="appealActionLoading"
+        @review="handleStartAppealReview"
+        @reject="handleRejectAppeal"
       />
     </section>
     <BaseToast :show="toast.show" :message="toast.message" :type="toast.type" />
@@ -459,10 +808,55 @@ onBeforeUnmount(() => {
   display: grid;
   gap: 10px;
   padding: 14px 18px;
-  margin-bottom: 12px;
   border: 1px solid var(--color-border-default);
   border-radius: 20px;
   background: var(--color-bg-surface);
+}
+
+.teamleader-ai-evaluation-view__progress-card--full {
+  grid-column: 1 / -1;
+  margin-bottom: 12px;
+}
+
+.teamleader-ai-evaluation-view__tabs {
+  align-self: flex-start;
+  margin-bottom: 12px;
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  padding-bottom: 4px;
+  background: var(--color-bg-app);
+}
+
+.teamleader-ai-evaluation-view__tabs :deep(.base-filter-tabs__count) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+}
+
+.teamleader-ai-evaluation-view__tabs :deep(.base-filter-tabs__item:nth-child(2)) {
+  border-color: #f3c3cb;
+  color: #c24157;
+  background: #fff5f6;
+}
+
+.teamleader-ai-evaluation-view__tabs :deep(.base-filter-tabs__item:nth-child(2) .base-filter-tabs__count) {
+  background: rgba(194, 65, 87, 0.12);
+  color: #c24157;
+}
+
+.teamleader-ai-evaluation-view__tabs :deep(.base-filter-tabs__item:nth-child(2).base-filter-tabs__item--active) {
+  background: #ffe7eb;
+  border-color: #e88998;
+  color: #a61d38;
+}
+
+.teamleader-ai-evaluation-view__tabs :deep(.base-filter-tabs__item:nth-child(2).base-filter-tabs__item--active .base-filter-tabs__count) {
+  background: #c24157;
+  color: #fff;
 }
 
 .teamleader-ai-evaluation-view__progress-copy {
@@ -519,8 +913,20 @@ onBeforeUnmount(() => {
   min-height: 0;
 }
 
+.teamleader-ai-evaluation-view__appeal-content {
+  display: grid;
+  grid-template-columns: minmax(270px, 0.72fr) minmax(0, 1.6fr);
+  gap: 18px;
+  align-items: stretch;
+  min-height: 0;
+}
+
 @media (max-width: 1120px) {
   .teamleader-ai-evaluation-view__content {
+    grid-template-columns: 1fr;
+  }
+
+  .teamleader-ai-evaluation-view__appeal-content {
     grid-template-columns: 1fr;
   }
 }

--- a/src/views/worker/WorkerAppealRequestView.vue
+++ b/src/views/worker/WorkerAppealRequestView.vue
@@ -1,23 +1,35 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
-import { getWorkerAppealRequestData, registerAppeal, updateAppeal } from '@/services/workerHrApi'
+import { getWorkerAppealRequestData, registerAppeal } from '@/services/workerHrApi'
 import WorkerAppealNotification from '@/components/hr/worker/appeal-request/WorkerAppealNotification.vue'
 import WorkerAppealHistory from '@/components/hr/worker/appeal-request/WorkerAppealHistory.vue'
 import WorkerAppealForm from '@/components/hr/worker/appeal-request/WorkerAppealForm.vue'
 
 const loading = ref(true)
 const evalHistory = ref([])
-const appealForms = ref({}) // key: qualitativeEvaluationId
+const appealForms = ref({}) // key: evaluationPeriodId
 const selectedId = ref(null) // qualitativeEvaluationId
+
+function formatPeriod(history) {
+  const raw = String(history?.evalYear ?? '')
+  if (raw.length === 6) {
+    const year = raw.slice(0, 4)
+    const month = Number(raw.slice(4, 6))
+    return `${year}년 ${month}월 ${history?.evalSequence ?? ''}차`
+  }
+  if (history?.evalYear && history?.evalSequence != null) {
+    return `${history.evalYear}년 ${history.evalSequence}차`
+  }
+  return '-'
+}
 
 onMounted(async () => {
   try {
     const { history, appeals } = await getWorkerAppealRequestData()
 
     evalHistory.value = history
-    // Index appeals by qualitativeEvaluationId
     appeals.forEach((a) => {
-      appealForms.value[a.evalHistoryId] = a
+      appealForms.value[a.evalPeriodId] = a
     })
 
     if (history.length) {
@@ -32,23 +44,27 @@ onMounted(async () => {
 
 const selectedAppeal = computed(() => {
   if (!selectedId.value) return null
-  // If no appeal exists for this evaluation, create a draft object
-  return appealForms.value[selectedId.value] || {
+  const selectedHistory = evalHistory.value.find((h) => h.id === selectedId.value)
+  if (!selectedHistory) return null
+  const currentAppeal = appealForms.value[selectedHistory.evalPeriodId] || {
     evalHistoryId: selectedId.value,
+    evalPeriodId: selectedHistory.evalPeriodId,
     title: '',
     content: '',
-    appealType: 'QUANTITATIVE_ERROR',
+    appealType: 'SCORE_ERRORS',
     status: 'NONE',
     processStatus: 0,
     submittedDate: '-',
   }
+  return {
+    ...currentAppeal,
+    quarter: formatPeriod(selectedHistory),
+  }
 })
 
-const selectedStatus = computed(() => {
-  if (!selectedId.value) return null
-  const item = evalHistory.value.find((h) => h.id === selectedId.value)
-  return item?.statusBadge ?? null
-})
+const hasEvalHistory = computed(() =>
+  evalHistory.value.some((item) => item?.id != null || item?.evalPeriodId != null)
+)
 
 function handleSelect(id) {
   selectedId.value = id
@@ -60,31 +76,27 @@ function handleCancel() {
 
 async function handleSubmit(payload) {
   if (!selectedId.value) return
-  const currentAppeal = appealForms.value[selectedId.value]
+  const selectedHistory = evalHistory.value.find((h) => h.id === selectedId.value)
+  if (!selectedHistory?.evalPeriodId) return
+  const currentAppeal = appealForms.value[selectedHistory.evalPeriodId]
 
   try {
     if (currentAppeal && currentAppeal.appealId) {
-      // Update existing appeal
-      await updateAppeal(currentAppeal.appealId, {
-        qualitativeEvaluationId: selectedId.value,
-        appealType: payload.appealType,
-        title: payload.title,
-        content: payload.content,
-      })
-    } else {
-      // Register new appeal
-      await registerAppeal({
-        qualitativeEvaluationId: selectedId.value,
-        appealType: payload.appealType,
-        title: payload.title,
-        content: payload.content,
-      })
+      alert('제출된 이의신청은 수정할 수 없습니다.')
+      return
     }
+    await registerAppeal({
+      evaluationPeriodId: selectedHistory.evalPeriodId,
+      appealType: payload.appealType,
+      title: payload.title,
+      content: payload.content,
+    })
     // Refresh data after save
     const { history, appeals } = await getWorkerAppealRequestData()
     evalHistory.value = history
+    appealForms.value = {}
     appeals.forEach((a) => {
-      appealForms.value[a.evalHistoryId] = a
+      appealForms.value[a.evalPeriodId] = a
     })
   } catch (e) {
     console.error('Failed to save appeal:', e)
@@ -102,7 +114,7 @@ async function handleSubmit(payload) {
 
       <div class="ar-grid">
         <WorkerAppealHistory
-          v-if="evalHistory.length"
+          v-if="hasEvalHistory"
           :history="evalHistory"
           :selected-id="selectedId"
           @select="handleSelect"
@@ -110,10 +122,12 @@ async function handleSubmit(payload) {
         <WorkerAppealForm
           v-if="selectedAppeal"
           :appeal-data="selectedAppeal"
-          :status-badge="selectedStatus"
           @cancel="handleCancel"
           @submit="handleSubmit"
         />
+        <div v-else class="ar-empty">
+          평가 이력이 없습니다.
+        </div>
       </div>
     </template>
   </div>
@@ -144,5 +158,19 @@ async function handleSubmit(payload) {
   padding: 60px 0;
   font-size: 15px;
   color: var(--color-text-muted);
+}
+
+.ar-empty {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 280px;
+  border: 1px dashed var(--color-border-default);
+  border-radius: var(--radius-card);
+  background: var(--color-bg-surface);
+  color: var(--color-text-muted);
+  font-size: 15px;
+  font-weight: 600;
 }
 </style>

--- a/src/views/worker/WorkerAppealRequestView.vue
+++ b/src/views/worker/WorkerAppealRequestView.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
-import { getWorkerAppealRequestData, registerAppeal } from '@/services/workerHrApi'
+import { getWorkerAppealRequestData, registerAppeal, uploadAppealAttachments } from '@/services/workerHrApi'
 import WorkerAppealNotification from '@/components/hr/worker/appeal-request/WorkerAppealNotification.vue'
 import WorkerAppealHistory from '@/components/hr/worker/appeal-request/WorkerAppealHistory.vue'
 import WorkerAppealForm from '@/components/hr/worker/appeal-request/WorkerAppealForm.vue'
@@ -85,12 +85,13 @@ async function handleSubmit(payload) {
       alert('제출된 이의신청은 수정할 수 없습니다.')
       return
     }
-    await registerAppeal({
+    const appealId = await registerAppeal({
       evaluationPeriodId: selectedHistory.evalPeriodId,
       appealType: payload.appealType,
       title: payload.title,
       content: payload.content,
     })
+    await uploadAppealAttachments(appealId, payload.files ?? [])
     // Refresh data after save
     const { history, appeals } = await getWorkerAppealRequestData()
     evalHistory.value = history
@@ -100,6 +101,11 @@ async function handleSubmit(payload) {
     })
   } catch (e) {
     console.error('Failed to save appeal:', e)
+    const errCode = e?.response?.data?.errorCode
+    if (errCode === 'APPEAL_ALREADY_EXISTS') {
+      alert('이의신청은 저장되었지만 새로고침이 필요합니다.')
+      return
+    }
     alert('이의 신청 저장에 실패했습니다.')
   }
 }


### PR DESCRIPTION
  ## 작업 개요
  HR 프론트 화면에서 평가승인/이의신청 흐름을 현재 백엔드 워크플로우에 맞게 정리했습니다.

  HRM 승인 화면, TL/DL 평가 화면, Worker 이의신청 화면을 함께 수정했고,
  공통 리스트/상세 패널 구조를 정리해 화면 흐름을 통일했습니다.

  ## 주요 변경 사항
  - HRM 평가승인/이의신청 승인 화면 로직 수정
  - 이의신청 목록을 `SUBMITTED`, `RECEIVING`, `COMPLETED` 기준으로 로드
  - `COMPLETED` appeal에 대해 `최종 확정` 액션 분기 추가
  - TL/DL 평가 화면에서 좌측 목록 / 우측 상세 패널 구조 공통화
  - 필터, 카드, 페이지네이션 UI 공통화
  - Worker 이의신청 폼 UI 정리
  - 평가기간/이의유형 표시 보정
  - 제출 후 읽기 전용 처리
  - 멤버 메타 표시용 공통 유틸 추가

  ## 검증
  - `npm run build` 성공
