### PR TITLE
fix: update hr criteria detail api and timeout

### DIFF
--- a/src/services/apiClient.js
+++ b/src/services/apiClient.js
@@ -16,7 +16,7 @@ function processQueue(error, token) {
 function createApiClient(baseURL) {
   const instance = axios.create({
     baseURL,
-    timeout: 5000,
+    timeout: 15000,
     withCredentials: true,
   })
 

--- a/src/views/hrmanager/HRMEvaluationCriteriaView.vue
+++ b/src/views/hrmanager/HRMEvaluationCriteriaView.vue
@@ -43,7 +43,7 @@ const authStore = useAuthStore()
 let toastTimer = null
 
 function fetchEvaluationCriteria() {
-  return axios.get(`${HR_API_BASE}/api/v1/hr/evaluation/criteria`, {
+  return axios.get(`${HR_API_BASE}/api/v1/hr/evaluation/criteria/detail`, {
     headers: { Authorization: `Bearer ${authStore.accessToken}` },
   })
 }


### PR DESCRIPTION
## 변경 내용
- HR 평가 기준 설정 화면이 상세 응답 API를 호출하도록 변경했습니다.
  - `/api/v1/hr/evaluation/criteria`
  - -> `/api/v1/hr/evaluation/criteria/detail`
- worker skill-gap 응답 확인을 위해 공통 axios timeout을 임시로 `5s -> 15s`로 상향했습니다.

## 메모
- timeout 상향은 확인용 임시 조치입니다.
- 다음 단계에서 skill-gap API 응답 시간 자체를 줄일 예정입니다.
