### PR TITLE
refactor: 내 평가 조회 UI 개선 및 평가기간 표기 공통화

### DIFF
--- a/src/components/hr/departmentleader/second-evaluation/DepartmentLeaderFirstEvaluationSummary.vue
+++ b/src/components/hr/departmentleader/second-evaluation/DepartmentLeaderFirstEvaluationSummary.vue
@@ -19,10 +19,6 @@ defineProps({
           <strong>{{ summary.qualitativeScore }}</strong>
           <span>정성</span>
         </div>
-        <div class="first-evaluation-summary__score">
-          <strong>{{ summary.compositeScore }}</strong>
-          <span>종합</span>
-        </div>
       </div>
     </div>
 

--- a/src/components/hr/hrmanager/evaluation-approval/HRMApprovalDetail.vue
+++ b/src/components/hr/hrmanager/evaluation-approval/HRMApprovalDetail.vue
@@ -70,9 +70,10 @@ watch(() => props.item?.id, () => {
           <textarea
             v-model="confirmComment"
             class="hrm-confirm-comment__input"
-            placeholder="최종 확정 의견을 입력하세요. (선택)"
+            placeholder="필요한 경우 최종 확정 코멘트를 입력하세요"
             rows="3"
           />
+          <p class="hrm-confirm-comment__hint">입력하면 20자 이상이어야 하며, 비워두고 바로 최종 확정할 수 있습니다.</p>
         </div>
         <div class="hrm-eval-actions">
           <button class="hrm-btn hrm-btn--approve" @click="emit('approve', confirmComment)">최종 확정</button>
@@ -327,7 +328,7 @@ watch(() => props.item?.id, () => {
 }
 
 .hrm-confirm-comment__label {
-  font-size: var(--font-size-xs);
+  font-size: var(--font-size-sm);
   font-weight: var(--font-weight-bold);
   color: var(--color-primary-700);
 }
@@ -349,6 +350,12 @@ watch(() => props.item?.id, () => {
 .hrm-confirm-comment__input:focus {
   outline: none;
   border-color: var(--color-primary-500);
+}
+
+.hrm-confirm-comment__hint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--color-text-muted);
 }
 
 /* footer 액션 */

--- a/src/components/hr/hrmanager/evaluation-criteria/HRMEvalTierHistoryGroupPanel.vue
+++ b/src/components/hr/hrmanager/evaluation-criteria/HRMEvalTierHistoryGroupPanel.vue
@@ -87,7 +87,7 @@ function orderedItems(items = []) {
 }
 .eval-history-card__empty {
   padding: 20px;
-  border: 1px dashed var(--color-border-default);
+  border: 1px solid var(--color-border-default);
   border-radius: 8px;
   font-size: var(--font-size-sm);
   color: var(--color-text-subtle);

--- a/src/components/hr/hrmanager/evaluation-criteria/HRMEvalWeightHistoryGroupPanel.vue
+++ b/src/components/hr/hrmanager/evaluation-criteria/HRMEvalWeightHistoryGroupPanel.vue
@@ -110,7 +110,7 @@ function orderedItems(items = []) {
 }
 .eval-history-card__empty {
   padding: 20px;
-  border: 1px dashed var(--color-border-default);
+  border: 1px solid var(--color-border-default);
   border-radius: 8px;
   font-size: var(--font-size-sm);
   color: var(--color-text-subtle);

--- a/src/components/hr/hrmanager/promotion-review/HRMPromotionDetail.vue
+++ b/src/components/hr/hrmanager/promotion-review/HRMPromotionDetail.vue
@@ -397,7 +397,7 @@ function missionStatusLabel(status) {
   padding: 18px 16px;
   border-radius: 14px;
   background: var(--color-bg-app);
-  border: 1px dashed var(--color-border-default);
+  border: 1px solid var(--color-border-default);
   font-size: var(--font-size-sm);
   color: var(--color-text-muted);
 }

--- a/src/components/hr/worker/appeal-request/WorkerAppealHistory.vue
+++ b/src/components/hr/worker/appeal-request/WorkerAppealHistory.vue
@@ -1,4 +1,6 @@
 <script setup>
+import { formatEvaluationPeriodLabel } from '@/utils/evaluationPeriod'
+
 const props = defineProps({
   history: { type: Array, required: true },
   selectedId: { type: Number, default: null },
@@ -22,13 +24,7 @@ function tierClass(tier) {
 }
 
 function periodLabel(item) {
-  const raw = String(item.evalYear ?? '')
-  if (raw.length === 6) {
-    const year = raw.slice(0, 4)
-    const month = Number(raw.slice(4, 6))
-    return `${year}년 ${month}월 ${item.evalSequence}차`
-  }
-  return `${item.evalYear}년 ${item.evalSequence}차`
+  return formatEvaluationPeriodLabel(item, { fallback: '-' })
 }
 
 function fmt(val) {

--- a/src/components/hr/worker/evaluation-result/WorkerEvaluationStatus.vue
+++ b/src/components/hr/worker/evaluation-result/WorkerEvaluationStatus.vue
@@ -32,6 +32,14 @@ function diffText(val) {
   if (val < 0) return `▼${Math.abs(val)}`
   return '—'
 }
+
+function rankText(val) {
+  return val === null || val === undefined || val === '-' ? '-' : `${val}위`
+}
+
+function rankTotalText(val) {
+  return val === null || val === undefined || val === '-' ? '-' : `${val}명`
+}
 </script>
 
 <template>
@@ -52,7 +60,7 @@ function diffText(val) {
       </svg>
       <div class="es__gauge-text">
         <span class="es__gauge-score">{{ status?.overallScore ?? '-' }}</span>
-        <span class="es__gauge-max">total points</span>
+        <span class="es__gauge-max">this quarter</span>
       </div>
     </div>
 
@@ -73,37 +81,37 @@ function diffText(val) {
       <span class="es__metric-diff" :class="diffClass(status?.qualitative?.diff ?? 0)">
         {{ diffText(status?.qualitative?.diff ?? 0) }}
       </span>
-      <span class="es__metric-sub">가중치 {{ status?.qualitative?.weight ?? '-' }}</span>
     </div>
 
     <div class="es__divider"></div>
 
     <div class="es__metric">
-      <span class="es__metric-label">설비보정</span>
-      <span class="es__metric-value es__metric-value--accent">{{ status?.equipmentCorrection?.label ?? '-' }}</span>
-      <span class="es__metric-sub">{{ status?.equipmentCorrection?.sub ?? '-' }}</span>
-    </div>
-
-    <div class="es__divider"></div>
-
-    <div class="es__metric">
-      <span class="es__metric-label">종합</span>
-      <span class="es__metric-value">{{ status?.composite?.score ?? '-' }}</span>
-      <span class="es__metric-diff" :class="diffClass(status?.composite?.diff ?? 0)">
-        {{ diffText(status?.composite?.diff ?? 0) }}
-      </span>
-      <span class="es__metric-sub">{{ status?.composite?.sub ?? '-' }}</span>
+      <span class="es__metric-label">전분기 비교</span>
+      <div class="es__compare-list">
+        <div class="es__compare-item">
+          <span class="es__compare-key">정량</span>
+          <span class="es__compare-value" :class="diffClass(status?.quantitative?.diff ?? 0)">
+            {{ diffText(status?.quantitative?.diff ?? 0) }}
+          </span>
+        </div>
+        <div class="es__compare-item">
+          <span class="es__compare-key">정성</span>
+          <span class="es__compare-value" :class="diffClass(status?.qualitative?.diff ?? 0)">
+            {{ diffText(status?.qualitative?.diff ?? 0) }}
+          </span>
+        </div>
+      </div>
     </div>
 
     <!-- Tier + Rank badge -->
     <div class="es__rank">
       <span class="es__rank-quarter">{{ status?.periodLabel ?? '이번 분기' }}</span>
       <span class="es__rank-tier">{{ status?.tier ?? '-' }}-Tier</span>
-      <span class="es__rank-label">라인 내 순위</span>
+      <span class="es__rank-label">포인트 순위</span>
       <div class="es__rank-numbers">
-        <span class="es__rank-current">{{ status?.rank ?? '-' }}</span>
+        <span class="es__rank-current">{{ rankText(status?.rank) }}</span>
         <span class="es__rank-sep">/</span>
-        <span class="es__rank-total">{{ status?.rankTotal ?? '-' }}위</span>
+        <span class="es__rank-total">{{ rankTotalText(status?.rankTotal) }}</span>
       </div>
       <span class="es__rank-diff diff--up" v-if="(status?.rankDiff ?? 0) > 0">
         ▲{{ status.rankDiff }} 전분기비
@@ -150,14 +158,14 @@ function diffText(val) {
 }
 
 .es__gauge-score {
-  font-size: 28px;
+  font-size: var(--font-size-2xl-plus);
   font-weight: 800;
   color: var(--color-text-strong);
   line-height: 1;
 }
 
 .es__gauge-max {
-  font-size: 12px;
+  font-size: var(--font-size-xs-plus);
   color: var(--color-text-muted);
 }
 
@@ -172,13 +180,13 @@ function diffText(val) {
 }
 
 .es__metric-label {
-  font-size: 13px;
+  font-size: var(--font-size-sm);
   font-weight: 600;
   color: var(--color-text-muted);
 }
 
 .es__metric-value {
-  font-size: 36px;
+  font-size: var(--font-size-2xl);
   font-weight: 800;
   color: var(--color-text-strong);
   line-height: 1.1;
@@ -189,13 +197,40 @@ function diffText(val) {
 }
 
 .es__metric-diff {
-  font-size: 13px;
+  font-size: var(--font-size-sm);
   font-weight: 600;
 }
 
 .es__metric-sub {
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
+}
+
+.es__compare-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.es__compare-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 120px;
+}
+
+.es__compare-key {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-text-muted);
+}
+
+.es__compare-value {
+  font-size: var(--font-size-lg);
+  font-weight: 800;
+  color: var(--color-text-strong);
 }
 
 .diff--up {
@@ -229,19 +264,19 @@ function diffText(val) {
 }
 
 .es__rank-quarter {
-  font-size: 12px;
+  font-size: var(--font-size-xs-plus);
   color: var(--color-text-muted);
 }
 
 .es__rank-tier {
-  font-size: 32px;
+  font-size: var(--font-size-display-md);
   font-weight: 800;
   color: var(--color-text-strong);
   line-height: 1.1;
 }
 
 .es__rank-label {
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
   margin-top: 4px;
 }
@@ -253,24 +288,24 @@ function diffText(val) {
 }
 
 .es__rank-current {
-  font-size: 32px;
+  font-size: var(--font-size-display-md);
   font-weight: 800;
   color: var(--color-text-strong);
 }
 
 .es__rank-sep {
-  font-size: 20px;
+  font-size: var(--font-size-xl);
   color: var(--color-text-muted);
 }
 
 .es__rank-total {
-  font-size: 20px;
+  font-size: var(--font-size-xl);
   font-weight: 700;
   color: var(--color-text-default);
 }
 
 .es__rank-diff {
-  font-size: 12px;
+  font-size: var(--font-size-xs-plus);
   font-weight: 600;
 }
 </style>

--- a/src/components/hr/worker/evaluation-result/WorkerGrowthFeedback.vue
+++ b/src/components/hr/worker/evaluation-result/WorkerGrowthFeedback.vue
@@ -36,7 +36,7 @@ function renderChart() {
       labels,
       datasets: [
         {
-          label: '내 종합 점수',
+          label: '분기 포인트',
           data: overallData,
           borderColor: '#5B4FCF',
           backgroundColor: '#5B4FCF',
@@ -149,7 +149,7 @@ onBeforeUnmount(() => {
   <div class="gf">
     <div class="gf__header">
       <span class="gf__icon">📈</span>
-      <h3 class="gf__title">성장 추이 & 피드백</h3>
+      <h3 class="gf__title">성장 추이</h3>
     </div>
 
     <!-- Line chart -->
@@ -161,7 +161,7 @@ onBeforeUnmount(() => {
       <div class="gf__chart-legend">
         <span class="gf__chart-legend-item">
           <span class="gf__chart-legend-line gf__chart-legend-line--overall"></span>
-          내 종합 점수
+          분기 포인트
         </span>
         <span v-if="hasTeamSeries" class="gf__chart-legend-item">
           <span class="gf__chart-legend-line gf__chart-legend-line--team"></span>
@@ -209,11 +209,11 @@ onBeforeUnmount(() => {
 }
 
 .gf__icon {
-  font-size: 16px;
+  font-size: var(--font-size-md);
 }
 
 .gf__title {
-  font-size: 18px;
+  font-size: var(--font-size-lg);
   font-weight: 700;
   color: var(--color-text-strong);
   margin: 0;
@@ -247,7 +247,7 @@ onBeforeUnmount(() => {
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 12px;
+  font-size: var(--font-size-xs-plus);
   color: var(--color-text-muted);
 }
 
@@ -294,7 +294,7 @@ onBeforeUnmount(() => {
 }
 
 .gf__goals-title {
-  font-size: 14px;
+  font-size: var(--font-size-base);
   font-weight: 700;
   color: var(--color-primary-800);
 }
@@ -314,7 +314,7 @@ onBeforeUnmount(() => {
 }
 
 .gf__goal-label {
-  font-size: 12px;
+  font-size: var(--font-size-xs-plus);
   color: var(--color-text-muted);
 }
 
@@ -325,18 +325,18 @@ onBeforeUnmount(() => {
 }
 
 .gf__goal-current {
-  font-size: 22px;
+  font-size: var(--font-size-lg-plus);
   font-weight: 800;
   color: var(--color-text-strong);
 }
 
 .gf__goal-arrow {
-  font-size: 16px;
+  font-size: var(--font-size-md);
   color: var(--color-text-muted);
 }
 
 .gf__goal-target {
-  font-size: 22px;
+  font-size: var(--font-size-lg-plus);
   font-weight: 800;
   color: var(--color-text-strong);
 }

--- a/src/components/hr/worker/evaluation-result/WorkerQualitativeEvaluation.vue
+++ b/src/components/hr/worker/evaluation-result/WorkerQualitativeEvaluation.vue
@@ -22,11 +22,15 @@ onMounted(() => {
 
     <!-- Evaluator info -->
     <div class="ql__evaluator">
-      <div class="ql__avatar">{{ (evaluation?.evaluator || '-').charAt(0) }}</div>
-      <span class="ql__evaluator-name">
-        {{ evaluation?.evaluator ?? '-' }} ({{ evaluation?.evaluatorRole ?? '-' }})
-      </span>
-      <span class="ql__nlp">NLP 신뢰도 {{ evaluation?.nlpConfidence ?? '0.00' }}</span>
+      <span class="ql__evaluator-title">평가자:</span>
+      <div v-if="(evaluation?.evaluators || []).length" class="ql__evaluator-list">
+        <div v-for="(item, index) in evaluation.evaluators" :key="item.label" class="ql__evaluator-item">
+          <span v-if="index > 0" class="ql__evaluator-sep">/</span>
+          <span class="ql__evaluator-badge">{{ item.label }}</span>
+          <span class="ql__evaluator-name">{{ item.name }}</span>
+        </div>
+      </div>
+      <span v-else class="ql__evaluator-name">-</span>
     </div>
 
     <hr class="ql__divider" />
@@ -74,11 +78,11 @@ onMounted(() => {
 }
 
 .ql__icon {
-  font-size: 16px;
+  font-size: var(--font-size-md);
 }
 
 .ql__title {
-  font-size: 18px;
+  font-size: var(--font-size-lg);
   font-weight: 700;
   color: var(--color-text-strong);
   margin: 0;
@@ -88,31 +92,56 @@ onMounted(() => {
   display: flex;
   align-items: center;
   gap: 10px;
+  flex-wrap: wrap;
 }
 
-.ql__avatar {
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  background: var(--color-primary-200);
-  color: var(--color-primary-800);
+.ql__evaluator-title {
+  font-size: var(--font-size-base);
+  font-weight: 600;
+  color: var(--color-text-muted);
+}
+
+.ql__evaluator-list {
   display: flex;
   align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.ql__evaluator-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ql__evaluator-sep {
+  font-size: var(--font-size-base);
+  color: var(--color-text-muted);
+}
+
+.ql__evaluator-badge {
+  display: inline-flex;
+  align-items: center;
   justify-content: center;
+  min-width: 34px;
+  height: 26px;
+  padding: 0 10px;
+  border-radius: 999px;
+  background: var(--color-primary-100);
+  color: var(--color-primary-800);
+  font-size: var(--font-size-xs-plus);
   font-weight: 700;
-  font-size: 14px;
-  flex-shrink: 0;
 }
 
 .ql__evaluator-name {
-  font-size: 14px;
+  font-size: var(--font-size-base);
   font-weight: 600;
   color: var(--color-text-strong);
 }
 
 .ql__nlp {
   margin-left: auto;
-  font-size: 12px;
+  font-size: var(--font-size-xs-plus);
   font-weight: 600;
   color: var(--tier-s);
   background: var(--color-mint-100);
@@ -148,13 +177,13 @@ onMounted(() => {
 }
 
 .ql__cat-label {
-  font-size: 15px;
+  font-size: var(--font-size-base-plus);
   font-weight: 700;
   color: var(--color-text-strong);
 }
 
 .ql__cat-score {
-  font-size: 15px;
+  font-size: var(--font-size-base-plus);
   font-weight: 700;
   color: var(--color-text-strong);
 }
@@ -179,7 +208,7 @@ onMounted(() => {
 }
 
 .ql__tag {
-  font-size: 12px;
+  font-size: var(--font-size-xs-plus);
   font-weight: 500;
   color: var(--color-text-default);
   background: var(--color-primary-100);

--- a/src/components/hr/worker/evaluation-result/WorkerQuantitativeEvaluation.vue
+++ b/src/components/hr/worker/evaluation-result/WorkerQuantitativeEvaluation.vue
@@ -1,11 +1,7 @@
 <script setup>
-import { ref } from 'vue'
-
-const props = defineProps({
+defineProps({
   evaluation: { type: Object, required: true },
 })
-
-const showFormula = ref(false)
 
 function isHighlight(val) {
   return val.endsWith('%') || val.endsWith('점')
@@ -34,13 +30,6 @@ function parseLabel(label) {
         <h3 class="qn__title">정량 평가 산출 내역</h3>
         <span class="qn__sub">설비 E_idx 보정 적용 기준</span>
       </div>
-      <button
-        class="qn__toggle"
-        :class="{ 'qn__toggle--active': showFormula }"
-        @click="showFormula = !showFormula"
-      >
-        정량 세부 산식
-      </button>
     </div>
 
     <!-- Formula steps -->
@@ -48,9 +37,6 @@ function parseLabel(label) {
       <div v-for="(step, i) in (evaluation?.steps || [])" :key="i" class="qn__step">
         <div class="qn__step-label">
           <span class="qn__step-name">{{ parseLabel(step.label).name }}</span>
-          <span v-if="showFormula && parseLabel(step.label).formula" class="qn__step-formula">
-            {{ parseLabel(step.label).formula }}
-          </span>
         </div>
         <span
           class="qn__step-value"
@@ -88,38 +74,20 @@ function parseLabel(label) {
 }
 
 .qn__icon-badge {
-  font-size: 18px;
+  font-size: var(--font-size-lg);
   line-height: 1;
 }
 
 .qn__title {
-  font-size: 18px;
+  font-size: var(--font-size-lg);
   font-weight: 700;
   color: var(--color-text-strong);
   margin: 0;
 }
 
 .qn__sub {
-  font-size: 12px;
+  font-size: var(--font-size-xs-plus);
   color: var(--color-text-muted);
-}
-
-.qn__toggle {
-  padding: 8px 18px;
-  border: 1px solid var(--color-border-default);
-  border-radius: var(--radius-lg);
-  background: var(--color-bg-surface);
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--color-text-default);
-  cursor: pointer;
-  transition: all 0.15s;
-}
-
-.qn__toggle--active {
-  background: var(--color-primary-800);
-  color: var(--color-white);
-  border-color: var(--color-primary-800);
 }
 
 .qn__steps {
@@ -145,19 +113,13 @@ function parseLabel(label) {
 }
 
 .qn__step-name {
-  font-size: 13px;
+  font-size: var(--font-size-sm);
   font-weight: 700;
   color: var(--color-text-strong);
 }
 
-.qn__step-formula {
-  font-family: 'Courier New', Courier, monospace;
-  font-size: 11px;
-  color: var(--color-text-muted);
-}
-
 .qn__step-value {
-  font-size: 16px;
+  font-size: var(--font-size-md);
   font-weight: 800;
   color: var(--color-text-strong);
   white-space: nowrap;

--- a/src/services/hrDashboardApi.js
+++ b/src/services/hrDashboardApi.js
@@ -1,4 +1,5 @@
 import { hrApi } from '@/services/apiClient'
+import { formatEvaluationPeriodLabel } from '@/utils/evaluationPeriod'
 
 function unwrap(response) {
   return response.data?.data ?? response.data
@@ -31,6 +32,14 @@ function formatPercent(value) {
 
 function formatOptionalPercent(value) {
   return value == null ? '-' : formatPercent(value)
+}
+
+function formatPeriodLabel(evalYear, evalSequence, suffix = '') {
+  const label = formatEvaluationPeriodLabel(
+    { evalYear, evalSequence },
+    { fallback: '-' },
+  )
+  return label === '-' ? label : `${label}${suffix}`
 }
 
 function tierTone(tier) {
@@ -222,7 +231,7 @@ export async function getTeamLeaderKpiReport({ year = 2026, evalSequence = 1 } =
       { label: '팀원 수', value: `${mappedRows.length}명`, tone: 'primary' },
       { label: '평균 정량점수', value: formatScore(avgScore), tone: 'success' },
       { label: '확정 건수', value: `${rows.filter((row) => row.status === 'CONFIRMED').length}건`, tone: 'success' },
-      { label: '평가 기간', value: `${year}-${evalSequence}`, tone: 'primary' },
+      { label: '평가 기간', value: formatPeriodLabel(year, evalSequence, ' 평가'), tone: 'primary' },
     ],
   }
 }
@@ -317,8 +326,8 @@ function tierDistributionFromCounts(counts = {}) {
 
 function mapHrmTrend(trend) {
   return {
-    month: `${trend.year}-Q${trend.evalSequence}`,
-    quarter: `${trend.year}-Q${trend.evalSequence}`,
+    month: formatPeriodLabel(trend.year, trend.evalSequence),
+    quarter: formatPeriodLabel(trend.year, trend.evalSequence),
     S: tierCount(trend, 'S'),
     A: tierCount(trend, 'A'),
     B: tierCount(trend, 'B'),
@@ -448,7 +457,7 @@ export async function getHrmDashboard(period = {}) {
       totalEmployees: toNumber(summary.totalEmployees),
       evaluationRate: formatScore(summary.evaluationRate),
       unevaluatedCount: toNumber(summary.unevaluatedCount),
-      tierDelta: `현재 평가기간 ${year}-Q${evalSequence}`,
+      tierDelta: `현재 평가기간 ${formatPeriodLabel(year, evalSequence, ' 평가')}`,
     },
     tierDistribution: tierDistributionFromCounts(tierCounts),
     tierTrend: trends.map(mapHrmTrend),
@@ -481,7 +490,7 @@ export async function getHrmKpiReport(period = {}) {
 
   return {
     report: {
-      quarter: `${year}년 ${evalSequence}분기`,
+      quarter: formatPeriodLabel(year, evalSequence),
       avgScore: formatScore(summary.avgScore),
       avgScoreDelta: '-',
       saRatio: toNumber(summary.totalEmployees)
@@ -499,11 +508,11 @@ export async function getHrmKpiReport(period = {}) {
     teamScores: teamStats.map((item) => ({
       team: item.team,
       score: toNumber(item.avg),
-      quarter: `${year}년 ${evalSequence}분기`,
+      quarter: formatPeriodLabel(year, evalSequence),
     })),
     tierTrend: trends.map(mapHrmTrend),
     teamLeaders: teamStats.map((item, index) =>
-      mapHrmTeamStatsReportRow(item, index, completionRate, `${year}년 ${evalSequence}분기`)
+      mapHrmTeamStatsReportRow(item, index, completionRate, formatPeriodLabel(year, evalSequence))
     ),
   }
 }

--- a/src/services/workerHrApi.js
+++ b/src/services/workerHrApi.js
@@ -610,7 +610,6 @@ function toEvalStatusViewModel(
   status,
   quantitative = null,
   qualitative = null,
-  pointSummary = null,
   pointHistory = [],
   profile = null,
   history = [],
@@ -622,7 +621,7 @@ function toEvalStatusViewModel(
   const quarterTotals = buildQuarterPointTotals(pointHistory)
   const overallScore = quarterTotals.length
     ? quarterTotals[quarterTotals.length - 1].total
-    : roundToOne(pointSummary?.totalPoints ?? 0)
+    : null
   const previousHistory = history.find((item) => item?.evalPeriodId !== status?.evalPeriodId) ?? null
 
   const quantitativeDiff = previousHistory ? roundToOne(quantitativeScore - toNumber(previousHistory.quantScore)) : 0
@@ -716,7 +715,7 @@ function toQualitativeViewModel(qual) {
   }
 }
 
-function buildPointGrowthChartData(pointHistory = [], pointSummary = null) {
+function buildPointGrowthChartData(pointHistory = []) {
   const quarterTotals = buildQuarterPointTotals(pointHistory)
   if (quarterTotals.length) {
     let cumulative = 0
@@ -730,25 +729,14 @@ function buildPointGrowthChartData(pointHistory = [], pointSummary = null) {
       }
     })
   }
-
-  const fallbackPoints = roundToOne(pointSummary?.totalPoints)
-  if (!fallbackPoints) return []
-
-  return [
-    {
-      label: '현재',
-      overall: fallbackPoints,
-      team: null,
-      company: null,
-    },
-  ]
+  return []
 }
 
-function toGrowthViewModel(pointHistory = [], pointSummary = null) {
-  const chartData = buildPointGrowthChartData(pointHistory, pointSummary)
+function toGrowthViewModel(pointHistory = []) {
+  const chartData = buildPointGrowthChartData(pointHistory)
   const currentPoints = chartData.length
     ? roundToOne(chartData[chartData.length - 1].overall)
-    : roundToOne(pointSummary?.totalPoints)
+    : null
 
   return {
     chartData,
@@ -756,19 +744,17 @@ function toGrowthViewModel(pointHistory = [], pointSummary = null) {
       {
         label: '이번 분기 포인트 목표',
         current: currentPoints,
-        target: roundToOne(toNumber(currentPoints) + 5),
+        target: currentPoints == null ? null : roundToOne(toNumber(currentPoints) + 5),
       },
     ],
   }
 }
 
-export async function getWorkerEvaluationData(periodId = null) {
-  const params = periodId ? { periodId } : {}
-  const [status, quantitative, qualitative, pointSummary, pointHistory, profile, history, tierChart] = await Promise.all([
+export async function getWorkerEvaluationData() {
+  const [status, quantitative, qualitative, pointHistory, profile, history, tierChart] = await Promise.all([
     optionalGet('/api/v1/hr/workers/me/evaluations/status', {}, null),
-    optionalGet('/api/v1/hr/workers/me/evaluations/quantitative', { params }, null),
-    optionalGet('/api/v1/hr/workers/me/evaluations/qualitative', { params }, null),
-    optionalGet('/api/v1/hr/workers/me/point-summary', {}, null),
+    optionalGet('/api/v1/hr/workers/me/evaluations/quantitative', {}, null),
+    optionalGet('/api/v1/hr/workers/me/evaluations/qualitative', {}, null),
     optionalGet('/api/v1/hr/workers/me/point-history', {}, []),
     optionalGet('/api/v1/hr/workers/me/profile', {}, null),
     optionalGet('/api/v1/hr/workers/me/evaluations/history', { params: { page: 0, size: 20 } }, null),
@@ -782,7 +768,6 @@ export async function getWorkerEvaluationData(periodId = null) {
       status,
       quantitative,
       qualitative,
-      pointSummary,
       (pointHistory ?? []).map(toPointHistoryViewModel),
       profile,
       historyItems,
@@ -790,9 +775,6 @@ export async function getWorkerEvaluationData(periodId = null) {
     ),
     quantitative: toQuantitativeViewModel(quantitative),
     qualitative: toQualitativeViewModel(qualitative),
-    feedback: toGrowthViewModel(
-      (pointHistory ?? []).map(toPointHistoryViewModel),
-      pointSummary,
-    ),
+    feedback: toGrowthViewModel((pointHistory ?? []).map(toPointHistoryViewModel)),
   }
 }

--- a/src/services/workerHrApi.js
+++ b/src/services/workerHrApi.js
@@ -1,4 +1,5 @@
 import { hrApi } from '@/services/apiClient'
+import { formatEvaluationPeriodLabel } from '@/utils/evaluationPeriod'
 
 function unwrap(response) {
   return response.data?.data ?? response.data
@@ -24,6 +25,13 @@ function roundToOne(value) {
 
 function normalizeTier(tier) {
   return tier || 'C'
+}
+
+function formatPeriodLabel(value, sequence, fallback = '-') {
+  return formatEvaluationPeriodLabel(
+    { evalYear: value, evalSequence: sequence },
+    { fallback },
+  )
 }
 
 function translateSkillName(skillName) {
@@ -192,6 +200,59 @@ function toPointHistoryViewModel(history) {
   }
 }
 
+function formatPointMonthLabel(value) {
+  if (!value) return '-'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    const raw = String(value)
+    const matched = raw.match(/^(\d{4})-(\d{2})/)
+    if (matched) {
+      return `${matched[1]}년 ${Number(matched[2])}월`
+    }
+    return raw
+  }
+  return `${date.getFullYear()}년 ${date.getMonth() + 1}월`
+}
+
+function getQuarterKey(value) {
+  if (!value) return null
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    const matched = String(value).match(/^(\d{4})-(\d{2})/)
+    if (!matched) return null
+    const year = Number(matched[1])
+    const month = Number(matched[2])
+    return `${year}-Q${Math.floor((month - 1) / 3) + 1}`
+  }
+  return `${date.getFullYear()}-Q${Math.floor(date.getMonth() / 3) + 1}`
+}
+
+function formatQuarterLabel(value) {
+  const matched = String(value ?? '').match(/^(\d{4})-Q([1-4])$/)
+  if (!matched) return value ?? '-'
+  return `${matched[1]}년 ${matched[2]}분기`
+}
+
+function buildQuarterPointTotals(pointHistory = []) {
+  const grouped = [...(pointHistory ?? [])]
+    .filter((item) => item?.date)
+    .sort((a, b) => String(a.date).localeCompare(String(b.date)))
+    .reduce((acc, item) => {
+      const key = getQuarterKey(item.date)
+      if (!key) return acc
+      acc[key] = (acc[key] ?? 0) + toNumber(item.points)
+      return acc
+    }, {})
+
+  return Object.entries(grouped)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, total]) => ({
+      key,
+      label: formatQuarterLabel(key),
+      total: roundToOne(total),
+    }))
+}
+
 function buildSkillGapViewModel(skillGap) {
   const currentSkills = skillGap.currentSkills ?? []
   const targetTier = skillGap.targetTier ?? 'S+'
@@ -300,7 +361,7 @@ export async function getWorkerProfileDashboard() {
     skills: skills.map(toSkillViewModel),
     milestones: tierHistory.map(toTierHistoryMilestone),
     chartData: tierChart.map((point) => ({
-      period: `${point.year ?? '-'}-${point.evalSequence ?? '-'}`,
+      period: formatPeriodLabel(point.year, point.evalSequence),
       value: Math.round(toNumber(point.totalScore)),
       tier: normalizeTier(point.tier),
     })),
@@ -550,45 +611,31 @@ function toEvalStatusViewModel(
   quantitative = null,
   qualitative = null,
   pointSummary = null,
+  pointHistory = [],
   profile = null,
   history = [],
   tierChart = [],
 ) {
-  const totalPoints = toNumber(pointSummary?.totalPoints)
   const tier = normalizeTier(profile?.currentTier ?? profile?.employeeTier ?? '-')
-  const quantitativeScore = roundToOne(quantitative?.tScore)
+  const quantitativeScore = roundToOne(quantitative?.sQuant)
   const qualitativeScore = roundToOne(qualitative?.score)
-  const compositeScore = roundToOne(profile?.totalScore)
+  const quarterTotals = buildQuarterPointTotals(pointHistory)
+  const overallScore = quarterTotals.length
+    ? quarterTotals[quarterTotals.length - 1].total
+    : roundToOne(pointSummary?.totalPoints ?? 0)
   const previousHistory = history.find((item) => item?.evalPeriodId !== status?.evalPeriodId) ?? null
-  const previousCompositePoint = [...(tierChart ?? [])]
-    .sort((a, b) => {
-      const yearDiff = toNumber(b?.year) - toNumber(a?.year)
-      if (yearDiff !== 0) return yearDiff
-      return toNumber(b?.evalSequence) - toNumber(a?.evalSequence)
-    })
-    .find((item) =>
-      !status?.evalYear ||
-      !status?.evalSequence ||
-      toNumber(item?.year) !== toNumber(status.evalYear) ||
-      toNumber(item?.evalSequence) !== toNumber(status.evalSequence),
-    )
 
   const quantitativeDiff = previousHistory ? roundToOne(quantitativeScore - toNumber(previousHistory.quantScore)) : 0
   const qualitativeDiff = previousHistory ? roundToOne(qualitativeScore - toNumber(previousHistory.score)) : 0
-  const compositeDiff = previousCompositePoint
-    ? roundToOne(compositeScore - toNumber(previousCompositePoint.totalScore))
-    : 0
 
   if (!status) {
     return {
       evalPeriodId: null,
       periodLabel: '-',
-      overallScore: totalPoints,
+      overallScore,
       tier,
       quantitative: { score: 0, diff: 0 },
-      qualitative: { score: 0, diff: 0, weight: 0.6 },
-      equipmentCorrection: { label: '-', sub: '-' },
-      composite: { score: 0, diff: 0, sub: '-' },
+      qualitative: { score: 0, diff: 0 },
       rank: '-',
       rankTotal: '-',
       rankDiff: 0,
@@ -597,15 +644,13 @@ function toEvalStatusViewModel(
 
   return {
     evalPeriodId: status.evalPeriodId,
-    periodLabel: status.evalYear ? `${status.evalYear}-Q${status.evalSequence}` : '-',
-    overallScore: totalPoints,
+    periodLabel: formatPeriodLabel(status.evalYear, status.evalSequence),
+    overallScore,
     tier,
     quantitative: { score: quantitativeScore, diff: quantitativeDiff },
-    qualitative: { score: qualitativeScore, diff: qualitativeDiff, weight: 0.6 },
-    equipmentCorrection: { label: '-', sub: '-' },
-    composite: { score: compositeScore, diff: compositeDiff, sub: '전분기 대비' },
-    rank: '-',
-    rankTotal: '-',
+    qualitative: { score: qualitativeScore, diff: qualitativeDiff },
+    rank: status.rank ?? '-',
+    rankTotal: status.rankTotal ?? '-',
     rankDiff: 0,
   }
 }
@@ -614,8 +659,6 @@ function toQuantitativeViewModel(quant) {
   if (!quant) {
     return {
       steps: [],
-      eidxChart: { title: '설비 가동 효율(E_idx) 추이', data: [], avg: '-', min: '-', max: '-' },
-      aiSummary: '정량 평가 데이터가 없습니다.',
     }
   }
 
@@ -629,8 +672,6 @@ function toQuantitativeViewModel(quant) {
 
   return {
     steps,
-    eidxChart: { title: '설비 가동 효율(E_idx) 추이', data: [], avg: '-', min: '-', max: '-' },
-    aiSummary: '정량 평가 데이터 분석 중입니다.',
   }
 }
 
@@ -638,12 +679,10 @@ function toQualitativeViewModel(qual) {
   if (!qual) {
     return {
       evaluator: '-',
-      evaluatorRole: 'Evaluator',
-      nlpConfidence: '0.00',
       grade: '-',
       score: 0,
       categories: [],
-      aiAnalysis: '정성 평가 데이터가 없습니다.',
+      evaluators: [],
     }
   }
 
@@ -663,102 +702,77 @@ function toQualitativeViewModel(qual) {
   }
 
   return {
-    evaluator: '-',
-    evaluatorRole: 'Evaluator',
-    nlpConfidence: '0.00',
+    evaluator: [
+      qual.firstEvaluatorName ? `1차. ${qual.firstEvaluatorName}` : null,
+      qual.secondEvaluatorName ? `2차. ${qual.secondEvaluatorName}` : null,
+    ].filter(Boolean).join(' / ') || '-',
+    evaluators: [
+      qual.firstEvaluatorName ? { label: '1차', name: qual.firstEvaluatorName } : null,
+      qual.secondEvaluatorName ? { label: '2차', name: qual.secondEvaluatorName } : null,
+    ].filter(Boolean),
     grade: qual.grade ?? '-',
     score: toNumber(qual.score),
     categories,
-    aiAnalysis: '정성 평가 의견을 분석 중입니다.',
   }
 }
 
-function buildGrowthChartData(tierChart = [], pointSummary = null, profile = null) {
-  const sortedPoints = [...(tierChart ?? [])]
-    .filter((item) => item?.year && item?.evalSequence)
-    .sort((a, b) => {
-      const yearDiff = toNumber(a.year) - toNumber(b.year)
-      if (yearDiff !== 0) return yearDiff
-      return toNumber(a.evalSequence) - toNumber(b.evalSequence)
+function buildPointGrowthChartData(pointHistory = [], pointSummary = null) {
+  const quarterTotals = buildQuarterPointTotals(pointHistory)
+  if (quarterTotals.length) {
+    let cumulative = 0
+    return quarterTotals.map((item) => {
+      cumulative += item.total
+      return {
+        label: item.label,
+        overall: roundToOne(cumulative),
+        team: null,
+        company: null,
+      }
     })
-    .map((item) => ({
-      label: `${item.year}.Q${item.evalSequence}`,
-      overall: roundToOne(item.totalScore),
-      team: null,
-    }))
-
-  if (sortedPoints.length) {
-    return sortedPoints
   }
 
-  const fallbackScore = roundToOne(profile?.totalScore || pointSummary?.totalPoints)
-  if (!fallbackScore) {
-    return []
-  }
+  const fallbackPoints = roundToOne(pointSummary?.totalPoints)
+  if (!fallbackPoints) return []
 
   return [
     {
       label: '현재',
-      overall: fallbackScore,
+      overall: fallbackPoints,
       team: null,
+      company: null,
     },
   ]
 }
 
-function toFeedbackViewModel(fb, growthTrend = [], tierChart = [], pointSummary = null, profile = null) {
-  const chartData = growthTrend.length
-    ? growthTrend.map((point) => ({
-      label: `${point.evalYear}.Q${point.evalSequence}`,
-      overall: roundToOne(point.myScore),
-      team: Number.isFinite(point.teamAverageScore) ? roundToOne(point.teamAverageScore) : null,
-      company: Number.isFinite(point.companyAverageScore) ? roundToOne(point.companyAverageScore) : null,
-    }))
-    : buildGrowthChartData(tierChart, pointSummary, profile)
-
-  if (!fb) {
-    return {
-      chartData,
-      feedback: {
-        content: '등록된 피드백이 없습니다.',
-        author: 'Team Leader',
-        date: '-',
-      },
-      nextQuarterGoals: [
-        { label: '생산성 향상', current: '-', target: '-' },
-        { label: '품질 관리', current: '-', target: '-' },
-      ],
-    }
-  }
-
-  const items = fb.feedbackItems || []
-  const tlFeedback = items.find(i => i.evaluationLevel === 1) || {}
+function toGrowthViewModel(pointHistory = [], pointSummary = null) {
+  const chartData = buildPointGrowthChartData(pointHistory, pointSummary)
+  const currentPoints = chartData.length
+    ? roundToOne(chartData[chartData.length - 1].overall)
+    : roundToOne(pointSummary?.totalPoints)
 
   return {
     chartData,
-    feedback: {
-      content: tlFeedback.evalComment ?? '등록된 피드백이 없습니다.',
-      author: 'Team Leader',
-      date: '-',
-    },
     nextQuarterGoals: [
-      { label: '생산성 향상', current: '-', target: '-' },
-      { label: '품질 관리', current: '-', target: '-' },
+      {
+        label: '이번 분기 포인트 목표',
+        current: currentPoints,
+        target: roundToOne(toNumber(currentPoints) + 5),
+      },
     ],
   }
 }
 
 export async function getWorkerEvaluationData(periodId = null) {
   const params = periodId ? { periodId } : {}
-  const [status, quantitative, qualitative, feedback, pointSummary, profile, history, tierChart, growthTrend] = await Promise.all([
+  const [status, quantitative, qualitative, pointSummary, pointHistory, profile, history, tierChart] = await Promise.all([
     optionalGet('/api/v1/hr/workers/me/evaluations/status', {}, null),
     optionalGet('/api/v1/hr/workers/me/evaluations/quantitative', { params }, null),
     optionalGet('/api/v1/hr/workers/me/evaluations/qualitative', { params }, null),
-    optionalGet('/api/v1/hr/workers/me/evaluations/feedback', { params }, null),
     optionalGet('/api/v1/hr/workers/me/point-summary', {}, null),
+    optionalGet('/api/v1/hr/workers/me/point-history', {}, []),
     optionalGet('/api/v1/hr/workers/me/profile', {}, null),
     optionalGet('/api/v1/hr/workers/me/evaluations/history', { params: { page: 0, size: 20 } }, null),
     optionalGet('/api/v1/hr/workers/me/tier-chart', {}, []),
-    optionalGet('/api/v1/hr/workers/me/evaluations/growth-trend', {}, []),
   ])
 
   const historyItems = history?.content?.map(toEvalHistoryViewModel) ?? []
@@ -769,12 +783,16 @@ export async function getWorkerEvaluationData(periodId = null) {
       quantitative,
       qualitative,
       pointSummary,
+      (pointHistory ?? []).map(toPointHistoryViewModel),
       profile,
       historyItems,
       tierChart ?? [],
     ),
     quantitative: toQuantitativeViewModel(quantitative),
     qualitative: toQualitativeViewModel(qualitative),
-    feedback: toFeedbackViewModel(feedback, growthTrend ?? [], tierChart ?? [], pointSummary, profile),
+    feedback: toGrowthViewModel(
+      (pointHistory ?? []).map(toPointHistoryViewModel),
+      pointSummary,
+    ),
   }
 }

--- a/src/utils/evaluationPeriod.js
+++ b/src/utils/evaluationPeriod.js
@@ -1,0 +1,29 @@
+function resolveYearAndMonth(evalYear) {
+  const raw = String(evalYear ?? '').trim()
+  if (!raw) return { year: null, month: null }
+
+  if (raw.length >= 6) {
+    return {
+      year: raw.slice(0, 4),
+      month: Number.parseInt(raw.slice(4, 6), 10) || null,
+    }
+  }
+
+  return {
+    year: raw,
+    month: null,
+  }
+}
+
+export function formatEvaluationPeriodLabel(
+  { evalYear, evalSequence } = {},
+  { fallback = '-' } = {},
+) {
+  if (evalYear == null || evalSequence == null) return fallback
+
+  const { year, month } = resolveYearAndMonth(evalYear)
+  if (year == null) return fallback
+
+  if (month == null) return `${year}년 ${evalSequence}차`
+  return `${year}년 ${month}월 ${evalSequence}차`
+}

--- a/src/views/departmentleader/DepartmentLeaderSecondEvaluationView.vue
+++ b/src/views/departmentleader/DepartmentLeaderSecondEvaluationView.vue
@@ -7,6 +7,7 @@ import ReviewerAppealListPanel from '@/components/hr/common/appeal/ReviewerAppea
 import DepartmentLeaderEvalMemberListPanel from '@/components/hr/departmentleader/second-evaluation/DepartmentLeaderEvalMemberListPanel.vue'
 import DepartmentLeaderEvalFormPanel from '@/components/hr/departmentleader/second-evaluation/DepartmentLeaderEvalFormPanel.vue'
 import { approveDlAppeal, fetchDlAppealDetail, fetchDlAppeals, fetchDlTargets, fetchDlEvaluationDetail, rejectDlAppeal, updateDlEvaluation } from '@/services/departmentleader/evaluationApi'
+import { formatEvaluationPeriodLabel } from '@/utils/evaluationPeriod'
 import { formatMemberMeta } from '@/utils/hrListFormat'
 import { mapStatus, statusToLabel } from '@/utils/evaluationStatus'
 
@@ -61,13 +62,10 @@ function formatScore(value) {
 }
 
 function formatPeriodText(evalYear, evalSequence) {
-  if (!evalYear) return '평가기간 미지정'
-  const raw = String(evalYear)
-  const year = raw.slice(0, 4)
-  const month = raw.length >= 6 ? String(parseInt(raw.slice(4), 10)) : null
-  return month
-    ? `${year}년 ${month}월 ${evalSequence}차`
-    : `${year}년 ${evalSequence}차`
+  return formatEvaluationPeriodLabel(
+    { evalYear, evalSequence },
+    { fallback: '평가기간 미지정' },
+  )
 }
 
 function mapAppealSummary(appeal) {
@@ -125,13 +123,8 @@ function mapAppealDetail(appeal) {
 
 const periodLabel = computed(() => {
   if (!periodInfo.value?.evalYear) return null
-  const raw = String(periodInfo.value.evalYear)
-  const year = raw.slice(0, 4)
-  const month = raw.length >= 6 ? String(parseInt(raw.slice(4), 10)) : null
-  const seq = periodInfo.value.evalSequence
-  return month
-    ? `${year}년 ${month}월 ${seq}차 평가`
-    : `${year}년 ${seq}차 평가`
+  const label = formatEvaluationPeriodLabel(periodInfo.value, { fallback: null })
+  return label ? `${label} 평가` : null
 })
 let toastTimer = null
 

--- a/src/views/hrmanager/HRMApprovalView.vue
+++ b/src/views/hrmanager/HRMApprovalView.vue
@@ -8,6 +8,7 @@ import HRMApprovalList from '@/components/hr/hrmanager/evaluation-approval/HRMAp
 import HRMApprovalDetail from '@/components/hr/hrmanager/evaluation-approval/HRMApprovalDetail.vue'
 import { BaseConfirmModal, BaseToast } from '@/components/common/base/overlay'
 import hrApprovalApi from '@/services/hrApprovalApi.js'
+import { formatEvaluationPeriodLabel } from '@/utils/evaluationPeriod'
 import { formatMemberMeta } from '@/utils/hrListFormat'
 
 function shortDate(dateStr) {
@@ -30,6 +31,11 @@ function formatDate(dateStr) {
   const date = new Date(dateStr)
   if (Number.isNaN(date.getTime())) return '-'
   return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, '0')}.${String(date.getDate()).padStart(2, '0')}`
+}
+
+function formatEvaluationPeriodChip(summary) {
+  const label = formatEvaluationPeriodLabel(summary, { fallback: '-' })
+  return label === '-' ? label : `${label} 평가`
 }
 
 function formatPercent(done, total) {
@@ -123,8 +129,8 @@ function defaultAppealDetail(summary) {
 }
 
 function formatAppealPeriod(evalYear, evalSequence) {
-  if (evalYear == null || evalSequence == null) return '-'
-  return `${evalYear}년 ${evalSequence}차 평가`
+  const label = formatEvaluationPeriodLabel({ evalYear, evalSequence }, { fallback: '-' })
+  return label === '-' ? label : `${label} 평가`
 }
 
 function defaultEvaluationDetail(summary) {
@@ -519,12 +525,34 @@ function showToast(message) {
   toastTimer = setTimeout(() => { toast.value.show = false }, 2500)
 }
 
-function handleApprove(comment = '') {
+async function handleApprove(comment = '') {
   if (!selectedItem.value) return
   const isEvaluation = approvalMode.value === 'evaluation'
   const isAppealFinalConfirm = approvalMode.value === 'appeal' && selectedItem.value.rawStatus === 'COMPLETED'
   confirmReason.value = ''
-  if (isEvaluation) evaluationConfirmComment.value = typeof comment === 'string' ? comment : (comment?.value ?? '')
+  if (isEvaluation) {
+    const evalComment = typeof comment === 'string' ? comment.trim() : (comment?.value ?? '').trim()
+
+    if (evalComment && evalComment.length < 20) {
+      showToast('최종 확정 코멘트는 입력 시 20자 이상이어야 합니다.')
+      return
+    }
+
+    try {
+      await hrApprovalApi.confirmEvaluation(selectedItem.value.evaluateeId, {
+        evaluationPeriodId: selectedItem.value.evaluationPeriodId,
+        evalComment,
+        inputMethod: selectedItem.value.detail.inputMethod ?? 'TEXT',
+      })
+      await loadEvaluations()
+      showToast(`${selectedItem.value.name}님의 평가가 최종 확정되었습니다.`)
+    } catch (e) {
+      console.error(e)
+      showToast('처리 중 오류가 발생했습니다.')
+    }
+    return
+  }
+
   confirmModal.value = {
     show: true,
     action: 'approve',
@@ -642,7 +670,7 @@ async function handleConfirm() {
           </div>
           <div class="hrm-approval__progress-side">
             <span class="hrm-approval__progress-period-chip">
-              {{ evaluationPeriodSummary?.evalYear ?? '-' }}년 {{ evaluationPeriodSummary?.evalSequence ?? '-' }}차 평가
+              {{ formatEvaluationPeriodChip(evaluationPeriodSummary) }}
             </span>
             <span class="hrm-approval__progress-range">
               {{ formatDate(evaluationPeriodSummary?.startDate) }} - {{ formatDate(evaluationPeriodSummary?.endDate) }}

--- a/src/views/hrmanager/HRMEvaluationPeriodView.vue
+++ b/src/views/hrmanager/HRMEvaluationPeriodView.vue
@@ -9,6 +9,7 @@ import {
   deleteEvaluationPeriod,
   fetchActiveAlgorithmVersionId,
 } from '@/services/hrmanager/evaluationPeriodApi'
+import { formatEvaluationPeriodLabel } from '@/utils/evaluationPeriod'
 
 // ── 상태 ──────────────────────────────────────────────
 const periods = ref([])
@@ -203,16 +204,8 @@ const inProgressCount = computed(() => periods.value.filter((p) => p.status === 
 const closingCount = computed(() => periods.value.filter((p) => p.status === 'CLOSING').length)
 const confirmedCount = computed(() => periods.value.filter((p) => p.status === 'CONFIRMED').length)
 
-function parsePeriodYear(evalYear) {
-  const s = String(evalYear)
-  if (s.length === 6) return { year: s.slice(0, 4), month: parseInt(s.slice(4, 6)) }
-  return { year: s, month: null }
-}
-
 function formatPeriodLabel(period) {
-  const { year, month } = parsePeriodYear(period.evalYear)
-  const monthStr = month ? ` ${month}월` : ''
-  return `${year}년${monthStr} ${period.evalSequence}차`
+  return formatEvaluationPeriodLabel(period, { fallback: '-' })
 }
 
 function formatDateRange(period) {

--- a/src/views/teamleader/TeamLeaderAiEvaluationView.vue
+++ b/src/views/teamleader/TeamLeaderAiEvaluationView.vue
@@ -7,6 +7,7 @@ import ReviewerAppealListPanel from '@/components/hr/common/appeal/ReviewerAppea
 import TeamLeaderAiEvaluationMemberListPanel from '@/components/hr/teamleader/qualitative-evaluation/TeamLeaderAiEvaluationMemberListPanel.vue'
 import TeamLeaderAiEvaluationPanel from '@/components/hr/teamleader/qualitative-evaluation/TeamLeaderAiEvaluationPanel.vue'
 import { approveTlAppeal, fetchTlAppealDetail, fetchTlAppeals, fetchTlTargets, rejectTlAppeal, updateTlEvaluation } from '@/services/teamleader/evaluationApi'
+import { formatEvaluationPeriodLabel } from '@/utils/evaluationPeriod'
 import { formatMemberMeta } from '@/utils/hrListFormat'
 import { mapStatus, statusToLabel } from '@/utils/evaluationStatus'
 
@@ -63,13 +64,10 @@ function formatScore(value) {
 }
 
 function formatPeriodText(evalYear, evalSequence) {
-  if (!evalYear) return '평가기간 미지정'
-  const raw = String(evalYear)
-  const year = raw.slice(0, 4)
-  const month = raw.length >= 6 ? String(parseInt(raw.slice(4), 10)) : null
-  return month
-    ? `${year}년 ${month}월 ${evalSequence}차`
-    : `${year}년 ${evalSequence}차`
+  return formatEvaluationPeriodLabel(
+    { evalYear, evalSequence },
+    { fallback: '평가기간 미지정' },
+  )
 }
 
 function mapAppealSummary(appeal) {
@@ -127,13 +125,8 @@ function mapAppealDetail(appeal) {
 
 const periodLabel = computed(() => {
   if (!periodInfo.value?.evalYear) return null
-  const raw = String(periodInfo.value.evalYear)
-  const year = raw.slice(0, 4)
-  const month = raw.length >= 6 ? String(parseInt(raw.slice(4), 10)) : null
-  const seq = periodInfo.value.evalSequence
-  return month
-    ? `${year}년 ${month}월 ${seq}차 평가`
-    : `${year}년 ${seq}차 평가`
+  const label = formatEvaluationPeriodLabel(periodInfo.value, { fallback: null })
+  return label ? `${label} 평가` : null
 })
 
 const selectedTargetId = ref('')

--- a/src/views/worker/WorkerAppealRequestView.vue
+++ b/src/views/worker/WorkerAppealRequestView.vue
@@ -4,6 +4,7 @@ import { getWorkerAppealRequestData, registerAppeal, uploadAppealAttachments } f
 import WorkerAppealNotification from '@/components/hr/worker/appeal-request/WorkerAppealNotification.vue'
 import WorkerAppealHistory from '@/components/hr/worker/appeal-request/WorkerAppealHistory.vue'
 import WorkerAppealForm from '@/components/hr/worker/appeal-request/WorkerAppealForm.vue'
+import { formatEvaluationPeriodLabel } from '@/utils/evaluationPeriod'
 
 const loading = ref(true)
 const evalHistory = ref([])
@@ -11,16 +12,7 @@ const appealForms = ref({}) // key: evaluationPeriodId
 const selectedId = ref(null) // qualitativeEvaluationId
 
 function formatPeriod(history) {
-  const raw = String(history?.evalYear ?? '')
-  if (raw.length === 6) {
-    const year = raw.slice(0, 4)
-    const month = Number(raw.slice(4, 6))
-    return `${year}년 ${month}월 ${history?.evalSequence ?? ''}차`
-  }
-  if (history?.evalYear && history?.evalSequence != null) {
-    return `${history.evalYear}년 ${history.evalSequence}차`
-  }
-  return '-'
+  return formatEvaluationPeriodLabel(history, { fallback: '-' })
 }
 
 onMounted(async () => {
@@ -172,7 +164,7 @@ async function handleSubmit(payload) {
   align-items: center;
   justify-content: center;
   min-height: 280px;
-  border: 1px dashed var(--color-border-default);
+  border: 1px solid var(--color-border-default);
   border-radius: var(--radius-card);
   background: var(--color-bg-surface);
   color: var(--color-text-muted);

--- a/src/views/worker/WorkerEvaluationResultView.vue
+++ b/src/views/worker/WorkerEvaluationResultView.vue
@@ -67,7 +67,7 @@ onMounted(async () => {
   align-items: center;
   justify-content: center;
   padding: 60px 0;
-  font-size: 15px;
+  font-size: var(--font-size-base-plus);
   color: var(--color-text-muted);
 }
 </style>


### PR DESCRIPTION
  ## 작업 내용
  - 내 평가 조회 화면 UI 정리
  - 정량 점수 기준 `sQuant`로 정리
  - 정성 평가자/항목별 내역 표시 방식 정리
  - 성장 추이/포인트 목표 영역 정리
  - 불필요한 표시(`설비보정`, `가중치`, `NLP 신뢰도`, 정량 토글 등) 제거
  - 평가기간 표기 공통 유틸 적용
  - HR 관련 화면 dashed border -> solid 정리
  - `point-history`가 없을 때 전체 누적 포인트를 분기 포인트처럼 보여주던 fallback 제거
  - 내 평가 조회에서 미사용 `periodId` 흐름 제거

  ## 확인 포인트
  - 내 평가 조회 상태 카드 값 정상 노출
  - 정량/정성 데이터 정상 노출
  - 분기 포인트 데이터 없을 때 빈 상태 정상 노출
  - 평가기간 표기 동일 규칙 적용