### PR TITLE
kms ui 수정

### DIFF
--- a/src/components/admin/kms/KmsFeed.vue
+++ b/src/components/admin/kms/KmsFeed.vue
@@ -14,9 +14,19 @@ const searchQuery = ref('')
 const currentPage = ref(1)
 const pageSize = 4
 const isComposing = ref(false)
+const defaultAuthor = Object.freeze({
+  name: '',
+  initial: '?',
+  color: '#5B4FCF',
+  tier: 'C',
+})
+
+const normalizedCards = computed(() =>
+  (props.articles ?? []).filter((card) => card && typeof card === 'object'),
+)
 
 const filteredCards = computed(() => {
-  let list = [...props.articles]
+  let list = [...normalizedCards.value]
 
   if (props.selectedFilter === 'popular') {
     list = list.filter((card) => card.isPopular)
@@ -47,7 +57,24 @@ const pagedCards = computed(() => {
   const start = (currentPage.value - 1) * pageSize
   return filteredCards.value.slice(start, start + pageSize)
 })
-const pageNumbers = computed(() => Array.from({ length: totalPages.value }, (_, index) => index + 1))
+const pageButtons = computed(() => {
+  const total = totalPages.value
+  const current = currentPage.value
+
+  if (total <= 7) {
+    return Array.from({ length: total }, (_, index) => index + 1)
+  }
+
+  if (current <= 4) {
+    return [1, 2, 3, 4, 5, '...', total]
+  }
+
+  if (current >= total - 3) {
+    return [1, '...', total - 4, total - 3, total - 2, total - 1, total]
+  }
+
+  return [1, '...', current - 1, current, current + 1, '...', total]
+})
 
 watch(() => [props.selectedFilter, searchQuery.value], () => {
   currentPage.value = 1
@@ -61,7 +88,17 @@ watch(filteredCards, (cards) => {
 })
 
 function setPage(page) {
-  currentPage.value = page
+  if (typeof page !== 'number' || Number.isNaN(page)) {
+    return
+  }
+  const lastPage = Math.max(totalPages.value, 1)
+  const nextPage = Math.min(Math.max(page, 1), lastPage)
+
+  if (nextPage === currentPage.value) {
+    return
+  }
+
+  currentPage.value = nextPage
 }
 
 function handleSearchInput(event) {
@@ -96,6 +133,37 @@ function categoryClass(category) {
     안전: 'card-tag--safety',
   }
   return map[category] || 'card-tag--default'
+}
+
+function authorOf(card) {
+  const author = card?.author
+  if (!author || typeof author !== 'object') {
+    return defaultAuthor
+  }
+
+  return {
+    name: author.name ?? '',
+    initial: author.initial ?? author.name?.[0] ?? '?',
+    color: author.color ?? '#5B4FCF',
+    tier: author.tier ?? 'C',
+  }
+}
+
+function tagsOf(card) {
+  return Array.isArray(card?.tags) ? card.tags : []
+}
+
+function tagStyle(tag) {
+  const palette = {
+    기술: { background: '#F3F0FF', color: '#5B4FCF' },
+    장비: { background: '#E8FFF8', color: '#0E9F6E' },
+    지식: { background: '#FFF6E5', color: '#B7791F' },
+  }
+
+  return palette[tag] ?? {
+    background: '#F5F7FA',
+    color: '#475467',
+  }
 }
 </script>
 
@@ -181,7 +249,7 @@ function categoryClass(category) {
             <span class="card-tag" :class="categoryClass(card.category)">{{ card.category }}</span>
             <span v-if="card.equipment" class="card-tag card-tag--equip">{{ card.equipment }}</span>
             <span
-              v-for="tag in card.tags"
+              v-for="tag in tagsOf(card)"
               :key="tag"
               class="card-tag"
               :style="tagStyle(tag)"
@@ -210,11 +278,11 @@ function categoryClass(category) {
         <!-- 카드 푸터 -->
         <div class="card-footer">
           <div class="author-info">
-            <div class="author-avatar" :style="{ background: card.author.color }">
-              {{ card.author.initial }}
+            <div class="author-avatar" :style="{ background: authorOf(card).color }">
+              {{ authorOf(card).initial }}
             </div>
-            <span class="author-name">{{ card.author.name }}</span>
-            <span class="author-tier" :class="tierClass(card.author.tier)">{{ card.author.tier }}</span>
+            <span class="author-name">{{ authorOf(card).name }}</span>
+            <span class="author-tier" :class="tierClass(authorOf(card).tier)">{{ authorOf(card).tier }}</span>
           </div>
           <div class="card-meta">
             <span class="meta-item">👁 {{ card.views }}</span>
@@ -248,15 +316,29 @@ function categoryClass(category) {
 
     <div v-if="filteredCards.length > 0" class="feed-pagination">
       <button
-        v-for="page in pageNumbers"
-        :key="page"
         type="button"
-        class="feed-page"
-        :class="{ 'feed-page--active': currentPage === page }"
-        @click="setPage(page)"
-      >
-        {{ page }}
-      </button>
+        class="feed-page feed-page--nav"
+        :disabled="currentPage <= 1"
+        @click="setPage(currentPage - 1)"
+      >&lt;</button>
+      <template v-for="(page, index) in pageButtons" :key="`${page}-${index}`">
+        <span v-if="page === '...'" class="feed-ellipsis">...</span>
+        <button
+          v-else
+          type="button"
+          class="feed-page"
+          :class="{ 'feed-page--active': currentPage === page }"
+          @click="setPage(page)"
+        >
+          {{ page }}
+        </button>
+      </template>
+      <button
+        type="button"
+        class="feed-page feed-page--nav"
+        :disabled="currentPage >= totalPages"
+        @click="setPage(currentPage + 1)"
+      >&gt;</button>
     </div>
 
   </div>
@@ -580,28 +662,44 @@ function categoryClass(category) {
 
 .feed-pagination {
   display: flex;
+  align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: 6px;
   padding-top: 4px;
   flex-shrink: 0;
 }
 
 .feed-page {
-  width: 36px;
-  height: 36px;
-  border-radius: 10px;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
   border: 1px solid var(--color-border-default);
   background: var(--color-bg-surface);
   color: var(--color-text-default);
-  font-size: var(--font-size-sm);
+  font-size: 11px;
   font-weight: var(--font-weight-bold);
   cursor: pointer;
+}
+
+.feed-page:disabled {
+  opacity: 0.45;
+  cursor: default;
 }
 
 .feed-page--active {
   border-color: var(--color-primary-700);
   background: var(--color-primary-700);
   color: var(--color-white);
+}
+
+.feed-ellipsis {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  color: var(--color-text-muted);
 }
 
 .feed-expand-enter-active,

--- a/src/components/admin/kms/KmsFeed.vue
+++ b/src/components/admin/kms/KmsFeed.vue
@@ -1,14 +1,15 @@
 <script setup>
-import { computed, ref, watch } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 const props = defineProps({
   categories:        { type: Array,  default: () => [] },
   articles:          { type: Array,  default: () => [] },
   selectedFilter:    { type: String, default: 'all' },
+  totalPages:        { type: Number, default: 1 },
   pageQueryReady:    { type: Boolean, default: false },
 })
-const emit = defineEmits(['filterChange', 'delete', 'restore', 'open-detail', 'toggle-bookmark'])
+const emit = defineEmits(['filterChange', 'delete', 'restore', 'open-detail', 'toggle-bookmark', 'query-change'])
 const showAllCategories = ref(false)
 const defaultVisibleCategoryCount = 3
 const searchInput = ref('')
@@ -28,39 +29,14 @@ const normalizedCards = computed(() =>
   (props.articles ?? []).filter((card) => card && typeof card === 'object'),
 )
 
-const filteredCards = computed(() => {
-  let list = [...normalizedCards.value]
-
-  if (props.selectedFilter === 'popular') {
-    list = list.filter((card) => card.isPopular)
-  } else if (props.selectedFilter === 'bookmarked') {
-    list = list.filter((card) => card.bookmarked)
-  } else if (props.selectedFilter !== 'all') {
-    list = list.filter((card) => card.category === props.selectedFilter)
-  }
-
-  const keyword = searchQuery.value.trim().toLowerCase()
-  if (!keyword) {
-    return list
-  }
-
-  return list.filter((card) =>
-    [card.title, card.summary, card.equipment, card.author?.name, ...(card.tags ?? [])]
-      .join(' ')
-      .toLowerCase()
-      .includes(keyword),
-  )
-})
+const filteredCards = computed(() => normalizedCards.value)
 
 const primaryCategories = computed(() => props.categories.slice(0, defaultVisibleCategoryCount))
 const hiddenCategories = computed(() => props.categories.slice(defaultVisibleCategoryCount))
 const hasHiddenCategories = computed(() => hiddenCategories.value.length > 0)
-const totalPages = computed(() => Math.max(1, Math.ceil(filteredCards.value.length / pageSize)))
+const totalPages = computed(() => Math.max(props.totalPages ?? 1, 1))
 const currentPage = computed(() => Math.min(normalizePageQuery(route.query.p), totalPages.value))
-const pagedCards = computed(() => {
-  const start = (currentPage.value - 1) * pageSize
-  return filteredCards.value.slice(start, start + pageSize)
-})
+const pagedCards = computed(() => filteredCards.value)
 const pageButtons = computed(() => {
   const total = totalPages.value
   const current = currentPage.value
@@ -112,18 +88,29 @@ watch(() => [props.selectedFilter, searchQuery.value], () => {
   syncPageQuery(1)
 })
 
-watch(filteredCards, (cards) => {
+watch(() => [props.selectedFilter, searchQuery.value, currentPage.value, props.pageQueryReady], () => {
   if (!props.pageQueryReady) {
     return
   }
 
-  const nextTotal = Math.max(1, Math.ceil(cards.length / pageSize))
-  const normalizedPage = normalizePageQuery(route.query.p)
+  emit('query-change', {
+    filterKey: props.selectedFilter,
+    keyword: searchQuery.value.trim(),
+    page: currentPage.value,
+    pageSize,
+  })
+}, { immediate: true })
 
-  if (normalizedPage > nextTotal) {
-    syncPageQuery(nextTotal)
+watch(() => [props.totalPages, props.pageQueryReady], () => {
+  if (!props.pageQueryReady) {
+    return
   }
-})
+
+  const normalizedPage = normalizePageQuery(route.query.p)
+  if (normalizedPage > totalPages.value) {
+    syncPageQuery(totalPages.value)
+  }
+}, { immediate: true })
 
 function setPage(page) {
   if (typeof page !== 'number' || Number.isNaN(page)) {
@@ -150,10 +137,11 @@ function handleCompositionStart() {
   isComposing.value = true
 }
 
-function handleCompositionEnd(event) {
+async function handleCompositionEnd(event) {
   isComposing.value = false
   searchInput.value = event.target.value
-  searchQuery.value = searchInput.value
+  await nextTick()
+  searchQuery.value = event.target.value
 }
 
 function tierClass(tier) {
@@ -347,12 +335,12 @@ function tagStyle(tag) {
 
       </div>
 
-      <div v-if="filteredCards.length === 0" class="feed-empty">
+      <div v-if="pagedCards.length === 0" class="feed-empty">
         해당 조건의 문서가 없습니다.
       </div>
     </div>
 
-    <div v-if="filteredCards.length > 0" class="feed-pagination">
+    <div v-if="pagedCards.length > 0" class="feed-pagination">
       <button
         type="button"
         class="feed-page feed-page--nav"

--- a/src/components/admin/kms/KmsFeed.vue
+++ b/src/components/admin/kms/KmsFeed.vue
@@ -5,38 +5,15 @@ const props = defineProps({
   categories:        { type: Array,  default: () => [] },
   articles:          { type: Array,  default: () => [] },
   selectedFilter:    { type: String, default: 'all' },
-  selectedTagFilter: { type: String, default: null },
-  tagFilters:        { type: Array,  default: () => [] },
 })
-const emit = defineEmits(['filterChange', 'tagFilterChange', 'delete', 'restore', 'open-detail', 'toggle-bookmark'])
+const emit = defineEmits(['filterChange', 'delete', 'restore', 'open-detail', 'toggle-bookmark'])
 const showAllCategories = ref(false)
 const defaultVisibleCategoryCount = 3
+const searchInput = ref('')
 const searchQuery = ref('')
 const currentPage = ref(1)
 const pageSize = 4
-
-const TAG_PALETTE = [
-  {
-    bg: 'var(--color-success-soft, #dcfce7)',
-    color: 'var(--color-success-text, #028a6b)',
-  },
-  {
-    bg: 'var(--color-primary-100, #efeaff)',
-    color: 'var(--color-primary-700, #5b4fcf)',
-  },
-  {
-    bg: 'var(--color-warning-soft, #fef3c7)',
-    color: 'var(--color-warning-text, #a07000)',
-  },
-  {
-    bg: 'var(--color-danger-bg, #ffecf1)',
-    color: 'var(--color-danger-text, #c0103e)',
-  },
-  {
-    bg: 'var(--color-bg-surface-muted, #f8f7ff)',
-    color: 'var(--color-text-muted, #7a6fa8)',
-  },
-]
+const isComposing = ref(false)
 
 const filteredCards = computed(() => {
   let list = [...props.articles]
@@ -47,12 +24,6 @@ const filteredCards = computed(() => {
     list = list.filter((card) => card.bookmarked)
   } else if (props.selectedFilter !== 'all') {
     list = list.filter((card) => card.category === props.selectedFilter)
-  }
-
-  if (props.selectedTagFilter) {
-    list = list.filter((card) =>
-      card.tags.some((t) => t === props.selectedTagFilter),
-    )
   }
 
   const keyword = searchQuery.value.trim().toLowerCase()
@@ -78,7 +49,7 @@ const pagedCards = computed(() => {
 })
 const pageNumbers = computed(() => Array.from({ length: totalPages.value }, (_, index) => index + 1))
 
-watch(() => [props.selectedFilter, props.selectedTagFilter, searchQuery.value], () => {
+watch(() => [props.selectedFilter, searchQuery.value], () => {
   currentPage.value = 1
 })
 
@@ -89,30 +60,25 @@ watch(filteredCards, (cards) => {
   }
 })
 
-function getPaletteIndex(tag) {
-  const value = String(tag ?? '')
-  let hash = 0
-  for (let index = 0; index < value.length; index += 1) {
-    hash = (hash * 31 + value.charCodeAt(index)) % TAG_PALETTE.length
-  }
-  return Math.abs(hash) % TAG_PALETTE.length
-}
-
-function getKmsTagStyle(tag) {
-  if (!tag) {
-    return TAG_PALETTE[0]
-  }
-  return TAG_PALETTE[getPaletteIndex(tag)]
-}
-
-function tagStyle(tag) {
-  const found = props.tagFilters.find((t) => t.key === tag)
-  if (found?.bg && found?.color) return { background: found.bg, color: found.color }
-  return getKmsTagStyle(tag)
-}
-
 function setPage(page) {
   currentPage.value = page
+}
+
+function handleSearchInput(event) {
+  searchInput.value = event.target.value
+  if (!isComposing.value) {
+    searchQuery.value = searchInput.value
+  }
+}
+
+function handleCompositionStart() {
+  isComposing.value = true
+}
+
+function handleCompositionEnd(event) {
+  isComposing.value = false
+  searchInput.value = event.target.value
+  searchQuery.value = searchInput.value
 }
 
 function tierClass(tier) {
@@ -141,27 +107,14 @@ function categoryClass(category) {
       </div>
     </div>
 
-    <!-- 필터 탭 + 태그 필터 (한 행) -->
-    <div class="filter-row">
-      <div class="feed-tabs-wrap">
-        <div class="feed-tabs-main">
-          <div class="feed-tabs">
-            <button
-              v-for="filter in primaryCategories"
-              :key="filter.key"
-              type="button"
-              class="feed-tab"
-              :class="{ 'feed-tab--active': selectedFilter === filter.key }"
-              @click="emit('filterChange', filter.key)"
-            >
-              {{ filter.label }}
-            </button>
-          </div>
-
-          <Transition name="feed-expand">
-            <div v-if="showAllCategories" class="feed-tabs feed-tabs--expanded">
+    <div class="feed-controls">
+      <!-- 필터 탭 -->
+      <div class="filter-row">
+        <div class="feed-tabs-wrap">
+          <div class="feed-tabs-main">
+            <div class="feed-tabs">
               <button
-                v-for="filter in hiddenCategories"
+                v-for="filter in primaryCategories"
                 :key="filter.key"
                 type="button"
                 class="feed-tab"
@@ -171,38 +124,44 @@ function categoryClass(category) {
                 {{ filter.label }}
               </button>
             </div>
-          </Transition>
+
+            <Transition name="feed-expand">
+              <div v-if="showAllCategories" class="feed-tabs feed-tabs--expanded">
+                <button
+                  v-for="filter in hiddenCategories"
+                  :key="filter.key"
+                  type="button"
+                  class="feed-tab"
+                  :class="{ 'feed-tab--active': selectedFilter === filter.key }"
+                  @click="emit('filterChange', filter.key)"
+                >
+                  {{ filter.label }}
+                </button>
+              </div>
+            </Transition>
+          </div>
+
+          <button
+            v-if="hasHiddenCategories"
+            type="button"
+            class="feed-more"
+            @click="showAllCategories = !showAllCategories"
+          >
+            {{ showAllCategories ? '접기' : '+ 더보기' }}
+          </button>
         </div>
-
-        <button
-          v-if="hasHiddenCategories"
-          type="button"
-          class="feed-more"
-          @click="showAllCategories = !showAllCategories"
-        >
-          {{ showAllCategories ? '접기' : '+ 더보기' }}
-        </button>
       </div>
-      <template v-if="props.tagFilters.length > 0">
-        <span
-          v-for="t in props.tagFilters"
-          :key="t.key"
-          class="tag-chip"
-          :style="selectedTagFilter === t.key
-            ? { background: 'var(--color-primary-800)', color: 'var(--color-text-inverse)' }
-            : { background: t.bg, color: t.color }
-          "
-          @click="emit('tagFilterChange', selectedTagFilter === t.key ? null : t.key)"
-        >{{ t.key }}</span>
-      </template>
-    </div>
 
-    <input
-      v-model="searchQuery"
-      class="feed-search"
-      type="text"
-      placeholder="지식 검색"
-    />
+      <input
+        :value="searchInput"
+        class="feed-search"
+        type="text"
+        placeholder="지식 검색"
+        @input="handleSearchInput"
+        @compositionstart="handleCompositionStart"
+        @compositionend="handleCompositionEnd"
+      />
+    </div>
 
     <!-- 지식 카드 목록 -->
     <div class="card-list">
@@ -312,7 +271,7 @@ function categoryClass(category) {
   background: var(--color-bg-surface);
   padding: 22px;
   display: grid;
-  grid-template-rows: auto auto minmax(0, 1fr);
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
   gap: 12px;
   font-family: var(--font-family-base);
   overflow: hidden;
@@ -332,12 +291,13 @@ function categoryClass(category) {
   color: var(--color-primary-300);
 }
 
-/* 필터 + 태그 한 행 */
+.feed-controls {
+  display: grid;
+  gap: 12px;
+}
+
 .filter-row {
-  display: flex;
-  align-items: flex-start;
-  gap: 8px;
-  flex-wrap: wrap;
+  display: block;
 }
 
 .feed-search {
@@ -410,18 +370,6 @@ function categoryClass(category) {
   white-space: nowrap;
   margin-left: auto;
   flex-shrink: 0;
-}
-
-.tag-chip {
-  height: 36px;
-  padding: 0 14px;
-  border-radius: 20px;
-  font-size: var(--font-size-xs-plus);
-  font-weight: var(--font-weight-bold);
-  display: flex;
-  align-items: center;
-  cursor: pointer;
-  transition: background 0.15s;
 }
 
 /* 지식 카드 */

--- a/src/components/admin/kms/KmsFeed.vue
+++ b/src/components/admin/kms/KmsFeed.vue
@@ -1,19 +1,22 @@
 <script setup>
 import { computed, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 
 const props = defineProps({
   categories:        { type: Array,  default: () => [] },
   articles:          { type: Array,  default: () => [] },
   selectedFilter:    { type: String, default: 'all' },
+  pageQueryReady:    { type: Boolean, default: false },
 })
 const emit = defineEmits(['filterChange', 'delete', 'restore', 'open-detail', 'toggle-bookmark'])
 const showAllCategories = ref(false)
 const defaultVisibleCategoryCount = 3
 const searchInput = ref('')
 const searchQuery = ref('')
-const currentPage = ref(1)
 const pageSize = 4
 const isComposing = ref(false)
+const route = useRoute()
+const router = useRouter()
 const defaultAuthor = Object.freeze({
   name: '',
   initial: '?',
@@ -53,6 +56,7 @@ const primaryCategories = computed(() => props.categories.slice(0, defaultVisibl
 const hiddenCategories = computed(() => props.categories.slice(defaultVisibleCategoryCount))
 const hasHiddenCategories = computed(() => hiddenCategories.value.length > 0)
 const totalPages = computed(() => Math.max(1, Math.ceil(filteredCards.value.length / pageSize)))
+const currentPage = computed(() => Math.min(normalizePageQuery(route.query.p), totalPages.value))
 const pagedCards = computed(() => {
   const start = (currentPage.value - 1) * pageSize
   return filteredCards.value.slice(start, start + pageSize)
@@ -76,14 +80,48 @@ const pageButtons = computed(() => {
   return [1, '...', current - 1, current, current + 1, '...', total]
 })
 
+function normalizePageQuery(value) {
+  const parsed = Number.parseInt(Array.isArray(value) ? value[0] : value, 10)
+  if (Number.isNaN(parsed) || parsed < 1) {
+    return 1
+  }
+  return parsed
+}
+
+function syncPageQuery(page) {
+  const normalizedPage = normalizePageQuery(page)
+  const nextQuery = { ...route.query }
+
+  if (normalizedPage <= 1) {
+    delete nextQuery.p
+  } else {
+    nextQuery.p = String(normalizedPage)
+  }
+
+  const currentQueryPage = Array.isArray(route.query.p) ? route.query.p[0] : route.query.p
+  const nextQueryPage = nextQuery.p
+
+  if ((currentQueryPage ?? undefined) === (nextQueryPage ?? undefined)) {
+    return
+  }
+
+  void router.replace({ query: nextQuery })
+}
+
 watch(() => [props.selectedFilter, searchQuery.value], () => {
-  currentPage.value = 1
+  syncPageQuery(1)
 })
 
 watch(filteredCards, (cards) => {
+  if (!props.pageQueryReady) {
+    return
+  }
+
   const nextTotal = Math.max(1, Math.ceil(cards.length / pageSize))
-  if (currentPage.value > nextTotal) {
-    currentPage.value = nextTotal
+  const normalizedPage = normalizePageQuery(route.query.p)
+
+  if (normalizedPage > nextTotal) {
+    syncPageQuery(nextTotal)
   }
 })
 
@@ -98,7 +136,7 @@ function setPage(page) {
     return
   }
 
-  currentPage.value = nextPage
+  syncPageQuery(nextPage)
 }
 
 function handleSearchInput(event) {

--- a/src/components/admin/kms/KmsFeed.vue
+++ b/src/components/admin/kms/KmsFeed.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 
 const props = defineProps({
   categories:        { type: Array,  default: () => [] },
@@ -11,6 +11,9 @@ const props = defineProps({
 const emit = defineEmits(['filterChange', 'tagFilterChange', 'delete', 'restore', 'open-detail', 'toggle-bookmark'])
 const showAllCategories = ref(false)
 const defaultVisibleCategoryCount = 3
+const searchQuery = ref('')
+const currentPage = ref(1)
+const pageSize = 4
 
 const TAG_PALETTE = [
   {
@@ -52,12 +55,39 @@ const filteredCards = computed(() => {
     )
   }
 
-  return list
+  const keyword = searchQuery.value.trim().toLowerCase()
+  if (!keyword) {
+    return list
+  }
+
+  return list.filter((card) =>
+    [card.title, card.summary, card.equipment, card.author?.name, ...(card.tags ?? [])]
+      .join(' ')
+      .toLowerCase()
+      .includes(keyword),
+  )
 })
 
 const primaryCategories = computed(() => props.categories.slice(0, defaultVisibleCategoryCount))
 const hiddenCategories = computed(() => props.categories.slice(defaultVisibleCategoryCount))
 const hasHiddenCategories = computed(() => hiddenCategories.value.length > 0)
+const totalPages = computed(() => Math.max(1, Math.ceil(filteredCards.value.length / pageSize)))
+const pagedCards = computed(() => {
+  const start = (currentPage.value - 1) * pageSize
+  return filteredCards.value.slice(start, start + pageSize)
+})
+const pageNumbers = computed(() => Array.from({ length: totalPages.value }, (_, index) => index + 1))
+
+watch(() => [props.selectedFilter, props.selectedTagFilter, searchQuery.value], () => {
+  currentPage.value = 1
+})
+
+watch(filteredCards, (cards) => {
+  const nextTotal = Math.max(1, Math.ceil(cards.length / pageSize))
+  if (currentPage.value > nextTotal) {
+    currentPage.value = nextTotal
+  }
+})
 
 function getPaletteIndex(tag) {
   const value = String(tag ?? '')
@@ -81,6 +111,10 @@ function tagStyle(tag) {
   return getKmsTagStyle(tag)
 }
 
+function setPage(page) {
+  currentPage.value = page
+}
+
 function tierClass(tier) {
   if (tier === 'S') return 'author-tier--s'
   if (tier === 'A') return 'author-tier--a'
@@ -101,6 +135,11 @@ function categoryClass(category) {
 
 <template>
   <div class="kms-feed">
+    <div class="kms-feed__top">
+      <div>
+        <p class="kms-feed__eyebrow">지식 허브</p>
+      </div>
+    </div>
 
     <!-- 필터 탭 + 태그 필터 (한 행) -->
     <div class="filter-row">
@@ -158,10 +197,17 @@ function categoryClass(category) {
       </template>
     </div>
 
+    <input
+      v-model="searchQuery"
+      class="feed-search"
+      type="text"
+      placeholder="지식 검색"
+    />
+
     <!-- 지식 카드 목록 -->
     <div class="card-list">
       <div
-        v-for="card in filteredCards"
+        v-for="card in pagedCards"
         :key="card.id"
         class="knowledge-card"
         :class="{ 'knowledge-card--deleted': card.isDeleted }"
@@ -241,15 +287,49 @@ function categoryClass(category) {
       </div>
     </div>
 
+    <div v-if="filteredCards.length > 0" class="feed-pagination">
+      <button
+        v-for="page in pageNumbers"
+        :key="page"
+        type="button"
+        class="feed-page"
+        :class="{ 'feed-page--active': currentPage === page }"
+        @click="setPage(page)"
+      >
+        {{ page }}
+      </button>
+    </div>
+
   </div>
 </template>
 
 <style scoped>
 .kms-feed {
-  display: flex;
-  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  border: 1px solid var(--color-border-default);
+  border-radius: 20px;
+  background: var(--color-bg-surface);
+  padding: 22px;
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr);
   gap: 12px;
   font-family: var(--font-family-base);
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+.kms-feed__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.kms-feed__eyebrow {
+  font-size: var(--font-size-xs-plus);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary-300);
 }
 
 /* 필터 + 태그 한 행 */
@@ -258,6 +338,16 @@ function categoryClass(category) {
   align-items: flex-start;
   gap: 8px;
   flex-wrap: wrap;
+}
+
+.feed-search {
+  height: 42px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 12px;
+  padding: 0 14px;
+  font-size: var(--font-size-base);
+  color: var(--color-text-default);
+  background: var(--color-bg-surface);
 }
 
 .feed-tabs-wrap {
@@ -293,10 +383,10 @@ function categoryClass(category) {
   padding: 0 14px;
   border-radius: 999px;
   border: 1px solid var(--color-border-default);
-  background: #fff;
+  background: var(--color-bg-surface);
   color: var(--color-text-default);
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   cursor: pointer;
   white-space: nowrap;
 }
@@ -312,10 +402,10 @@ function categoryClass(category) {
   padding: 0 14px;
   border-radius: 999px;
   border: 1px solid var(--color-border-default);
-  background: #fff;
+  background: var(--color-bg-surface);
   color: var(--color-text-muted);
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   cursor: pointer;
   white-space: nowrap;
   margin-left: auto;
@@ -326,8 +416,8 @@ function categoryClass(category) {
   height: 36px;
   padding: 0 14px;
   border-radius: 20px;
-  font-size: 12px;
-  font-weight: 700;
+  font-size: var(--font-size-xs-plus);
+  font-weight: var(--font-weight-bold);
   display: flex;
   align-items: center;
   cursor: pointer;
@@ -336,25 +426,29 @@ function categoryClass(category) {
 
 /* 지식 카드 */
 .card-list {
-  display: flex;
-  flex-direction: column;
+  display: grid;
   gap: 10px;
+  align-content: start;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 4px;
 }
 
 .knowledge-card {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  padding: 16px 18px;
-  background: var(--color-bg-surface, #ffffff);
-  border: 1.5px solid var(--color-border-default, #e0dcff);
-  border-radius: 12px;
+  display: grid;
+  gap: 8px;
+  padding: 14px 16px;
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-default);
+  border-radius: 16px;
   cursor: pointer;
-  transition: box-shadow 0.15s;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 .knowledge-card:hover {
-  box-shadow: 0 2px 12px rgba(45, 31, 110, 0.08);
+  border-color: var(--color-primary-300);
+  box-shadow: 0 12px 24px rgba(62, 42, 156, 0.08);
+  transform: translateY(-1px);
 }
 
 .knowledge-card--deleted {
@@ -382,10 +476,10 @@ function categoryClass(category) {
 }
 
 .card-tag {
-  font-size: 10px;
-  font-weight: 600;
-  padding: 2px 8px;
-  border-radius: 4px;
+  font-size: var(--font-size-2xs);
+  font-weight: var(--font-weight-semibold);
+  padding: 3px 8px;
+  border-radius: 999px;
 }
 
 .card-tag--deleted {
@@ -403,18 +497,18 @@ function categoryClass(category) {
 .card-tag--equip { background: #f4f4fb; color: var(--color-text-muted); }
 
 .card-date {
-  font-size: 10px;
-  color: var(--color-text-muted, #a89ed8);
+  font-size: var(--font-size-2xs);
+  color: var(--color-text-muted);
 }
 
 .btn-bookmark {
-  width: 24px;
-  height: 24px;
+  width: 28px;
+  height: 28px;
   border-radius: 50%;
   border: 1px solid var(--color-border-default);
-  background: #fff;
+  background: var(--color-bg-surface);
   color: var(--color-text-muted);
-  font-size: 12px;
+  font-size: 15px;
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -430,18 +524,18 @@ function categoryClass(category) {
 .card-body {
   display: flex;
   flex-direction: column;
-  gap: 5px;
+  gap: 6px;
 }
 
 .card-title {
-  font-size: 14px;
-  font-weight: 700;
-  color: var(--color-primary-800, #2d1f6e);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary-800);
 }
 
 .card-summary {
-  font-size: 12px;
-  color: var(--color-text-sub, #7a6fa8);
+  font-size: var(--font-size-xs-plus);
+  color: var(--color-text-muted);
   line-height: 1.5;
 }
 
@@ -456,32 +550,33 @@ function categoryClass(category) {
   display: flex;
   align-items: center;
   gap: 6px;
+  flex-wrap: wrap;
 }
 
 .author-avatar {
-  width: 24px;
-  height: 24px;
+  width: 26px;
+  height: 26px;
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 10px;
-  font-weight: 700;
+  font-size: 12px;
+  font-weight: var(--font-weight-bold);
   color: var(--color-text-inverse);
   flex-shrink: 0;
 }
 
 .author-name {
-  font-size: 11px;
-  font-weight: 600;
+  font-size: var(--font-size-xs-plus);
+  font-weight: var(--font-weight-bold);
   color: var(--color-primary-800);
 }
 
 .author-tier {
   padding: 2px 6px;
   border-radius: 8px;
-  font-size: 10px;
-  font-weight: 800;
+  font-size: var(--font-size-2xs);
+  font-weight: var(--font-weight-extrabold);
 }
 
 .author-tier--s { background: #00bf95; color: #fff; }
@@ -503,9 +598,9 @@ function categoryClass(category) {
   padding: 0 14px;
   border-radius: 8px;
   border: 1px solid var(--color-border-default);
-  background: #fff;
-  font-size: 12px;
-  font-weight: 700;
+  background: var(--color-bg-surface);
+  font-size: var(--font-size-xs-plus);
+  font-weight: var(--font-weight-bold);
   cursor: pointer;
 }
 
@@ -522,17 +617,43 @@ function categoryClass(category) {
 }
 
 .meta-item {
-  font-size: 11px;
-  color: var(--color-text-muted, #a89ed8);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
 }
 
 .feed-empty {
   padding: 40px;
   text-align: center;
   color: var(--color-text-muted);
-  font-size: 13px;
+  font-size: var(--font-size-sm);
   border: 1px dashed var(--color-border-default);
-  border-radius: 12px;
+  border-radius: 16px;
+}
+
+.feed-pagination {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  padding-top: 4px;
+  flex-shrink: 0;
+}
+
+.feed-page {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-surface);
+  color: var(--color-text-default);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+  cursor: pointer;
+}
+
+.feed-page--active {
+  border-color: var(--color-primary-700);
+  background: var(--color-primary-700);
+  color: var(--color-white);
 }
 
 .feed-expand-enter-active,
@@ -572,6 +693,15 @@ function categoryClass(category) {
   .feed-expand-enter-to,
   .feed-expand-leave-from {
     max-width: 100%;
+  }
+
+  .card-footer {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .card-actions {
+    margin-left: 0;
   }
 }
 </style>

--- a/src/components/kms/common/knowledge-hub/KnowledgeHubContributors.vue
+++ b/src/components/kms/common/knowledge-hub/KnowledgeHubContributors.vue
@@ -27,6 +27,7 @@ const topRanking = computed(() => props.ranking.slice(0, 3))
           </div>
         </div>
         <div class="contributors__right">
+          <p class="contributors__score">기여점수 {{ person.score ?? 0 }}점</p>
           <p>게시글 {{ person.articles }}건</p>
           <p>조회수 {{ person.views ?? 0 }}회</p>
         </div>
@@ -155,5 +156,10 @@ const topRanking = computed(() => props.ranking.slice(0, 3))
   color: var(--color-text-muted);
   text-align: right;
   white-space: nowrap;
+}
+
+.contributors__score {
+  color: var(--color-primary-700);
+  font-weight: 700;
 }
 </style>

--- a/src/components/kms/common/knowledge-hub/KnowledgeHubFeed.vue
+++ b/src/components/kms/common/knowledge-hub/KnowledgeHubFeed.vue
@@ -11,11 +11,13 @@ const emit = defineEmits(['open-write', 'open-detail', 'toggle-bookmark'])
 const authStore = useAuthStore()
 
 const activeCategory = ref('all')
+const searchInput = ref('')
 const searchQuery = ref('')
 const showAllCategories = ref(false)
 const currentPage = ref(1)
 const defaultVisibleCategoryCount = 3
 const pageSize = 4
+const isComposing = ref(false)
 const isWorker = computed(() => authStore.role() === 'worker')
 
 const primaryCategories = computed(() => props.categories.slice(0, defaultVisibleCategoryCount))
@@ -69,6 +71,23 @@ function setCategory(categoryKey) {
 
 function setPage(page) {
   currentPage.value = page
+}
+
+function handleSearchInput(event) {
+  searchInput.value = event.target.value
+  if (!isComposing.value) {
+    searchQuery.value = searchInput.value
+  }
+}
+
+function handleCompositionStart() {
+  isComposing.value = true
+}
+
+function handleCompositionEnd(event) {
+  isComposing.value = false
+  searchInput.value = event.target.value
+  searchQuery.value = searchInput.value
 }
 
 function tierClass(tier) {
@@ -140,7 +159,15 @@ function categoryClass(category) {
         </button>
       </div>
 
-      <input v-model="searchQuery" class="feed__search" type="text" placeholder="지식 검색" />
+      <input
+        :value="searchInput"
+        class="feed__search"
+        type="text"
+        placeholder="지식 검색"
+        @input="handleSearchInput"
+        @compositionstart="handleCompositionStart"
+        @compositionend="handleCompositionEnd"
+      />
     </div>
 
     <div class="feed__list">

--- a/src/components/kms/common/knowledge-hub/KnowledgeHubFeed.vue
+++ b/src/components/kms/common/knowledge-hub/KnowledgeHubFeed.vue
@@ -1,15 +1,16 @@
 ﻿<script setup>
-import { computed, ref, watch } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 
 const props = defineProps({
   categories: { type: Array, default: () => [] },
   articles: { type: Array, default: () => [] },
+  totalPages: { type: Number, default: 1 },
   pageQueryReady: { type: Boolean, default: false },
 })
 
-const emit = defineEmits(['open-write', 'open-detail', 'toggle-bookmark'])
+const emit = defineEmits(['open-write', 'open-detail', 'toggle-bookmark', 'query-change'])
 const authStore = useAuthStore()
 
 const activeCategory = ref('all')
@@ -27,34 +28,10 @@ const primaryCategories = computed(() => props.categories.slice(0, defaultVisibl
 const hiddenCategories = computed(() => props.categories.slice(defaultVisibleCategoryCount))
 const hasHiddenCategories = computed(() => hiddenCategories.value.length > 0)
 
-const filteredArticles = computed(() => {
-  let result = props.articles
-
-  if (activeCategory.value === 'popular') {
-    result = result.filter((item) => item.isPopular)
-  } else if (activeCategory.value === 'latest') {
-    result = [...result].sort((a, b) => b.id - a.id)
-  } else if (activeCategory.value === 'bookmarked') {
-    result = result.filter((item) => item.isBookmarked)
-  } else if (activeCategory.value !== 'all') {
-    result = result.filter((item) => item.category === activeCategory.value)
-  }
-
-  const keyword = searchQuery.value.trim().toLowerCase()
-  if (!keyword) {
-    return result
-  }
-
-  return result.filter((item) => [item.title, item.preview, item.code, item.equipment].join(' ').toLowerCase().includes(keyword))
-})
-
-const totalPages = computed(() => Math.max(1, Math.ceil(filteredArticles.value.length / pageSize)))
+const filteredArticles = computed(() => props.articles ?? [])
+const totalPages = computed(() => Math.max(props.totalPages ?? 1, 1))
 const currentPage = computed(() => Math.min(normalizePageQuery(route.query.p), totalPages.value))
-
-const pagedArticles = computed(() => {
-  const start = (currentPage.value - 1) * pageSize
-  return filteredArticles.value.slice(start, start + pageSize)
-})
+const pagedArticles = computed(() => filteredArticles.value)
 
 const pageButtons = computed(() => {
   const total = totalPages.value
@@ -107,18 +84,29 @@ watch([activeCategory, searchQuery], () => {
   syncPageQuery(1)
 })
 
-watch(filteredArticles, (articles) => {
+watch([activeCategory, searchQuery, currentPage, () => props.pageQueryReady], () => {
   if (!props.pageQueryReady) {
     return
   }
 
-  const nextTotal = Math.max(1, Math.ceil(articles.length / pageSize))
-  const normalizedPage = normalizePageQuery(route.query.p)
+  emit('query-change', {
+    categoryKey: activeCategory.value,
+    keyword: searchQuery.value.trim(),
+    page: currentPage.value,
+    pageSize,
+  })
+}, { immediate: true })
 
-  if (normalizedPage > nextTotal) {
-    syncPageQuery(nextTotal)
+watch(() => [props.totalPages, props.pageQueryReady], () => {
+  if (!props.pageQueryReady) {
+    return
   }
-})
+
+  const normalizedPage = normalizePageQuery(route.query.p)
+  if (normalizedPage > totalPages.value) {
+    syncPageQuery(totalPages.value)
+  }
+}, { immediate: true })
 
 function setCategory(categoryKey) {
   activeCategory.value = categoryKey
@@ -149,10 +137,11 @@ function handleCompositionStart() {
   isComposing.value = true
 }
 
-function handleCompositionEnd(event) {
+async function handleCompositionEnd(event) {
   isComposing.value = false
   searchInput.value = event.target.value
-  searchQuery.value = searchInput.value
+  await nextTick()
+  searchQuery.value = event.target.value
 }
 
 function tierClass(tier) {
@@ -278,10 +267,10 @@ function categoryClass(category) {
         </div>
       </article>
 
-      <div v-if="filteredArticles.length === 0" class="feed__empty">조건에 맞는 문서가 없습니다.</div>
+      <div v-if="pagedArticles.length === 0" class="feed__empty">조건에 맞는 문서가 없습니다.</div>
     </div>
 
-    <div v-if="filteredArticles.length > 0" class="feed__pagination">
+    <div v-if="pagedArticles.length > 0" class="feed__pagination">
       <button
         type="button"
         class="feed__page feed__page--nav"

--- a/src/components/kms/common/knowledge-hub/KnowledgeHubFeed.vue
+++ b/src/components/kms/common/knowledge-hub/KnowledgeHubFeed.vue
@@ -52,7 +52,24 @@ const pagedArticles = computed(() => {
   return filteredArticles.value.slice(start, start + pageSize)
 })
 
-const pageNumbers = computed(() => Array.from({ length: totalPages.value }, (_, index) => index + 1))
+const pageButtons = computed(() => {
+  const total = totalPages.value
+  const current = currentPage.value
+
+  if (total <= 7) {
+    return Array.from({ length: total }, (_, index) => index + 1)
+  }
+
+  if (current <= 4) {
+    return [1, 2, 3, 4, 5, '...', total]
+  }
+
+  if (current >= total - 3) {
+    return [1, '...', total - 4, total - 3, total - 2, total - 1, total]
+  }
+
+  return [1, '...', current - 1, current, current + 1, '...', total]
+})
 
 watch([activeCategory, searchQuery], () => {
   currentPage.value = 1
@@ -70,7 +87,17 @@ function setCategory(categoryKey) {
 }
 
 function setPage(page) {
-  currentPage.value = page
+  if (typeof page !== 'number' || Number.isNaN(page)) {
+    return
+  }
+  const lastPage = Math.max(totalPages.value, 1)
+  const nextPage = Math.min(Math.max(page, 1), lastPage)
+
+  if (nextPage === currentPage.value) {
+    return
+  }
+
+  currentPage.value = nextPage
 }
 
 function handleSearchInput(event) {
@@ -218,15 +245,29 @@ function categoryClass(category) {
 
     <div v-if="filteredArticles.length > 0" class="feed__pagination">
       <button
-        v-for="page in pageNumbers"
-        :key="page"
         type="button"
-        class="feed__page"
-        :class="{ 'feed__page--active': currentPage === page }"
-        @click="setPage(page)"
-      >
-        {{ page }}
-      </button>
+        class="feed__page feed__page--nav"
+        :disabled="currentPage <= 1"
+        @click="setPage(currentPage - 1)"
+      >&lt;</button>
+      <template v-for="(page, index) in pageButtons" :key="`${page}-${index}`">
+        <span v-if="page === '...'" class="feed__ellipsis">...</span>
+        <button
+          v-else
+          type="button"
+          class="feed__page"
+          :class="{ 'feed__page--active': currentPage === page }"
+          @click="setPage(page)"
+        >
+          {{ page }}
+        </button>
+      </template>
+      <button
+        type="button"
+        class="feed__page feed__page--nav"
+        :disabled="currentPage >= totalPages"
+        @click="setPage(currentPage + 1)"
+      >&gt;</button>
     </div>
   </section>
 </template>
@@ -491,28 +532,44 @@ function categoryClass(category) {
 
 .feed__pagination {
   display: flex;
+  align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: 6px;
   padding-top: 4px;
   flex-shrink: 0;
 }
 
 .feed__page {
-  width: 36px;
-  height: 36px;
-  border-radius: 10px;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
   border: 1px solid var(--color-border-default);
   background: #fff;
   color: var(--color-text-default);
-  font-size: 13px;
+  font-size: 11px;
   font-weight: 700;
   cursor: pointer;
+}
+
+.feed__page:disabled {
+  opacity: 0.45;
+  cursor: default;
 }
 
 .feed__page--active {
   border-color: var(--color-primary-700);
   background: var(--color-primary-700);
   color: #fff;
+}
+
+.feed__ellipsis {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  color: var(--color-text-muted);
 }
 
 .feed-expand-enter-active,

--- a/src/components/kms/common/knowledge-hub/KnowledgeHubFeed.vue
+++ b/src/components/kms/common/knowledge-hub/KnowledgeHubFeed.vue
@@ -1,10 +1,12 @@
 ﻿<script setup>
 import { computed, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 
 const props = defineProps({
   categories: { type: Array, default: () => [] },
   articles: { type: Array, default: () => [] },
+  pageQueryReady: { type: Boolean, default: false },
 })
 
 const emit = defineEmits(['open-write', 'open-detail', 'toggle-bookmark'])
@@ -14,11 +16,12 @@ const activeCategory = ref('all')
 const searchInput = ref('')
 const searchQuery = ref('')
 const showAllCategories = ref(false)
-const currentPage = ref(1)
 const defaultVisibleCategoryCount = 3
 const pageSize = 4
 const isComposing = ref(false)
 const isWorker = computed(() => authStore.role() === 'worker')
+const route = useRoute()
+const router = useRouter()
 
 const primaryCategories = computed(() => props.categories.slice(0, defaultVisibleCategoryCount))
 const hiddenCategories = computed(() => props.categories.slice(defaultVisibleCategoryCount))
@@ -46,6 +49,7 @@ const filteredArticles = computed(() => {
 })
 
 const totalPages = computed(() => Math.max(1, Math.ceil(filteredArticles.value.length / pageSize)))
+const currentPage = computed(() => Math.min(normalizePageQuery(route.query.p), totalPages.value))
 
 const pagedArticles = computed(() => {
   const start = (currentPage.value - 1) * pageSize
@@ -71,14 +75,48 @@ const pageButtons = computed(() => {
   return [1, '...', current - 1, current, current + 1, '...', total]
 })
 
+function normalizePageQuery(value) {
+  const parsed = Number.parseInt(Array.isArray(value) ? value[0] : value, 10)
+  if (Number.isNaN(parsed) || parsed < 1) {
+    return 1
+  }
+  return parsed
+}
+
+function syncPageQuery(page) {
+  const normalizedPage = normalizePageQuery(page)
+  const nextQuery = { ...route.query }
+
+  if (normalizedPage <= 1) {
+    delete nextQuery.p
+  } else {
+    nextQuery.p = String(normalizedPage)
+  }
+
+  const currentQueryPage = Array.isArray(route.query.p) ? route.query.p[0] : route.query.p
+  const nextQueryPage = nextQuery.p
+
+  if ((currentQueryPage ?? undefined) === (nextQueryPage ?? undefined)) {
+    return
+  }
+
+  void router.replace({ query: nextQuery })
+}
+
 watch([activeCategory, searchQuery], () => {
-  currentPage.value = 1
+  syncPageQuery(1)
 })
 
 watch(filteredArticles, (articles) => {
+  if (!props.pageQueryReady) {
+    return
+  }
+
   const nextTotal = Math.max(1, Math.ceil(articles.length / pageSize))
-  if (currentPage.value > nextTotal) {
-    currentPage.value = nextTotal
+  const normalizedPage = normalizePageQuery(route.query.p)
+
+  if (normalizedPage > nextTotal) {
+    syncPageQuery(nextTotal)
   }
 })
 
@@ -97,7 +135,7 @@ function setPage(page) {
     return
   }
 
-  currentPage.value = nextPage
+  syncPageQuery(nextPage)
 }
 
 function handleSearchInput(event) {

--- a/src/components/kms/teamleader/knowledge-approval/TeamLeaderKnowledgeApprovalQueue.vue
+++ b/src/components/kms/teamleader/knowledge-approval/TeamLeaderKnowledgeApprovalQueue.vue
@@ -1,5 +1,7 @@
-﻿<script setup>
-import { computed, ref, watch } from 'vue'
+<script setup>
+import { computed, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
 const props = defineProps({
   items: {
     type: Array,
@@ -12,27 +14,87 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['select-item'])
-const currentPage = ref(1)
 const pageSize = 5
+const route = useRoute()
+const router = useRouter()
 
 const totalPages = computed(() => Math.max(1, Math.ceil(props.items.length / pageSize)))
-const pageNumbers = computed(() => Array.from({ length: totalPages.value }, (_, index) => index + 1))
+const currentPage = computed(() => Math.min(normalizePageQuery(route.query.p), totalPages.value))
+const pageButtons = computed(() => {
+  const total = totalPages.value
+  const current = currentPage.value
+
+  if (total <= 7) {
+    return Array.from({ length: total }, (_, index) => index + 1)
+  }
+
+  if (current <= 4) {
+    return [1, 2, 3, 4, 5, '...', total]
+  }
+
+  if (current >= total - 3) {
+    return [1, '...', total - 4, total - 3, total - 2, total - 1, total]
+  }
+
+  return [1, '...', current - 1, current, current + 1, '...', total]
+})
 
 const pagedItems = computed(() => {
   const start = (currentPage.value - 1) * pageSize
   return props.items.slice(start, start + pageSize)
 })
 
-watch(() => props.items.length, () => {
-  if (currentPage.value > totalPages.value) {
-    currentPage.value = totalPages.value
+function normalizePageQuery(value) {
+  const parsed = Number.parseInt(Array.isArray(value) ? value[0] : value, 10)
+  if (Number.isNaN(parsed) || parsed < 1) {
+    return 1
   }
-})
-
-function setPage(page) {
-  currentPage.value = page
+  return parsed
 }
 
+function syncPageQuery(page) {
+  const normalizedPage = normalizePageQuery(page)
+  const nextQuery = { ...route.query }
+
+  if (normalizedPage <= 1) {
+    delete nextQuery.p
+  } else {
+    nextQuery.p = String(normalizedPage)
+  }
+
+  const currentQueryPage = Array.isArray(route.query.p) ? route.query.p[0] : route.query.p
+  const nextQueryPage = nextQuery.p
+
+  if ((currentQueryPage ?? undefined) === (nextQueryPage ?? undefined)) {
+    return
+  }
+
+  void router.replace({ query: nextQuery })
+}
+
+watch(() => props.items.length, () => {
+  if (props.items.length === 0) {
+    return
+  }
+
+  const normalizedPage = normalizePageQuery(route.query.p)
+  if (normalizedPage > totalPages.value) {
+    syncPageQuery(totalPages.value)
+  }
+}, { immediate: true })
+
+function setPage(page) {
+  if (typeof page !== 'number' || Number.isNaN(page)) {
+    return
+  }
+
+  const nextPage = Math.min(Math.max(page, 1), totalPages.value)
+  if (nextPage === currentPage.value) {
+    return
+  }
+
+  syncPageQuery(nextPage)
+}
 </script>
 
 <template>
@@ -67,14 +129,32 @@ function setPage(page) {
 
     <div v-if="items.length > 0" class="queue__pagination">
       <button
-        v-for="page in pageNumbers"
-        :key="page"
         type="button"
-        class="queue__page"
-        :class="{ 'queue__page--active': currentPage === page }"
-        @click="setPage(page)"
+        class="queue__page queue__page--nav"
+        :disabled="currentPage <= 1"
+        @click="setPage(currentPage - 1)"
       >
-        {{ page }}
+        &lt;
+      </button>
+      <template v-for="(page, index) in pageButtons" :key="`${page}-${index}`">
+        <span v-if="page === '...'" class="queue__ellipsis">...</span>
+        <button
+          v-else
+          type="button"
+          class="queue__page"
+          :class="{ 'queue__page--active': currentPage === page }"
+          @click="setPage(page)"
+        >
+          {{ page }}
+        </button>
+      </template>
+      <button
+        type="button"
+        class="queue__page queue__page--nav"
+        :disabled="currentPage >= totalPages"
+        @click="setPage(currentPage + 1)"
+      >
+        &gt;
       </button>
     </div>
   </section>
@@ -201,6 +281,7 @@ function setPage(page) {
 .queue__pagination {
   display: flex;
   justify-content: center;
+  align-items: center;
   gap: 8px;
   padding-top: 4px;
   flex-shrink: 0;
@@ -218,10 +299,25 @@ function setPage(page) {
   cursor: pointer;
 }
 
+.queue__page:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
 .queue__page--active {
   border-color: var(--color-primary-700);
   background: var(--color-primary-700);
   color: #fff;
 }
-</style>
 
+.queue__ellipsis {
+  width: 34px;
+  height: 34px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+}
+</style>

--- a/src/components/kms/teamleader/knowledge-approval/TeamLeaderKnowledgeApprovalReviewPanel.vue
+++ b/src/components/kms/teamleader/knowledge-approval/TeamLeaderKnowledgeApprovalReviewPanel.vue
@@ -45,7 +45,6 @@ const emit = defineEmits(['update:review-note', 'approve', 'hold', 'reject'])
             <strong>{{ item.author }}</strong>
             <span class="review__tier">{{ item.authorTier }}</span>
           </div>
-          <p>{{ item.line }} · 경력 {{ item.workCount }}건</p>
         </div>
       </div>
 
@@ -144,7 +143,6 @@ const emit = defineEmits(['update:review-note', 'approve', 'hold', 'reject'])
 }
 
 .review__date,
-.review__author p,
 .review__attachment {
   font-size: 12px;
   color: var(--color-text-muted);
@@ -170,15 +168,15 @@ const emit = defineEmits(['update:review-note', 'approve', 'hold', 'reject'])
 
 .review__author strong,
 .review__article-card h3 {
-  font-size: 15px;
+  font-size: 18px;
   color: var(--color-primary-800);
 }
 
 .review__tier,
 .review__badge {
-  padding: 4px 10px;
+  padding: 5px 12px;
   border-radius: 999px;
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 800;
 }
 

--- a/src/components/kms/worker/my-knowledge-management/WorkerKnowledgeAddModal.vue
+++ b/src/components/kms/worker/my-knowledge-management/WorkerKnowledgeAddModal.vue
@@ -24,6 +24,7 @@ const equipmentLoadFailed = ref(false)
 const {
   isRecording,
   speechMessage,
+  speechTone,
   supportsSpeechRecognition,
   toggleVoiceInput,
 } = useSpeechRecognition({
@@ -148,7 +149,7 @@ function handleSaveDraft() {
               {{ isRecording ? '음성 입력 종료' : '음성으로 작성' }}
             </button>
           </div>
-          <p class="ka__hint">{{ speechMessage }}</p>
+          <p class="ka__hint" :class="`ka__hint--${speechTone}`">{{ speechMessage }}</p>
           <textarea
             v-model="content"
             class="ka__textarea ka__textarea--lg"
@@ -265,8 +266,23 @@ function handleSaveDraft() {
 
 .ka__hint {
   font-size: var(--font-size-xs-plus);
-  color: var(--color-text-muted);
   margin: 0;
+}
+
+.ka__hint--idle {
+  color: var(--color-text-muted);
+}
+
+.ka__hint--active {
+  color: var(--color-primary-700);
+}
+
+.ka__hint--ended {
+  color: var(--color-success);
+}
+
+.ka__hint--error {
+  color: var(--color-danger);
 }
 
 .ka__error {

--- a/src/components/kms/worker/my-knowledge-management/WorkerKnowledgeAddModal.vue
+++ b/src/components/kms/worker/my-knowledge-management/WorkerKnowledgeAddModal.vue
@@ -1,8 +1,9 @@
 <script setup>
-import { ref, onMounted } from 'vue'
+import { onMounted, ref } from 'vue'
 import { BaseFormModal } from '@/components/common/base'
 import { ARTICLE_CATEGORY_OPTIONS } from '@/constants'
 import knowledgeArticleApi from '@/services/knowledgeArticleApi'
+import { useSpeechRecognition } from '@/utils/useSpeechRecognition'
 
 const emit = defineEmits(['close', 'submit', 'saveDraft'])
 const props = defineProps({
@@ -20,6 +21,17 @@ const content     = ref('')
 const equipmentList = ref([])
 const errorMessage = ref('')
 const equipmentLoadFailed = ref(false)
+const {
+  isRecording,
+  speechMessage,
+  supportsSpeechRecognition,
+  toggleVoiceInput,
+} = useSpeechRecognition({
+  getText: () => content.value,
+  setText: (value) => {
+    content.value = value
+  },
+})
 
 onMounted(async () => {
   try {
@@ -126,9 +138,17 @@ function handleSaveDraft() {
         <div class="ka__field">
           <div class="ka__label-row">
             <label class="ka__label">본문</label>
-            <button class="ka__voice-btn" type="button" :disabled="submitting">음성으로 작성</button>
+            <button
+              class="ka__voice-btn"
+              :class="{ 'ka__voice-btn--active': isRecording }"
+              type="button"
+              :disabled="submitting || !supportsSpeechRecognition"
+              @click="toggleVoiceInput"
+            >
+              {{ isRecording ? '음성 입력 종료' : '음성으로 작성' }}
+            </button>
           </div>
-          <p class="ka__hint">음성 인식으로 본문을 빠르게 작성할 수 있습니다.</p>
+          <p class="ka__hint">{{ speechMessage }}</p>
           <textarea
             v-model="content"
             class="ka__textarea ka__textarea--lg"
@@ -162,8 +182,8 @@ function handleSaveDraft() {
 }
 
 .ka__label {
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--color-text-strong);
 }
 
@@ -178,7 +198,7 @@ function handleSaveDraft() {
   padding: 10px 14px;
   border: 1px solid var(--color-border-default);
   border-radius: var(--radius-sm);
-  font-size: 14px;
+  font-size: var(--font-size-base);
   color: var(--color-text-default);
   background: var(--color-bg-surface);
   outline: none;
@@ -199,7 +219,7 @@ function handleSaveDraft() {
   padding: 12px 14px;
   border: 1px solid var(--color-border-default);
   border-radius: var(--radius-sm);
-  font-size: 14px;
+  font-size: var(--font-size-base);
   color: var(--color-text-default);
   resize: none;
   outline: none;
@@ -216,12 +236,13 @@ function handleSaveDraft() {
 }
 
 .ka__voice-btn {
-  padding: 5px 14px;
+  min-width: 108px;
+  padding: 7px 14px;
   border: 1px solid var(--color-primary-300);
   border-radius: var(--radius-xs);
   background: var(--color-bg-surface);
-  font-size: 12px;
-  font-weight: 600;
+  font-size: var(--font-size-xs-plus);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-primary-700);
   cursor: pointer;
   transition: all 0.15s;
@@ -231,15 +252,26 @@ function handleSaveDraft() {
   background: var(--color-primary-100);
 }
 
+.ka__voice-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.ka__voice-btn--active {
+  border-color: var(--color-primary-600);
+  background: var(--color-primary-100);
+  color: var(--color-primary-800);
+}
+
 .ka__hint {
-  font-size: 12px;
+  font-size: var(--font-size-xs-plus);
   color: var(--color-text-muted);
   margin: 0;
 }
 
 .ka__error {
   margin: 0;
-  font-size: 12px;
+  font-size: var(--font-size-xs-plus);
   color: var(--color-danger);
 }
 </style>

--- a/src/components/kms/worker/my-knowledge-management/WorkerKnowledgeDetailModal.vue
+++ b/src/components/kms/worker/my-knowledge-management/WorkerKnowledgeDetailModal.vue
@@ -6,7 +6,7 @@ defineProps({
   article: { type: Object, required: true },
 })
 
-const emit = defineEmits(['close', 'delete', 'restore'])
+const emit = defineEmits(['close', 'edit', 'delete', 'restore'])
 
 function statusClass(status) {
   if (status === '삭제대기') return 'st--deleted'
@@ -75,8 +75,16 @@ function categoryClass(cat) {
       <button type="button" class="kd__restore-btn" @click="emit('restore', article)">복원</button>
     </div>
 
-    <div v-else-if="article.rawStatus !== 'APPROVED'" class="kd__actions">
-      <button type="button" class="kd__delete-btn" @click="emit('delete', article)">삭제</button>
+    <div v-else class="kd__actions">
+      <button type="button" class="kd__edit-btn" @click="emit('edit', article)">수정</button>
+      <button
+        v-if="article.rawStatus !== 'APPROVED'"
+        type="button"
+        class="kd__delete-btn"
+        @click="emit('delete', article)"
+      >
+        삭제
+      </button>
     </div>
   </BaseModal>
 </template>
@@ -231,6 +239,19 @@ function categoryClass(cat) {
 .kd__actions {
   display: flex;
   justify-content: flex-end;
+  gap: 10px;
+}
+
+.kd__edit-btn {
+  height: 40px;
+  padding: 0 18px;
+  border: 1px solid var(--color-primary-300);
+  border-radius: var(--radius-xs);
+  background: var(--color-bg-surface);
+  color: var(--color-primary-700);
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
 }
 
 .kd__delete-btn {

--- a/src/components/kms/worker/my-knowledge-management/WorkerKnowledgeEditModal.vue
+++ b/src/components/kms/worker/my-knowledge-management/WorkerKnowledgeEditModal.vue
@@ -1,8 +1,9 @@
 <script setup>
-import { ref, onMounted } from 'vue'
+import { onMounted, ref } from 'vue'
 import { BaseFormModal } from '@/components/common/base'
 import { ARTICLE_CATEGORY_OPTIONS } from '@/constants'
 import knowledgeArticleApi from '@/services/knowledgeArticleApi'
+import { useSpeechRecognition } from '@/utils/useSpeechRecognition'
 
 const props = defineProps({
   article: { type: Object, required: true },
@@ -19,6 +20,17 @@ const content     = ref(props.article.content ?? '')
 const equipmentList = ref([])
 const errorMessage = ref('')
 const equipmentLoadFailed = ref(false)
+const {
+  isRecording,
+  speechMessage,
+  supportsSpeechRecognition,
+  toggleVoiceInput,
+} = useSpeechRecognition({
+  getText: () => content.value,
+  setText: (value) => {
+    content.value = value
+  },
+})
 
 onMounted(async () => {
   try {
@@ -121,7 +133,19 @@ function handleSaveDraft() {
       <!-- Content -->
       <div class="ke__row">
         <div class="ke__field">
-          <label class="ke__label">본문</label>
+          <div class="ke__label-row">
+            <label class="ke__label">본문</label>
+            <button
+              class="ke__voice-btn"
+              :class="{ 'ke__voice-btn--active': isRecording }"
+              type="button"
+              :disabled="!supportsSpeechRecognition"
+              @click="toggleVoiceInput"
+            >
+              {{ isRecording ? '음성 입력 종료' : '음성으로 작성' }}
+            </button>
+          </div>
+          <p class="ke__hint">{{ speechMessage }}</p>
           <textarea
             v-model="content"
             class="ke__textarea ke__textarea--lg"
@@ -155,9 +179,15 @@ function handleSaveDraft() {
 }
 
 .ke__label {
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--color-text-strong);
+}
+
+.ke__label-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .ke__input,
@@ -165,7 +195,7 @@ function handleSaveDraft() {
   padding: 10px 14px;
   border: 1px solid var(--color-border-default);
   border-radius: var(--radius-sm);
-  font-size: 14px;
+  font-size: var(--font-size-base);
   color: var(--color-text-default);
   background: var(--color-bg-surface);
   outline: none;
@@ -186,7 +216,7 @@ function handleSaveDraft() {
   padding: 12px 14px;
   border: 1px solid var(--color-border-default);
   border-radius: var(--radius-sm);
-  font-size: 14px;
+  font-size: var(--font-size-base);
   color: var(--color-text-default);
   resize: none;
   outline: none;
@@ -202,9 +232,43 @@ function handleSaveDraft() {
   min-height: 140px;
 }
 
+.ke__voice-btn {
+  min-width: 108px;
+  padding: 7px 14px;
+  border: 1px solid var(--color-primary-300);
+  border-radius: var(--radius-xs);
+  background: var(--color-bg-surface);
+  font-size: var(--font-size-xs-plus);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-primary-700);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.ke__voice-btn:hover {
+  background: var(--color-primary-100);
+}
+
+.ke__voice-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.ke__voice-btn--active {
+  border-color: var(--color-primary-600);
+  background: var(--color-primary-100);
+  color: var(--color-primary-800);
+}
+
+.ke__hint {
+  margin: 0;
+  font-size: var(--font-size-xs-plus);
+  color: var(--color-text-muted);
+}
+
 .ke__error {
   margin: 0;
-  font-size: 12px;
+  font-size: var(--font-size-xs-plus);
   color: var(--color-danger);
 }
 </style>

--- a/src/components/kms/worker/my-knowledge-management/WorkerKnowledgeEditModal.vue
+++ b/src/components/kms/worker/my-knowledge-management/WorkerKnowledgeEditModal.vue
@@ -23,6 +23,7 @@ const equipmentLoadFailed = ref(false)
 const {
   isRecording,
   speechMessage,
+  speechTone,
   supportsSpeechRecognition,
   toggleVoiceInput,
 } = useSpeechRecognition({
@@ -145,7 +146,7 @@ function handleSaveDraft() {
               {{ isRecording ? '음성 입력 종료' : '음성으로 작성' }}
             </button>
           </div>
-          <p class="ke__hint">{{ speechMessage }}</p>
+          <p class="ke__hint" :class="`ke__hint--${speechTone}`">{{ speechMessage }}</p>
           <textarea
             v-model="content"
             class="ke__textarea ke__textarea--lg"
@@ -263,7 +264,22 @@ function handleSaveDraft() {
 .ke__hint {
   margin: 0;
   font-size: var(--font-size-xs-plus);
+}
+
+.ke__hint--idle {
   color: var(--color-text-muted);
+}
+
+.ke__hint--active {
+  color: var(--color-primary-700);
+}
+
+.ke__hint--ended {
+  color: var(--color-success);
+}
+
+.ke__hint--error {
+  color: var(--color-danger);
 }
 
 .ke__error {

--- a/src/components/kms/worker/my-knowledge-management/WorkerMyKnowledgeList.vue
+++ b/src/components/kms/worker/my-knowledge-management/WorkerMyKnowledgeList.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, computed, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { BaseFilterTabs } from '@/components/common/base'
 import { ARTICLE_STATUS_LABEL, CATEGORY_CLASS_MAP } from '@/constants'
 
@@ -12,8 +13,9 @@ const emit = defineEmits(['detail', 'edit', 'delete', 'restore'])
 const categories = ['전체', '장애조치', '공정개선', '설비운영', '안전', '기타', '승인대기', '반려', '임시저장', '삭제대기']
 const activeCategory = ref('전체')
 const searchQuery = ref('')
-const currentPage = ref(1)
 const pageSize = 4
+const route = useRoute()
+const router = useRouter()
 
 const filteredArticles = computed(() => {
   let result = props.articles
@@ -46,24 +48,73 @@ const filteredArticles = computed(() => {
 })
 
 const totalPages = computed(() => Math.max(1, Math.ceil(filteredArticles.value.length / pageSize)))
+const currentPage = computed(() => Math.min(normalizePageQuery(route.query.p), totalPages.value))
 
 const pagedArticles = computed(() => {
   const start = (currentPage.value - 1) * pageSize
   return filteredArticles.value.slice(start, start + pageSize)
 })
 
-const pageNumbers = computed(() => Array.from({ length: totalPages.value }, (_, index) => index + 1))
+const pageButtons = computed(() => {
+  const total = totalPages.value
+  const current = currentPage.value
+
+  if (total <= 7) {
+    return Array.from({ length: total }, (_, index) => index + 1)
+  }
+
+  if (current <= 4) {
+    return [1, 2, 3, 4, 5, '...', total]
+  }
+
+  if (current >= total - 3) {
+    return [1, '...', total - 4, total - 3, total - 2, total - 1, total]
+  }
+
+  return [1, '...', current - 1, current, current + 1, '...', total]
+})
+
+function normalizePageQuery(value) {
+  const parsed = Number.parseInt(Array.isArray(value) ? value[0] : value, 10)
+  if (Number.isNaN(parsed) || parsed < 1) {
+    return 1
+  }
+  return parsed
+}
+
+function syncPageQuery(page) {
+  const normalizedPage = normalizePageQuery(page)
+  const nextQuery = { ...route.query }
+
+  if (normalizedPage <= 1) {
+    delete nextQuery.p
+  } else {
+    nextQuery.p = String(normalizedPage)
+  }
+
+  const currentQueryPage = Array.isArray(route.query.p) ? route.query.p[0] : route.query.p
+  const nextQueryPage = nextQuery.p
+
+  if ((currentQueryPage ?? undefined) === (nextQueryPage ?? undefined)) {
+    return
+  }
+
+  void router.replace({ query: nextQuery })
+}
 
 watch([activeCategory, searchQuery], () => {
-  currentPage.value = 1
+  syncPageQuery(1)
 })
 
 watch(filteredArticles, (articles) => {
   const nextTotal = Math.max(1, Math.ceil(articles.length / pageSize))
-  if (currentPage.value > nextTotal) {
-    currentPage.value = nextTotal
+  if (articles.length === 0) {
+    return
   }
-})
+  if (currentPage.value > nextTotal) {
+    syncPageQuery(nextTotal)
+  }
+}, { immediate: true })
 
 function statusClass(status) {
   if (status === '삭제대기') return 'st--deleted'
@@ -85,7 +136,16 @@ function actionLabel(status) {
 }
 
 function setPage(page) {
-  currentPage.value = page
+  if (typeof page !== 'number' || Number.isNaN(page)) {
+    return
+  }
+
+  const nextPage = Math.min(Math.max(page, 1), totalPages.value)
+  if (nextPage === currentPage.value) {
+    return
+  }
+
+  syncPageQuery(nextPage)
 }
 </script>
 
@@ -118,7 +178,16 @@ function setPage(page) {
 
     <!-- Article Cards -->
     <div class="mkl__list">
-      <div v-for="article in pagedArticles" :key="article.id" class="mkl__card" :class="{ 'mkl__card--deleted': article.isDeleted }">
+      <div
+        v-for="article in pagedArticles"
+        :key="article.id"
+        class="mkl__card"
+        :class="{ 'mkl__card--deleted': article.isDeleted }"
+        tabindex="0"
+        @click="emit('detail', article)"
+        @keydown.enter="emit('detail', article)"
+        @keydown.space.prevent="emit('detail', article)"
+      >
         <div class="mkl__card-top">
           <div class="mkl__card-badges">
             <span class="mkl__badge" :class="categoryClass(article.category)">
@@ -141,25 +210,25 @@ function setPage(page) {
             <span>수정 횟수 {{ article.reuses }}회</span>
           </div>
           <div class="mkl__card-actions">
-            <button class="mkl__action-btn" @click="emit('detail', article)">상세</button>
+            <button class="mkl__action-btn" @click.stop="emit('detail', article)">상세</button>
             <button
               v-if="!article.isDeleted"
               class="mkl__action-btn"
-              @click="emit('edit', article)"
+              @click.stop="emit('edit', article)"
             >
               {{ actionLabel(article.status) }}
             </button>
             <button
               v-if="!article.isDeleted && article.rawStatus !== 'APPROVED'"
               class="mkl__action-btn mkl__action-btn--delete"
-              @click="emit('delete', article)"
+              @click.stop="emit('delete', article)"
             >
               삭제
             </button>
             <button
               v-if="article.isDeleted"
               class="mkl__action-btn mkl__action-btn--restore"
-              @click="emit('restore', article)"
+              @click.stop="emit('restore', article)"
             >
               복원
             </button>
@@ -172,14 +241,32 @@ function setPage(page) {
 
     <div v-if="filteredArticles.length > 0" class="mkl__pagination">
       <button
-        v-for="page in pageNumbers"
-        :key="page"
+        type="button"
+        class="mkl__page mkl__page--nav"
+        :disabled="currentPage <= 1"
+        @click="setPage(currentPage - 1)"
+      >
+        &lt;
+      </button>
+      <template v-for="(page, index) in pageButtons" :key="`${page}-${index}`">
+        <span v-if="page === '...'" class="mkl__ellipsis">...</span>
+      <button
+        v-else
         type="button"
         class="mkl__page"
         :class="{ 'mkl__page--active': currentPage === page }"
         @click="setPage(page)"
       >
         {{ page }}
+      </button>
+      </template>
+      <button
+        type="button"
+        class="mkl__page mkl__page--nav"
+        :disabled="currentPage >= totalPages"
+        @click="setPage(currentPage + 1)"
+      >
+        &gt;
       </button>
     </div>
   </div>
@@ -291,11 +378,14 @@ function setPage(page) {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  cursor: pointer;
   transition: border-color 0.15s;
 }
 
-.mkl__card:hover {
+.mkl__card:hover,
+.mkl__card:focus-visible {
   border-color: var(--color-primary-300);
+  outline: none;
 }
 
 .mkl__card--deleted {
@@ -488,9 +578,25 @@ function setPage(page) {
   cursor: pointer;
 }
 
+.mkl__page:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
 .mkl__page--active {
   border-color: var(--color-primary-700);
   background: var(--color-primary-700);
   color: #fff;
+}
+
+.mkl__ellipsis {
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-muted);
+  font-size: 13px;
+  font-weight: 700;
 }
 </style>

--- a/src/components/kms/worker/skill-gap/WorkerCustomizedLearningRecommendations.vue
+++ b/src/components/kms/worker/skill-gap/WorkerCustomizedLearningRecommendations.vue
@@ -105,7 +105,7 @@ const tierClass = (tier) => {
 }
 
 .lr__label {
-  font-size: 13px;
+  font-size: var(--font-size-sm);
   color: var(--color-text-muted);
 }
 
@@ -120,6 +120,7 @@ const tierClass = (tier) => {
   background: var(--color-bg-surface);
   border: 1px solid var(--color-border-default);
   border-radius: var(--radius-md);
+  min-height: 132px;
   padding: 18px 20px;
   display: flex;
   flex-direction: column;
@@ -139,15 +140,15 @@ const tierClass = (tier) => {
 }
 
 .lr__priority {
-  font-size: 11px;
-  font-weight: 700;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
   padding: 3px 10px;
   border-radius: var(--radius-2xs);
 }
 
 .lr__category {
-  font-size: 11px;
-  font-weight: 700;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
   padding: 3px 10px;
   border-radius: var(--radius-2xs);
   background: var(--color-neutral-100);
@@ -155,23 +156,24 @@ const tierClass = (tier) => {
 }
 
 .lr__duration {
-  font-size: 20px;
-  font-weight: 800;
+  font-size: var(--font-size-lg-plus);
+  font-weight: var(--font-weight-extrabold);
   color: var(--color-text-strong);
   font-family: var(--font-family-num);
 }
 
 .lr__course-title {
-  font-size: 15px;
-  font-weight: 700;
+  font-size: var(--font-size-base-plus);
+  font-weight: var(--font-weight-bold);
   color: var(--color-text-strong);
   margin: 0;
 }
 
 .lr__course-desc {
-  font-size: 12px;
+  font-size: var(--font-size-xs-plus);
   color: var(--color-text-muted);
   margin: 0;
+  line-height: 1.5;
 }
 
 .lr__course-bottom {
@@ -182,18 +184,20 @@ const tierClass = (tier) => {
 }
 
 .lr__course-diff {
-  font-size: 13px;
+  font-size: var(--font-size-sm);
   color: var(--tier-s);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .lr__course-btn {
+  min-width: 92px;
+  min-height: 34px;
   padding: 6px 20px;
   border: 1px solid var(--color-border-default);
   border-radius: var(--radius-xs);
   background: var(--color-bg-surface);
-  font-size: 12px;
-  font-weight: 600;
+  font-size: var(--font-size-xs-plus);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-text-default);
   cursor: pointer;
 }
@@ -217,7 +221,7 @@ const tierClass = (tier) => {
 
 /* ── Related Articles ──────────────────────────────────── */
 .lr__articles {
-  background: linear-gradient(180deg, #312376 0%, #24195e 100%);
+  background: linear-gradient(180deg, var(--color-primary-800) 0%, var(--color-primary-900) 100%);
   border-radius: var(--radius-md);
   padding: 18px;
   display: flex;
@@ -228,8 +232,8 @@ const tierClass = (tier) => {
 }
 
 .lr__articles-label {
-  font-size: 12px;
-  font-weight: 700;
+  font-size: var(--font-size-xs-plus);
+  font-weight: var(--font-weight-bold);
   color: var(--color-white);
   letter-spacing: 0.02em;
 }
@@ -246,7 +250,7 @@ const tierClass = (tier) => {
   display: grid;
   gap: 6px;
   width: 100%;
-  min-height: 0;
+  min-height: 96px;
   flex: 1 1 0;
   padding: 12px 14px;
   border: 1px solid rgba(255, 255, 255, 0.16);
@@ -270,43 +274,43 @@ const tierClass = (tier) => {
 }
 
 .lr__article-bullet {
-  width: 22px;
-  height: 22px;
+  width: 24px;
+  height: 24px;
   border-radius: 999px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   background: rgba(255, 255, 255, 0.16);
   color: var(--color-white);
-  font-size: 10px;
-  font-weight: 800;
+  font-size: var(--font-size-2xs);
+  font-weight: var(--font-weight-extrabold);
   flex-shrink: 0;
   margin-top: 1px;
 }
 
 .lr__article-bullet--s {
-  background: #00bf95;
-  color: #fff;
+  background: var(--tier-s);
+  color: var(--color-white);
 }
 
 .lr__article-bullet--a {
   background: var(--color-primary-500);
-  color: #fff;
+  color: var(--color-white);
 }
 
 .lr__article-bullet--b {
-  background: #ffd166;
-  color: #2d237c;
+  background: var(--tier-b);
+  color: var(--color-primary-800);
 }
 
 .lr__article-bullet--c {
-  background: #ef476f;
-  color: #fff;
+  background: var(--tier-c);
+  color: var(--color-white);
 }
 
 .lr__article-title {
-  font-size: 13px;
-  font-weight: 600;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-white);
   line-height: 1.45;
   display: -webkit-box;
@@ -317,7 +321,7 @@ const tierClass = (tier) => {
 
 .lr__article-preview {
   margin: 0;
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   line-height: 1.45;
   color: rgba(255, 255, 255, 0.74);
   display: -webkit-box;
@@ -327,9 +331,24 @@ const tierClass = (tier) => {
 }
 
 .lr__article-likes {
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   color: rgba(255, 255, 255, 0.72);
   flex-shrink: 0;
   justify-self: end;
+}
+
+@media (max-width: 768px) {
+  .lr {
+    padding: 20px;
+  }
+
+  .lr__course,
+  .lr__article {
+    min-height: auto;
+  }
+
+  .lr__duration {
+    font-size: var(--font-size-lg);
+  }
 }
 </style>

--- a/src/components/kms/worker/skill-gap/WorkerSkillGapChartAndStatus.vue
+++ b/src/components/kms/worker/skill-gap/WorkerSkillGapChartAndStatus.vue
@@ -90,6 +90,7 @@ const overallPercent = computed(() => {
   return Math.round((props.summary.currentOverall / props.summary.targetOverall) * 100)
 })
 
+const currentLabel = computed(() => `현재 ${props.currentTier}등급`)
 const targetLabel = computed(() => `${props.targetTier} 등급 목표`)
 const comparisonLabel = computed(() => `현재 ${props.currentTier} 등급 VS ${props.targetTier} 등급 목표`)
 const gapSummaryLabel = computed(() => {
@@ -98,6 +99,10 @@ const gapSummaryLabel = computed(() => {
   }
   return `평균 기준 ▲ ${props.summary.totalGap}점 필요`
 })
+
+function tierClass(tier) {
+  return `sg__tier--${String(tier ?? 'C').toLowerCase()}`
+}
 </script>
 
 <template>
@@ -126,7 +131,7 @@ const gapSummaryLabel = computed(() => {
         <path
           :d="targetPath"
           fill="rgba(0, 191, 149, 0.08)"
-          stroke="#00BF95"
+          stroke="var(--color-success)"
           stroke-width="2"
           stroke-dasharray="6 3"
         />
@@ -134,7 +139,7 @@ const gapSummaryLabel = computed(() => {
         <path
           :d="currentPath"
           fill="rgba(91, 79, 207, 0.18)"
-          stroke="#5B4FCF"
+          stroke="var(--color-primary-700)"
           stroke-width="2"
         />
         <text
@@ -152,11 +157,11 @@ const gapSummaryLabel = computed(() => {
 
     <!-- Legend -->
     <div class="sg__legend">
-      <span class="sg__legend-item">
-        <span class="sg__legend-dot" style="background: #5B4FCF"></span> 현재 ● #5B4FCF
+      <span class="sg__legend-item" :class="tierClass(currentTier)">
+        <span class="sg__legend-dot sg__legend-dot--current"></span> {{ currentLabel }}
       </span>
-      <span class="sg__legend-item">
-        <span class="sg__legend-line"></span> {{ targetLabel }} -- #00BF95
+      <span class="sg__legend-item" :class="tierClass(targetTier)">
+        <span class="sg__legend-dot sg__legend-dot--target"></span> {{ targetLabel }}
       </span>
     </div>
 
@@ -235,6 +240,7 @@ const gapSummaryLabel = computed(() => {
   display: flex;
   align-items: center;
   gap: 6px;
+  font-weight: 700;
 }
 
 .sg__legend-dot {
@@ -243,10 +249,28 @@ const gapSummaryLabel = computed(() => {
   border-radius: 50%;
 }
 
-.sg__legend-line {
-  width: 16px;
-  height: 0;
-  border-top: 2px dashed var(--tier-s);
+.sg__legend-dot--current {
+  background: var(--color-primary-700);
+}
+
+.sg__legend-dot--target {
+  background: var(--color-success);
+}
+
+.sg__tier--s {
+  color: var(--tier-s);
+}
+
+.sg__tier--a {
+  color: var(--tier-a);
+}
+
+.sg__tier--b {
+  color: var(--tier-b);
+}
+
+.sg__tier--c {
+  color: var(--tier-c);
 }
 
 /* ── Gap Summary ───────────────────────────────────────── */
@@ -321,7 +345,7 @@ const gapSummaryLabel = computed(() => {
 .sg__row-target {
   font-size: 13px;
   font-weight: 700;
-  color: var(--tier-s);
+  color: var(--color-success);
   width: 24px;
 }
 

--- a/src/services/knowledgeArticleApi.js
+++ b/src/services/knowledgeArticleApi.js
@@ -9,6 +9,10 @@ const knowledgeArticleApi = {
     return kmsApi.get('/api/kms/articles', { params })
   },
 
+  getPagedArticles(params = {}) {
+    return kmsApi.get('/api/kms/articles/paged', { params })
+  },
+
   getArticleDetail(articleId) {
     return kmsApi.get(`/api/kms/articles/${articleId}`)
   },

--- a/src/utils/fetchAllKmsArticles.js
+++ b/src/utils/fetchAllKmsArticles.js
@@ -1,0 +1,28 @@
+const DEFAULT_PAGE_SIZE = 100
+const MAX_PAGE_COUNT = 50
+
+export default async function fetchAllKmsArticles(getArticles, params = {}) {
+  const pageSize = Math.max(1, Number(params.size ?? DEFAULT_PAGE_SIZE))
+  const articles = []
+
+  for (let page = 0; page < MAX_PAGE_COUNT; page += 1) {
+    const response = await getArticles({
+      ...params,
+      page,
+      size: pageSize,
+    })
+    const batch = response?.data?.data ?? []
+
+    if (!Array.isArray(batch) || batch.length === 0) {
+      break
+    }
+
+    articles.push(...batch)
+
+    if (batch.length < pageSize) {
+      break
+    }
+  }
+
+  return articles
+}

--- a/src/utils/useSpeechRecognition.js
+++ b/src/utils/useSpeechRecognition.js
@@ -13,71 +13,73 @@ export function useSpeechRecognition(options = {}) {
 
   const isRecording = ref(false)
   const speechMessage = ref(idleMessage)
+  const speechTone = ref('idle')
 
   let recognition = null
   let baseText = ''
   let finalTranscript = ''
+  let errorOccurred = false
+  let stoppedByUser = false
 
-  const supportsSpeechRecognition = computed(() => {
-    if (typeof window === 'undefined') {
-      return false
-    }
-
-    return Boolean(window.SpeechRecognition || window.webkitSpeechRecognition)
-  })
-
-  function createRecognition() {
+  function getSpeechRecognitionConstructor() {
     if (typeof window === 'undefined') {
       return null
     }
 
-    const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition
+    return window.SpeechRecognition || window.webkitSpeechRecognition || null
+  }
+
+  function resolveSpeechErrorMessage(errorCode) {
+    switch (errorCode) {
+      case 'not-allowed':
+      case 'service-not-allowed':
+        return '마이크 권한이 허용되지 않았습니다. 브라우저의 마이크 권한을 확인해 주세요.'
+      case 'audio-capture':
+        return '마이크를 찾을 수 없습니다. 입력 장치를 확인한 뒤 다시 시도해 주세요.'
+      case 'no-speech':
+        return '음성이 감지되지 않았습니다. 마이크 상태를 확인하고 다시 시도해 주세요.'
+      case 'network':
+        return '음성 인식 서비스 연결에 실패했습니다. 네트워크 상태를 확인해 주세요.'
+      case 'aborted':
+        return stoppedByUser
+          ? '음성 입력이 종료되었습니다. 필요하면 다시 시작해 주세요.'
+          : '음성 입력이 중단되었습니다. 다시 시도해 주세요.'
+      default:
+        return errorMessageText
+    }
+  }
+
+  const supportsSpeechRecognition = computed(() => {
+    return Boolean(getSpeechRecognitionConstructor())
+  })
+
+  function createRecognition() {
+    if (recognition) {
+      return recognition
+    }
+
+    const SpeechRecognition = getSpeechRecognitionConstructor()
     if (!SpeechRecognition) {
       return null
     }
 
-    const recognizer = new SpeechRecognition()
-    recognizer.lang = 'ko-KR'
-    recognizer.continuous = true
-    recognizer.interimResults = true
-    return recognizer
-  }
+    recognition = new SpeechRecognition()
+    recognition.lang = 'ko-KR'
+    recognition.continuous = true
+    recognition.interimResults = true
+    recognition.maxAlternatives = 1
 
-  function resetMessage() {
-    speechMessage.value = idleMessage
-  }
-
-  function stopVoiceInput() {
-    if (!recognition) {
-      isRecording.value = false
-      return
+    recognition.onstart = () => {
+      isRecording.value = true
+      speechMessage.value = listeningMessage
+      speechTone.value = 'active'
     }
-
-    recognition.stop()
-  }
-
-  function startVoiceInput() {
-    if (!supportsSpeechRecognition.value) {
-      speechMessage.value = unsupportedMessage
-      return
-    }
-
-    recognition = createRecognition()
-    if (!recognition) {
-      speechMessage.value = errorMessageText
-      return
-    }
-
-    baseText = (getText() ?? '').trim()
-    finalTranscript = ''
-    isRecording.value = true
-    speechMessage.value = listeningMessage
 
     recognition.onresult = (event) => {
       let interimTranscript = ''
 
       for (let index = event.resultIndex; index < event.results.length; index += 1) {
-        const transcript = event.results[index][0].transcript.trim()
+        const transcript = event.results[index][0]?.transcript?.trim()
 
         if (!transcript) {
           continue
@@ -93,19 +95,81 @@ export function useSpeechRecognition(options = {}) {
       setText([baseText, finalTranscript, interimTranscript].filter(Boolean).join(' ').trim())
     }
 
-    recognition.onerror = () => {
-      speechMessage.value = errorMessageText
+    recognition.onerror = (event) => {
+      errorOccurred = true
+      speechMessage.value = resolveSpeechErrorMessage(event?.error)
+      speechTone.value = event?.error === 'aborted' && stoppedByUser ? 'ended' : 'error'
       isRecording.value = false
-      recognition = null
     }
 
     recognition.onend = () => {
       isRecording.value = false
-      speechMessage.value = endedMessage
-      recognition = null
+
+      if (finalTranscript.trim()) {
+        setText([baseText, finalTranscript].filter(Boolean).join(' ').trim())
+      }
+
+      if (!errorOccurred) {
+        speechMessage.value = finalTranscript.trim()
+          ? endedMessage
+          : '음성 입력 결과가 없습니다. 마이크 상태를 확인하고 다시 시도해 주세요.'
+        speechTone.value = finalTranscript.trim() ? 'ended' : 'idle'
+      }
+
+      stoppedByUser = false
     }
 
-    recognition.start()
+    return recognition
+  }
+
+  function resetMessage() {
+    speechMessage.value = idleMessage
+    speechTone.value = 'idle'
+  }
+
+  function stopVoiceInput() {
+    if (!recognition) {
+      isRecording.value = false
+      return
+    }
+
+    stoppedByUser = true
+    recognition.stop()
+  }
+
+  function startVoiceInput() {
+    if (!supportsSpeechRecognition.value) {
+      speechMessage.value = unsupportedMessage
+      speechTone.value = 'error'
+      return
+    }
+
+    const recognizer = createRecognition()
+    if (!recognizer) {
+      speechMessage.value = errorMessageText
+      speechTone.value = 'error'
+      return
+    }
+
+    baseText = (getText() ?? '').trim()
+    finalTranscript = ''
+    errorOccurred = false
+    stoppedByUser = false
+    isRecording.value = false
+    speechMessage.value = '마이크 권한과 음성 인식을 준비하고 있습니다.'
+    speechTone.value = 'active'
+
+    try {
+      recognizer.start()
+    } catch (error) {
+      errorOccurred = true
+      isRecording.value = false
+      speechMessage.value =
+        error?.name === 'InvalidStateError'
+          ? '음성 입력이 이미 시작되어 있습니다. 잠시 후 다시 시도해 주세요.'
+          : errorMessageText
+      speechTone.value = 'error'
+    }
   }
 
   function toggleVoiceInput() {
@@ -124,6 +188,7 @@ export function useSpeechRecognition(options = {}) {
 
     recognition.onresult = null
     recognition.onerror = null
+    recognition.onstart = null
     recognition.onend = null
     recognition.abort()
     recognition = null
@@ -132,6 +197,7 @@ export function useSpeechRecognition(options = {}) {
   return {
     isRecording,
     speechMessage,
+    speechTone,
     supportsSpeechRecognition,
     toggleVoiceInput,
     stopVoiceInput,

--- a/src/utils/useSpeechRecognition.js
+++ b/src/utils/useSpeechRecognition.js
@@ -1,0 +1,140 @@
+import { computed, onBeforeUnmount, ref } from 'vue'
+
+export function useSpeechRecognition(options = {}) {
+  const {
+    getText = () => '',
+    setText = () => {},
+    idleMessage = '음성 인식으로 본문을 빠르게 작성할 수 있습니다.',
+    listeningMessage = '음성을 듣고 있습니다. 말씀하신 내용이 본문에 반영됩니다.',
+    endedMessage = '음성 입력이 종료되었습니다. 필요하면 다시 시작해 주세요.',
+    errorMessageText = '음성 인식 중 오류가 발생했습니다. 다시 시도해 주세요.',
+    unsupportedMessage = '현재 브라우저에서는 음성 인식을 지원하지 않습니다.',
+  } = options
+
+  const isRecording = ref(false)
+  const speechMessage = ref(idleMessage)
+
+  let recognition = null
+  let baseText = ''
+  let finalTranscript = ''
+
+  const supportsSpeechRecognition = computed(() => {
+    if (typeof window === 'undefined') {
+      return false
+    }
+
+    return Boolean(window.SpeechRecognition || window.webkitSpeechRecognition)
+  })
+
+  function createRecognition() {
+    if (typeof window === 'undefined') {
+      return null
+    }
+
+    const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition
+    if (!SpeechRecognition) {
+      return null
+    }
+
+    const recognizer = new SpeechRecognition()
+    recognizer.lang = 'ko-KR'
+    recognizer.continuous = true
+    recognizer.interimResults = true
+    return recognizer
+  }
+
+  function resetMessage() {
+    speechMessage.value = idleMessage
+  }
+
+  function stopVoiceInput() {
+    if (!recognition) {
+      isRecording.value = false
+      return
+    }
+
+    recognition.stop()
+  }
+
+  function startVoiceInput() {
+    if (!supportsSpeechRecognition.value) {
+      speechMessage.value = unsupportedMessage
+      return
+    }
+
+    recognition = createRecognition()
+    if (!recognition) {
+      speechMessage.value = errorMessageText
+      return
+    }
+
+    baseText = (getText() ?? '').trim()
+    finalTranscript = ''
+    isRecording.value = true
+    speechMessage.value = listeningMessage
+
+    recognition.onresult = (event) => {
+      let interimTranscript = ''
+
+      for (let index = event.resultIndex; index < event.results.length; index += 1) {
+        const transcript = event.results[index][0].transcript.trim()
+
+        if (!transcript) {
+          continue
+        }
+
+        if (event.results[index].isFinal) {
+          finalTranscript = [finalTranscript, transcript].filter(Boolean).join(' ').trim()
+        } else {
+          interimTranscript = [interimTranscript, transcript].filter(Boolean).join(' ').trim()
+        }
+      }
+
+      setText([baseText, finalTranscript, interimTranscript].filter(Boolean).join(' ').trim())
+    }
+
+    recognition.onerror = () => {
+      speechMessage.value = errorMessageText
+      isRecording.value = false
+      recognition = null
+    }
+
+    recognition.onend = () => {
+      isRecording.value = false
+      speechMessage.value = endedMessage
+      recognition = null
+    }
+
+    recognition.start()
+  }
+
+  function toggleVoiceInput() {
+    if (isRecording.value) {
+      stopVoiceInput()
+      return
+    }
+
+    startVoiceInput()
+  }
+
+  onBeforeUnmount(() => {
+    if (!recognition) {
+      return
+    }
+
+    recognition.onresult = null
+    recognition.onerror = null
+    recognition.onend = null
+    recognition.abort()
+    recognition = null
+  })
+
+  return {
+    isRecording,
+    speechMessage,
+    supportsSpeechRecognition,
+    toggleVoiceInput,
+    stopVoiceInput,
+    resetMessage,
+  }
+}

--- a/src/views/admin/AdminKnowledgeHub.vue
+++ b/src/views/admin/AdminKnowledgeHub.vue
@@ -101,6 +101,7 @@ const hubStats       = ref({
   averageViewCountChange: 0,
 })
 const selectedArticle = ref(null)
+const isPageQueryReady = ref(false)
 
 const selectedFilter = ref('all')
 
@@ -120,6 +121,7 @@ onMounted(async () => {
     loadContributors(),
     loadRecommendations(),
   ])
+  isPageQueryReady.value = true
 })
 
 const visibleArticles = computed(() => {
@@ -336,6 +338,7 @@ async function handleRestore(articleId) {
           :categories="knowledgeCategories"
           :articles="visibleArticles"
           :selectedFilter="selectedFilter"
+          :page-query-ready="isPageQueryReady"
           @filterChange="selectedFilter = $event"
           @delete="handleDelete"
           @restore="handleRestore"

--- a/src/views/admin/AdminKnowledgeHub.vue
+++ b/src/views/admin/AdminKnowledgeHub.vue
@@ -1,13 +1,27 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
-import { ARTICLE_CATEGORY_LABEL } from '@/constants'
+import { useRoute } from 'vue-router'
+import { ARTICLE_CATEGORY_LABEL, ARTICLE_CATEGORY_OPTIONS } from '@/constants'
 import KmsFeed      from '@/components/admin/kms/KmsFeed.vue'
 import KmsSidePanel from '@/components/admin/kms/KmsSidePanel.vue'
 import KnowledgeHubHeader from '@/components/kms/common/knowledge-hub/KnowledgeHubHeader.vue'
 import KnowledgeHubAiPanel from '@/components/kms/common/knowledge-hub/KnowledgeHubAiPanel.vue'
 import KnowledgeDetailModal from '@/components/kms/common/knowledge-hub/KnowledgeDetailModal.vue'
 import knowledgeArticleApi from '@/services/knowledgeArticleApi'
-import fetchAllKmsArticles from '@/utils/fetchAllKmsArticles'
+
+const HUB_PAGE_SIZE = 4
+const CATEGORY_VALUE_MAP = Object.fromEntries(
+  ARTICLE_CATEGORY_OPTIONS.map((option) => [option.label, option.value]),
+)
+const route = useRoute()
+
+function normalizePageQuery(value) {
+  const parsed = Number.parseInt(Array.isArray(value) ? value[0] : value, 10)
+  if (Number.isNaN(parsed) || parsed < 1) {
+    return 1
+  }
+  return parsed
+}
 
 const knowledgeCategories = [
   { key: 'all', label: '전체' },
@@ -93,6 +107,7 @@ const articles        = ref([])
 const bookmarkArticles = ref([])
 const contributors    = ref([])
 const recommendations = ref([])
+const totalPages      = ref(1)
 const hubStats       = ref({
   totalArticles: 0,
   newThisMonth: 0,
@@ -102,6 +117,12 @@ const hubStats       = ref({
 })
 const selectedArticle = ref(null)
 const isPageQueryReady = ref(false)
+const currentFeedQuery = ref({
+  filterKey: 'all',
+  keyword: '',
+  page: normalizePageQuery(route.query.p),
+  pageSize: HUB_PAGE_SIZE,
+})
 
 const selectedFilter = ref('all')
 
@@ -116,7 +137,7 @@ const statCards = computed(() => [
 onMounted(async () => {
   await Promise.allSettled([
     loadHubStats(),
-    loadArticles(),
+    loadArticlesPage(),
     loadBookmarks(),
     loadContributors(),
     loadRecommendations(),
@@ -124,17 +145,7 @@ onMounted(async () => {
   isPageQueryReady.value = true
 })
 
-const visibleArticles = computed(() => {
-  const merged = new Map()
-  for (const article of articles.value) {
-    merged.set(article.id, article)
-  }
-  for (const article of bookmarkArticles.value) {
-    const existing = merged.get(article.id)
-    merged.set(article.id, existing ? { ...existing, ...article, bookmarked: true } : article)
-  }
-  return [...merged.values()]
-})
+const visibleArticles = computed(() => articles.value)
 
 async function loadHubStats() {
   try {
@@ -151,17 +162,6 @@ async function loadHubStats() {
   }
 }
 
-async function loadArticles() {
-  try {
-    const articleDtos = await fetchAllKmsArticles(knowledgeArticleApi.getArticles, {
-      articleStatus: 'APPROVED',
-    })
-    articles.value = articleDtos.map(mapToFeedCard)
-  } catch (e) {
-    console.error('[KMS] 문서 목록 로드 실패:', e)
-  }
-}
-
 async function loadBookmarks() {
   try {
     const res = await knowledgeArticleApi.getMyBookmarks()
@@ -169,6 +169,61 @@ async function loadBookmarks() {
       .map((item) => ({ ...item, bookmarked: true }))
   } catch (e) {
     console.error('[KMS] 북마크 목록 로드 실패:', e)
+  }
+}
+
+function filterBookmarkCards(keyword = '') {
+  const normalizedKeyword = keyword.trim().toLowerCase()
+  if (!normalizedKeyword) {
+    return bookmarkArticles.value
+  }
+
+  return bookmarkArticles.value.filter((card) =>
+    [card.title, card.summary, card.equipment, card.author?.name, ...(card.tags ?? [])]
+      .join(' ')
+      .toLowerCase()
+      .includes(normalizedKeyword),
+  )
+}
+
+async function loadArticlesPage(query = currentFeedQuery.value) {
+  currentFeedQuery.value = { ...currentFeedQuery.value, ...query }
+
+  if (currentFeedQuery.value.filterKey === 'bookmarked') {
+    const filtered = filterBookmarkCards(currentFeedQuery.value.keyword)
+    totalPages.value = Math.max(1, Math.ceil(filtered.length / HUB_PAGE_SIZE))
+    const page = Math.min(Math.max(currentFeedQuery.value.page, 1), totalPages.value)
+    const start = (page - 1) * HUB_PAGE_SIZE
+    articles.value = filtered.slice(start, start + HUB_PAGE_SIZE)
+    return
+  }
+
+  const params = {
+    articleStatus: 'APPROVED',
+    page: Math.max(currentFeedQuery.value.page - 1, 0),
+    size: currentFeedQuery.value.pageSize ?? HUB_PAGE_SIZE,
+  }
+
+  if (currentFeedQuery.value.filterKey === 'popular') {
+    params.sort = 'popular'
+  } else if (currentFeedQuery.value.filterKey !== 'all') {
+    params.category = CATEGORY_VALUE_MAP[currentFeedQuery.value.filterKey]
+  }
+
+  if (currentFeedQuery.value.keyword) {
+    params.searchType = 'articleTitle'
+    params.keyword = currentFeedQuery.value.keyword
+  }
+
+  try {
+    const res = await knowledgeArticleApi.getPagedArticles(params)
+    const pageData = res.data.data ?? {}
+    totalPages.value = Math.max(pageData.totalPages ?? 0, 1)
+    articles.value = (pageData.items ?? []).map(mapToFeedCard)
+  } catch (e) {
+    console.error('[KMS] 관리자 문서 페이지 목록 로드 실패:', e)
+    articles.value = []
+    totalPages.value = 1
   }
 }
 
@@ -262,7 +317,7 @@ async function toggleBookmark(article) {
       await knowledgeArticleApi.addBookmark(article.id)
     }
 
-    await Promise.allSettled([loadArticles(), loadBookmarks()])
+    await Promise.allSettled([loadBookmarks(), loadArticlesPage()])
 
     if (selectedArticle.value?.id === article.id) {
       const next = !(article.bookmarked || article.isBookmarked)
@@ -292,10 +347,10 @@ async function handleDelete(articleId) {
     }
     await Promise.allSettled([
       loadHubStats(),
-      loadArticles(),
       loadBookmarks(),
       loadContributors(),
       loadRecommendations(),
+      loadArticlesPage(),
     ])
   } catch (e) {
     console.error('[KMS] 문서 삭제 실패:', e)
@@ -314,15 +369,19 @@ async function handleRestore(articleId) {
     }
     await Promise.allSettled([
       loadHubStats(),
-      loadArticles(),
       loadBookmarks(),
       loadContributors(),
       loadRecommendations(),
+      loadArticlesPage(),
     ])
   } catch (e) {
     console.error('[KMS] 문서 복원 실패:', e)
     window.alert('문서 복원에 실패했습니다.')
   }
+}
+
+function handleFeedQueryChange(query) {
+  void loadArticlesPage(query)
 }
 </script>
 
@@ -338,12 +397,14 @@ async function handleRestore(articleId) {
           :categories="knowledgeCategories"
           :articles="visibleArticles"
           :selectedFilter="selectedFilter"
+          :total-pages="totalPages"
           :page-query-ready="isPageQueryReady"
           @filterChange="selectedFilter = $event"
           @delete="handleDelete"
           @restore="handleRestore"
           @open-detail="openDetailModal"
           @toggle-bookmark="toggleBookmark"
+          @query-change="handleFeedQueryChange"
         />
       </div>
 

--- a/src/views/admin/AdminKnowledgeHub.vue
+++ b/src/views/admin/AdminKnowledgeHub.vue
@@ -7,8 +7,7 @@ import KnowledgeHubHeader from '@/components/kms/common/knowledge-hub/KnowledgeH
 import KnowledgeHubAiPanel from '@/components/kms/common/knowledge-hub/KnowledgeHubAiPanel.vue'
 import KnowledgeDetailModal from '@/components/kms/common/knowledge-hub/KnowledgeDetailModal.vue'
 import knowledgeArticleApi from '@/services/knowledgeArticleApi'
-
-const tagFilters = ref([])
+import fetchAllKmsArticles from '@/utils/fetchAllKmsArticles'
 
 const knowledgeCategories = [
   { key: 'all', label: '전체' },
@@ -85,6 +84,7 @@ function mapToContributor(dto, idx) {
     tier: dto.employeeTier ?? 'C',
     articles: dto.articleCount ?? 0,
     views:   dto.totalViewCount ?? 0,
+    score:   dto.contributionScore ?? 0,
   }
 }
 
@@ -102,8 +102,7 @@ const hubStats       = ref({
 })
 const selectedArticle = ref(null)
 
-const selectedFilter    = ref('all')
-const selectedTagFilter = ref(null)
+const selectedFilter = ref('all')
 
 // ── 통계 카드 ─────────────────────────────────────────────────
 const statCards = computed(() => [
@@ -120,7 +119,6 @@ onMounted(async () => {
     loadBookmarks(),
     loadContributors(),
     loadRecommendations(),
-    loadTags(),
   ])
 })
 
@@ -134,14 +132,6 @@ const visibleArticles = computed(() => {
     merged.set(article.id, existing ? { ...existing, ...article, bookmarked: true } : article)
   }
   return [...merged.values()]
-})
-
-const visibleTagFilters = computed(() => {
-  const usedTags = new Set(
-    visibleArticles.value.flatMap((article) => article.tags ?? []),
-  )
-
-  return tagFilters.value.filter((tag) => usedTags.has(tag.key))
 })
 
 async function loadHubStats() {
@@ -161,12 +151,10 @@ async function loadHubStats() {
 
 async function loadArticles() {
   try {
-    const res = await knowledgeArticleApi.getArticles({
-      page: 0,
-      size: 20,
+    const articleDtos = await fetchAllKmsArticles(knowledgeArticleApi.getArticles, {
       articleStatus: 'APPROVED',
     })
-    articles.value = (res.data.data ?? []).map(mapToFeedCard)
+    articles.value = articleDtos.map(mapToFeedCard)
   } catch (e) {
     console.error('[KMS] 문서 목록 로드 실패:', e)
   }
@@ -200,21 +188,6 @@ async function loadRecommendations() {
     }))
   } catch (e) {
     console.error('[KMS] AI 추천 로드 실패:', e)
-  }
-}
-
-async function loadTags() {
-  try {
-    const res = await knowledgeArticleApi.getTags()
-    tagFilters.value = [...new Set((res.data.data ?? [])
-      .map((tag) => tag.tagName)
-      .filter(Boolean)
-    )]
-      .sort((left, right) => left.localeCompare(right, 'ko'))
-      .map((tagName) => ({ key: tagName }))
-  } catch (e) {
-    console.error('[KMS] 태그 목록 로드 실패:', e)
-    tagFilters.value = []
   }
 }
 
@@ -363,10 +336,7 @@ async function handleRestore(articleId) {
           :categories="knowledgeCategories"
           :articles="visibleArticles"
           :selectedFilter="selectedFilter"
-          :selectedTagFilter="selectedTagFilter"
-          :tagFilters="visibleTagFilters"
           @filterChange="selectedFilter = $event"
-          @tagFilterChange="selectedTagFilter = $event"
           @delete="handleDelete"
           @restore="handleRestore"
           @open-detail="openDetailModal"

--- a/src/views/departmentleader/DepartmentLeaderKnowledgeHubView.vue
+++ b/src/views/departmentleader/DepartmentLeaderKnowledgeHubView.vue
@@ -1,13 +1,27 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
-import { ARTICLE_CATEGORY_LABEL } from '@/constants'
+import { useRoute } from 'vue-router'
+import { ARTICLE_CATEGORY_LABEL, ARTICLE_CATEGORY_OPTIONS } from '@/constants'
 import KnowledgeHubHeader from '@/components/kms/common/knowledge-hub/KnowledgeHubHeader.vue'
 import KnowledgeHubFeed from '@/components/kms/common/knowledge-hub/KnowledgeHubFeed.vue'
 import KnowledgeHubAiPanel from '@/components/kms/common/knowledge-hub/KnowledgeHubAiPanel.vue'
 import KnowledgeDetailModal from '@/components/kms/common/knowledge-hub/KnowledgeDetailModal.vue'
 import KnowledgeHubContributors from "@/components/kms/common/knowledge-hub/KnowledgeHubContributors.vue";
 import knowledgeArticleApi from '@/services/knowledgeArticleApi'
-import fetchAllKmsArticles from '@/utils/fetchAllKmsArticles'
+
+const HUB_PAGE_SIZE = 4
+const CATEGORY_VALUE_MAP = Object.fromEntries(
+  ARTICLE_CATEGORY_OPTIONS.map((option) => [option.label, option.value]),
+)
+const route = useRoute()
+
+function normalizePageQuery(value) {
+  const parsed = Number.parseInt(Array.isArray(value) ? value[0] : value, 10)
+  if (Number.isNaN(parsed) || parsed < 1) {
+    return 1
+  }
+  return parsed
+}
 
 
 function formatTrend(value, digits = 0) {
@@ -85,6 +99,7 @@ const articles          = ref([])
 const bookmarkArticles  = ref([])
 const contributors      = ref([])
 const aiRecommendations = ref([])
+const totalPages        = ref(1)
 const hubStats          = ref({
   totalArticles: 0,
   newThisMonth: 0,
@@ -93,6 +108,12 @@ const hubStats          = ref({
   averageViewCountChange: 0,
 })
 const isPageQueryReady = ref(false)
+const currentFeedQuery = ref({
+  categoryKey: 'all',
+  keyword: '',
+  page: normalizePageQuery(route.query.p),
+  pageSize: HUB_PAGE_SIZE,
+})
 
 const summaryCards = computed(() => [
   { key: 'totalArticles', label: '등록 지식 수', value: `${Number(hubStats.value.totalArticles ?? 0).toLocaleString()}건`, helper: '' },
@@ -116,7 +137,7 @@ const summaryCards = computed(() => [
 onMounted(async () => {
   await Promise.allSettled([
     loadHubStats(),
-    loadArticles(),
+    loadArticlesPage(),
     loadBookmarks(),
     loadContributors(),
     loadRecommendations(),
@@ -124,17 +145,7 @@ onMounted(async () => {
   isPageQueryReady.value = true
 })
 
-const visibleArticles = computed(() => {
-  const merged = new Map()
-  for (const article of articles.value) {
-    merged.set(article.id, article)
-  }
-  for (const article of bookmarkArticles.value) {
-    const existing = merged.get(article.id)
-    merged.set(article.id, existing ? { ...existing, ...article, isBookmarked: true } : article)
-  }
-  return [...merged.values()]
-})
+const visibleArticles = computed(() => articles.value)
 
 async function loadHubStats() {
   try {
@@ -151,19 +162,6 @@ async function loadHubStats() {
   }
 }
 
-async function loadArticles() {
-  try {
-    const articleDtos = await fetchAllKmsArticles(knowledgeArticleApi.getArticles, {
-      articleStatus: 'APPROVED',
-    })
-    articles.value = articleDtos
-      .filter((dto) => dto.articleStatus === 'APPROVED')
-      .map(mapToFeedItem)
-  } catch (e) {
-    console.error('[KMS] 문서 목록 로드 실패:', e)
-  }
-}
-
 async function loadBookmarks() {
   try {
     const res = await knowledgeArticleApi.getMyBookmarks()
@@ -173,6 +171,61 @@ async function loadBookmarks() {
       .map((item) => ({ ...item, isBookmarked: true }))
   } catch (e) {
     console.error('[KMS] 북마크 목록 로드 실패:', e)
+  }
+}
+
+function filterBookmarkArticles(keyword = '') {
+  const normalizedKeyword = keyword.trim().toLowerCase()
+  if (!normalizedKeyword) {
+    return bookmarkArticles.value
+  }
+
+  return bookmarkArticles.value.filter((article) =>
+    [article.title, article.equipment, article.author, article.category]
+      .join(' ')
+      .toLowerCase()
+      .includes(normalizedKeyword),
+  )
+}
+
+async function loadArticlesPage(query = currentFeedQuery.value) {
+  currentFeedQuery.value = { ...currentFeedQuery.value, ...query }
+
+  if (currentFeedQuery.value.categoryKey === 'bookmarked') {
+    const filtered = filterBookmarkArticles(currentFeedQuery.value.keyword)
+    totalPages.value = Math.max(1, Math.ceil(filtered.length / HUB_PAGE_SIZE))
+    const page = Math.min(Math.max(currentFeedQuery.value.page, 1), totalPages.value)
+    const start = (page - 1) * HUB_PAGE_SIZE
+    articles.value = filtered.slice(start, start + HUB_PAGE_SIZE)
+    return
+  }
+
+  const params = {
+    articleStatus: 'APPROVED',
+    page: Math.max(currentFeedQuery.value.page - 1, 0),
+    size: currentFeedQuery.value.pageSize ?? HUB_PAGE_SIZE,
+  }
+
+  if (currentFeedQuery.value.categoryKey === 'popular') {
+    params.sort = 'popular'
+  } else if (currentFeedQuery.value.categoryKey !== 'all') {
+    params.category = CATEGORY_VALUE_MAP[currentFeedQuery.value.categoryKey]
+  }
+
+  if (currentFeedQuery.value.keyword) {
+    params.searchType = 'articleTitle'
+    params.keyword = currentFeedQuery.value.keyword
+  }
+
+  try {
+    const res = await knowledgeArticleApi.getPagedArticles(params)
+    const pageData = res.data.data ?? {}
+    totalPages.value = Math.max(pageData.totalPages ?? 0, 1)
+    articles.value = (pageData.items ?? []).map(mapToFeedItem)
+  } catch (e) {
+    console.error('[KMS] 문서 페이지 목록 로드 실패:', e)
+    articles.value = []
+    totalPages.value = 1
   }
 }
 
@@ -203,7 +256,7 @@ async function handleAddArticle(data) {
       content: data.content,
     })
     showWriteModal.value = false
-    await loadArticles()
+    await loadArticlesPage()
   } catch (e) {
     console.error('[KMS] DL 문서 등록 실패:', e)
   }
@@ -218,7 +271,7 @@ async function handleSaveDraft(data) {
       content: data.content,
     })
     showWriteModal.value = false
-    await loadArticles()
+    await loadArticlesPage()
   } catch (e) {
     console.error('[KMS] DL 임시저장 실패:', e)
   }
@@ -288,7 +341,7 @@ async function toggleBookmark(article) {
       await knowledgeArticleApi.addBookmark(article.id)
     }
 
-    await Promise.allSettled([loadArticles(), loadBookmarks()])
+    await Promise.allSettled([loadBookmarks(), loadArticlesPage()])
 
     if (selectedArticle.value?.id === article.id) {
       selectedArticle.value = { ...selectedArticle.value, isBookmarked: !article.isBookmarked }
@@ -297,6 +350,10 @@ async function toggleBookmark(article) {
     console.error('[KMS] 북마크 처리 실패:', e)
     window.alert('북마크 처리에 실패했습니다.')
   }
+}
+
+function handleFeedQueryChange(query) {
+  void loadArticlesPage(query)
 }
 
 </script>
@@ -309,10 +366,12 @@ async function toggleBookmark(article) {
       <KnowledgeHubFeed
         :categories="knowledgeCategories"
         :articles="visibleArticles"
+        :total-pages="totalPages"
         :page-query-ready="isPageQueryReady"
         @open-write="showWriteModal = true"
         @open-detail="openDetailModal"
         @toggle-bookmark="toggleBookmark"
+        @query-change="handleFeedQueryChange"
       />
 
       <div class="dl-knowledge-view__sidebar">

--- a/src/views/departmentleader/DepartmentLeaderKnowledgeHubView.vue
+++ b/src/views/departmentleader/DepartmentLeaderKnowledgeHubView.vue
@@ -340,7 +340,7 @@ async function toggleBookmark(article) {
   min-width: 0;
   min-height: 0;
   height: calc(100vh - 80px);
-  padding: 12px 10px 18px;
+  padding: 20px 28px 28px;
   box-sizing: border-box;
   background: var(--color-bg-app);
   overflow: hidden;
@@ -348,21 +348,33 @@ async function toggleBookmark(article) {
 
 .dl-knowledge-view__grid {
   display: grid;
-  grid-template-columns: minmax(0, 1.55fr) minmax(300px, 0.92fr);
-  gap: 16px;
-  align-items: stretch;
+  grid-template-columns: minmax(0, 1.38fr) minmax(340px, 1fr);
+  gap: 20px;
+  align-items: start;
   height: 100%;
   min-height: 0;
   overflow: visible;
 }
 
 .dl-knowledge-view__sidebar {
-  display: grid;
-  grid-template-rows: auto minmax(0, 1fr) auto;
+  display: flex;
+  flex-direction: column;
   gap: 16px;
   height: 100%;
+  width: 100%;
   min-height: 0;
   overflow: visible;
+}
+
+@media (max-width: 1320px) {
+  .dl-knowledge-view {
+    padding: 16px 18px 24px;
+  }
+
+  .dl-knowledge-view__grid {
+    grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.92fr);
+    gap: 16px;
+  }
 }
 
 @media (max-width: 1180px) {

--- a/src/views/departmentleader/DepartmentLeaderKnowledgeHubView.vue
+++ b/src/views/departmentleader/DepartmentLeaderKnowledgeHubView.vue
@@ -7,6 +7,7 @@ import KnowledgeHubAiPanel from '@/components/kms/common/knowledge-hub/Knowledge
 import KnowledgeDetailModal from '@/components/kms/common/knowledge-hub/KnowledgeDetailModal.vue'
 import KnowledgeHubContributors from "@/components/kms/common/knowledge-hub/KnowledgeHubContributors.vue";
 import knowledgeArticleApi from '@/services/knowledgeArticleApi'
+import fetchAllKmsArticles from '@/utils/fetchAllKmsArticles'
 
 
 function formatTrend(value, digits = 0) {
@@ -57,6 +58,7 @@ function mapToContributor(dto, index) {
     tier:        dto.employeeTier ?? 'C',
     articles:    dto.articleCount ?? 0,
     views:       dto.totalViewCount ?? 0,
+    score:       dto.contributionScore ?? 0,
     avatarColor: '#5B4FCF',
   }
 }
@@ -149,12 +151,10 @@ async function loadHubStats() {
 
 async function loadArticles() {
   try {
-    const res = await knowledgeArticleApi.getArticles({
-      page: 0,
-      size: 20,
+    const articleDtos = await fetchAllKmsArticles(knowledgeArticleApi.getArticles, {
       articleStatus: 'APPROVED',
     })
-    articles.value = (res.data.data ?? [])
+    articles.value = articleDtos
       .filter((dto) => dto.articleStatus === 'APPROVED')
       .map(mapToFeedItem)
   } catch (e) {

--- a/src/views/departmentleader/DepartmentLeaderKnowledgeHubView.vue
+++ b/src/views/departmentleader/DepartmentLeaderKnowledgeHubView.vue
@@ -92,6 +92,7 @@ const hubStats          = ref({
   newThisMonthChange: 0,
   averageViewCountChange: 0,
 })
+const isPageQueryReady = ref(false)
 
 const summaryCards = computed(() => [
   { key: 'totalArticles', label: '등록 지식 수', value: `${Number(hubStats.value.totalArticles ?? 0).toLocaleString()}건`, helper: '' },
@@ -120,6 +121,7 @@ onMounted(async () => {
     loadContributors(),
     loadRecommendations(),
   ])
+  isPageQueryReady.value = true
 })
 
 const visibleArticles = computed(() => {
@@ -307,6 +309,7 @@ async function toggleBookmark(article) {
       <KnowledgeHubFeed
         :categories="knowledgeCategories"
         :articles="visibleArticles"
+        :page-query-ready="isPageQueryReady"
         @open-write="showWriteModal = true"
         @open-detail="openDetailModal"
         @toggle-bookmark="toggleBookmark"

--- a/src/views/teamleader/TeamLeaderKnowledgeHubView.vue
+++ b/src/views/teamleader/TeamLeaderKnowledgeHubView.vue
@@ -349,7 +349,7 @@ async function toggleBookmark(article) {
   min-width: 0;
   min-height: 0;
   height: calc(100vh - 80px);
-  padding: 12px 10px 18px;
+  padding: 20px 28px 28px;
   box-sizing: border-box;
   background: var(--color-bg-app);
   overflow: hidden;
@@ -357,21 +357,33 @@ async function toggleBookmark(article) {
 
 .teamleader-knowledge-view__grid {
   display: grid;
-  grid-template-columns: minmax(0, 1.55fr) minmax(300px, 0.92fr);
-  gap: 16px;
-  align-items: stretch;
+  grid-template-columns: minmax(0, 1.38fr) minmax(340px, 1fr);
+  gap: 20px;
+  align-items: start;
   height: 100%;
   min-height: 0;
   overflow: visible;
 }
 
 .teamleader-knowledge-view__sidebar {
-  display: grid;
-  grid-template-rows: auto minmax(0, 1fr) auto;
+  display: flex;
+  flex-direction: column;
   gap: 16px;
   height: 100%;
+  width: 100%;
   min-height: 0;
   overflow: visible;
+}
+
+@media (max-width: 1320px) {
+  .teamleader-knowledge-view {
+    padding: 16px 18px 24px;
+  }
+
+  .teamleader-knowledge-view__grid {
+    grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.92fr);
+    gap: 16px;
+  }
 }
 
 @media (max-width: 1180px) {

--- a/src/views/teamleader/TeamLeaderKnowledgeHubView.vue
+++ b/src/views/teamleader/TeamLeaderKnowledgeHubView.vue
@@ -93,6 +93,7 @@ const hubStats         = ref({
   newThisMonthChange: 0,
   averageViewCountChange: 0,
 })
+const isPageQueryReady = ref(false)
 
 const summaryCards = computed(() => [
   { key: 'totalArticles', label: '등록 지식 수', value: `${Number(hubStats.value.totalArticles ?? 0).toLocaleString()}건`, helper: '' },
@@ -121,6 +122,7 @@ onMounted(async () => {
     loadContributors(),
     loadRecommendations(),
   ])
+  isPageQueryReady.value = true
 })
 
 const visibleArticles = computed(() => {
@@ -308,6 +310,7 @@ async function toggleBookmark(article) {
       <KnowledgeHubFeed
         :categories="knowledgeCategories"
         :articles="visibleArticles"
+        :page-query-ready="isPageQueryReady"
         @open-write="showWriteModal = true"
         @open-detail="openDetailModal"
         @toggle-bookmark="toggleBookmark"

--- a/src/views/teamleader/TeamLeaderKnowledgeHubView.vue
+++ b/src/views/teamleader/TeamLeaderKnowledgeHubView.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
-import { ARTICLE_CATEGORY_LABEL } from '@/constants'
+import { useRoute } from 'vue-router'
+import { ARTICLE_CATEGORY_LABEL, ARTICLE_CATEGORY_OPTIONS } from '@/constants'
 import KnowledgeHubHeader from '@/components/kms/common/knowledge-hub/KnowledgeHubHeader.vue'
 import KnowledgeHubFeed from '@/components/kms/common/knowledge-hub/KnowledgeHubFeed.vue'
 import KnowledgeHubContributors from '@/components/kms/common/knowledge-hub/KnowledgeHubContributors.vue'
@@ -8,7 +9,20 @@ import KnowledgeHubAiPanel from '@/components/kms/common/knowledge-hub/Knowledge
 import KnowledgeWriteModalWrapper from '@/components/kms/common/knowledge-hub/KnowledgeWriteModalWrapper.vue'
 import KnowledgeDetailModal from '@/components/kms/common/knowledge-hub/KnowledgeDetailModal.vue'
 import knowledgeArticleApi from '@/services/knowledgeArticleApi'
-import fetchAllKmsArticles from '@/utils/fetchAllKmsArticles'
+
+const HUB_PAGE_SIZE = 4
+const CATEGORY_VALUE_MAP = Object.fromEntries(
+  ARTICLE_CATEGORY_OPTIONS.map((option) => [option.label, option.value]),
+)
+const route = useRoute()
+
+function normalizePageQuery(value) {
+  const parsed = Number.parseInt(Array.isArray(value) ? value[0] : value, 10)
+  if (Number.isNaN(parsed) || parsed < 1) {
+    return 1
+  }
+  return parsed
+}
 
 
 function formatTrend(value, digits = 0) {
@@ -86,6 +100,7 @@ const articles         = ref([])
 const bookmarkArticles = ref([])
 const contributors     = ref([])
 const aiRecommendations = ref([])
+const totalPages       = ref(1)
 const hubStats         = ref({
   totalArticles: 0,
   newThisMonth: 0,
@@ -94,6 +109,12 @@ const hubStats         = ref({
   averageViewCountChange: 0,
 })
 const isPageQueryReady = ref(false)
+const currentFeedQuery = ref({
+  categoryKey: 'all',
+  keyword: '',
+  page: normalizePageQuery(route.query.p),
+  pageSize: HUB_PAGE_SIZE,
+})
 
 const summaryCards = computed(() => [
   { key: 'totalArticles', label: '등록 지식 수', value: `${Number(hubStats.value.totalArticles ?? 0).toLocaleString()}건`, helper: '' },
@@ -117,7 +138,7 @@ const summaryCards = computed(() => [
 onMounted(async () => {
   await Promise.allSettled([
     loadHubStats(),
-    loadArticles(),
+    loadArticlesPage(),
     loadBookmarks(),
     loadContributors(),
     loadRecommendations(),
@@ -125,17 +146,7 @@ onMounted(async () => {
   isPageQueryReady.value = true
 })
 
-const visibleArticles = computed(() => {
-  const merged = new Map()
-  for (const article of articles.value) {
-    merged.set(article.id, article)
-  }
-  for (const article of bookmarkArticles.value) {
-    const existing = merged.get(article.id)
-    merged.set(article.id, existing ? { ...existing, ...article, isBookmarked: true } : article)
-  }
-  return [...merged.values()]
-})
+const visibleArticles = computed(() => articles.value)
 
 async function loadHubStats() {
   try {
@@ -152,19 +163,6 @@ async function loadHubStats() {
   }
 }
 
-async function loadArticles() {
-  try {
-    const articleDtos = await fetchAllKmsArticles(knowledgeArticleApi.getArticles, {
-      articleStatus: 'APPROVED',
-    })
-    articles.value = articleDtos
-      .filter((dto) => dto.articleStatus === 'APPROVED')
-      .map(mapToFeedItem)
-  } catch (e) {
-    console.error('[KMS] 문서 목록 로드 실패:', e)
-  }
-}
-
 async function loadBookmarks() {
   try {
     const res = await knowledgeArticleApi.getMyBookmarks()
@@ -174,6 +172,61 @@ async function loadBookmarks() {
       .map((item) => ({ ...item, isBookmarked: true }))
   } catch (e) {
     console.error('[KMS] 북마크 목록 로드 실패:', e)
+  }
+}
+
+function filterBookmarkArticles(keyword = '') {
+  const normalizedKeyword = keyword.trim().toLowerCase()
+  if (!normalizedKeyword) {
+    return bookmarkArticles.value
+  }
+
+  return bookmarkArticles.value.filter((article) =>
+    [article.title, article.equipment, article.author, article.category]
+      .join(' ')
+      .toLowerCase()
+      .includes(normalizedKeyword),
+  )
+}
+
+async function loadArticlesPage(query = currentFeedQuery.value) {
+  currentFeedQuery.value = { ...currentFeedQuery.value, ...query }
+
+  if (currentFeedQuery.value.categoryKey === 'bookmarked') {
+    const filtered = filterBookmarkArticles(currentFeedQuery.value.keyword)
+    totalPages.value = Math.max(1, Math.ceil(filtered.length / HUB_PAGE_SIZE))
+    const page = Math.min(Math.max(currentFeedQuery.value.page, 1), totalPages.value)
+    const start = (page - 1) * HUB_PAGE_SIZE
+    articles.value = filtered.slice(start, start + HUB_PAGE_SIZE)
+    return
+  }
+
+  const params = {
+    articleStatus: 'APPROVED',
+    page: Math.max(currentFeedQuery.value.page - 1, 0),
+    size: currentFeedQuery.value.pageSize ?? HUB_PAGE_SIZE,
+  }
+
+  if (currentFeedQuery.value.categoryKey === 'popular') {
+    params.sort = 'popular'
+  } else if (currentFeedQuery.value.categoryKey !== 'all') {
+    params.category = CATEGORY_VALUE_MAP[currentFeedQuery.value.categoryKey]
+  }
+
+  if (currentFeedQuery.value.keyword) {
+    params.searchType = 'articleTitle'
+    params.keyword = currentFeedQuery.value.keyword
+  }
+
+  try {
+    const res = await knowledgeArticleApi.getPagedArticles(params)
+    const pageData = res.data.data ?? {}
+    totalPages.value = Math.max(pageData.totalPages ?? 0, 1)
+    articles.value = (pageData.items ?? []).map(mapToFeedItem)
+  } catch (e) {
+    console.error('[KMS] 문서 페이지 목록 로드 실패:', e)
+    articles.value = []
+    totalPages.value = 1
   }
 }
 
@@ -204,7 +257,7 @@ async function handleAddArticle(data) {
       content: data.content,
     })
     showWriteModal.value = false
-    await loadArticles()
+    await loadArticlesPage()
   } catch (e) {
     console.error('[KMS] TL 문서 등록 실패:', e)
   }
@@ -219,7 +272,7 @@ async function handleSaveDraft(data) {
       content: data.content,
     })
     showWriteModal.value = false
-    await loadArticles()
+    await loadArticlesPage()
   } catch (e) {
     console.error('[KMS] TL 임시저장 실패:', e)
   }
@@ -289,7 +342,7 @@ async function toggleBookmark(article) {
       await knowledgeArticleApi.addBookmark(article.id)
     }
 
-    await Promise.allSettled([loadArticles(), loadBookmarks()])
+    await Promise.allSettled([loadBookmarks(), loadArticlesPage()])
 
     if (selectedArticle.value?.id === article.id) {
       selectedArticle.value = { ...selectedArticle.value, isBookmarked: !article.isBookmarked }
@@ -298,6 +351,10 @@ async function toggleBookmark(article) {
     console.error('[KMS] 북마크 처리 실패:', e)
     window.alert('북마크 처리에 실패했습니다.')
   }
+}
+
+function handleFeedQueryChange(query) {
+  void loadArticlesPage(query)
 }
 
 </script>
@@ -310,10 +367,12 @@ async function toggleBookmark(article) {
       <KnowledgeHubFeed
         :categories="knowledgeCategories"
         :articles="visibleArticles"
+        :total-pages="totalPages"
         :page-query-ready="isPageQueryReady"
         @open-write="showWriteModal = true"
         @open-detail="openDetailModal"
         @toggle-bookmark="toggleBookmark"
+        @query-change="handleFeedQueryChange"
       />
 
       <div class="teamleader-knowledge-view__sidebar">

--- a/src/views/teamleader/TeamLeaderKnowledgeHubView.vue
+++ b/src/views/teamleader/TeamLeaderKnowledgeHubView.vue
@@ -8,6 +8,7 @@ import KnowledgeHubAiPanel from '@/components/kms/common/knowledge-hub/Knowledge
 import KnowledgeWriteModalWrapper from '@/components/kms/common/knowledge-hub/KnowledgeWriteModalWrapper.vue'
 import KnowledgeDetailModal from '@/components/kms/common/knowledge-hub/KnowledgeDetailModal.vue'
 import knowledgeArticleApi from '@/services/knowledgeArticleApi'
+import fetchAllKmsArticles from '@/utils/fetchAllKmsArticles'
 
 
 function formatTrend(value, digits = 0) {
@@ -58,6 +59,7 @@ function mapToContributor(dto, index) {
     tier:        dto.employeeTier ?? 'C',
     articles:    dto.articleCount ?? 0,
     views:       dto.totalViewCount ?? 0,
+    score:       dto.contributionScore ?? 0,
     avatarColor: '#5B4FCF',
   }
 }
@@ -150,12 +152,10 @@ async function loadHubStats() {
 
 async function loadArticles() {
   try {
-    const res = await knowledgeArticleApi.getArticles({
-      page: 0,
-      size: 20,
+    const articleDtos = await fetchAllKmsArticles(knowledgeArticleApi.getArticles, {
       articleStatus: 'APPROVED',
     })
-    articles.value = (res.data.data ?? [])
+    articles.value = articleDtos
       .filter((dto) => dto.articleStatus === 'APPROVED')
       .map(mapToFeedItem)
   } catch (e) {

--- a/src/views/worker/WorkerKnowledgeHubView.vue
+++ b/src/views/worker/WorkerKnowledgeHubView.vue
@@ -8,6 +8,7 @@ import WorkerKnowledgeAddModal from '@/components/kms/worker/my-knowledge-manage
 import KnowledgeDetailModal from '@/components/kms/common/knowledge-hub/KnowledgeDetailModal.vue'
 import { ARTICLE_CATEGORY_LABEL } from '@/constants'
 import knowledgeArticleApi from '@/services/knowledgeArticleApi'
+import fetchAllKmsArticles from '@/utils/fetchAllKmsArticles'
 
 
 function formatTrend(value, digits = 0) {
@@ -58,6 +59,7 @@ function mapToContributor(dto, index) {
     tier: dto.employeeTier ?? 'C',
     articles: dto.articleCount ?? 0,
     views: dto.totalViewCount ?? 0,
+    score: dto.contributionScore ?? 0,
     avatarColor: '#5B4FCF',
   }
 }
@@ -136,12 +138,10 @@ async function loadHubStats() {
 
 async function loadArticles() {
   try {
-    const res = await knowledgeArticleApi.getArticles({
-      page: 0,
-      size: 20,
+    const articleDtos = await fetchAllKmsArticles(knowledgeArticleApi.getArticles, {
       articleStatus: 'APPROVED',
     })
-    knowledgeArticles.value = (res.data.data ?? [])
+    knowledgeArticles.value = articleDtos
       .filter((dto) => dto.articleStatus === 'APPROVED')
       .map(mapToFeedItem)
   } catch (e) {

--- a/src/views/worker/WorkerKnowledgeHubView.vue
+++ b/src/views/worker/WorkerKnowledgeHubView.vue
@@ -97,6 +97,7 @@ const hubStats          = ref({
   averageViewCountChange: 0,
 })
 const isArticleSubmitting = ref(false)
+const isPageQueryReady = ref(false)
 
 // ── 데이터 로드 ────────────────────────────────────────────────
 onMounted(async () => {
@@ -107,6 +108,7 @@ onMounted(async () => {
     loadContributors(),
     loadRecommendations(),
   ])
+  isPageQueryReady.value = true
 })
 
 const visibleArticles = computed(() => {
@@ -343,6 +345,7 @@ function closeModal() {
       <KnowledgeHubFeed
         :categories="knowledgeCategories"
         :articles="visibleArticles"
+        :page-query-ready="isPageQueryReady"
         @open-write="showAddModal = true"
         @open-detail="openDetailModal"
         @toggle-bookmark="toggleBookmark"

--- a/src/views/worker/WorkerKnowledgeHubView.vue
+++ b/src/views/worker/WorkerKnowledgeHubView.vue
@@ -1,15 +1,28 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
 import KnowledgeHubHeader from '@/components/kms/common/knowledge-hub/KnowledgeHubHeader.vue'
 import KnowledgeHubFeed from '@/components/kms/common/knowledge-hub/KnowledgeHubFeed.vue'
 import KnowledgeHubContributors from '@/components/kms/common/knowledge-hub/KnowledgeHubContributors.vue'
 import KnowledgeHubAiPanel from '@/components/kms/common/knowledge-hub/KnowledgeHubAiPanel.vue'
 import WorkerKnowledgeAddModal from '@/components/kms/worker/my-knowledge-management/WorkerKnowledgeAddModal.vue'
 import KnowledgeDetailModal from '@/components/kms/common/knowledge-hub/KnowledgeDetailModal.vue'
-import { ARTICLE_CATEGORY_LABEL } from '@/constants'
+import { ARTICLE_CATEGORY_LABEL, ARTICLE_CATEGORY_OPTIONS } from '@/constants'
 import knowledgeArticleApi from '@/services/knowledgeArticleApi'
-import fetchAllKmsArticles from '@/utils/fetchAllKmsArticles'
 
+const HUB_PAGE_SIZE = 4
+const CATEGORY_VALUE_MAP = Object.fromEntries(
+  ARTICLE_CATEGORY_OPTIONS.map((option) => [option.label, option.value]),
+)
+const route = useRoute()
+
+function normalizePageQuery(value) {
+  const parsed = Number.parseInt(Array.isArray(value) ? value[0] : value, 10)
+  if (Number.isNaN(parsed) || parsed < 1) {
+    return 1
+  }
+  return parsed
+}
 
 function formatTrend(value, digits = 0) {
   const numeric = Number(value ?? 0)
@@ -89,6 +102,7 @@ const knowledgeArticles = ref([])
 const bookmarkArticles  = ref([])
 const monthlyRanking    = ref([])
 const aiRecommendations = ref([])
+const totalPages        = ref(1)
 const hubStats          = ref({
   totalArticles: 0,
   newThisMonth: 0,
@@ -98,30 +112,25 @@ const hubStats          = ref({
 })
 const isArticleSubmitting = ref(false)
 const isPageQueryReady = ref(false)
+const currentFeedQuery = ref({
+  categoryKey: 'all',
+  keyword: '',
+  page: normalizePageQuery(route.query.p),
+  pageSize: HUB_PAGE_SIZE,
+})
 
 // ── 데이터 로드 ────────────────────────────────────────────────
 onMounted(async () => {
   await Promise.allSettled([
     loadHubStats(),
-    loadArticles(),
+    loadArticlesPage(),
     loadBookmarks(),
     loadContributors(),
     loadRecommendations(),
   ])
   isPageQueryReady.value = true
 })
-
-const visibleArticles = computed(() => {
-  const merged = new Map()
-  for (const article of knowledgeArticles.value) {
-    merged.set(article.id, article)
-  }
-  for (const article of bookmarkArticles.value) {
-    const existing = merged.get(article.id)
-    merged.set(article.id, existing ? { ...existing, ...article, isBookmarked: true } : article)
-  }
-  return [...merged.values()]
-})
+const visibleArticles = computed(() => knowledgeArticles.value)
 
 async function loadHubStats() {
   try {
@@ -138,19 +147,6 @@ async function loadHubStats() {
   }
 }
 
-async function loadArticles() {
-  try {
-    const articleDtos = await fetchAllKmsArticles(knowledgeArticleApi.getArticles, {
-      articleStatus: 'APPROVED',
-    })
-    knowledgeArticles.value = articleDtos
-      .filter((dto) => dto.articleStatus === 'APPROVED')
-      .map(mapToFeedItem)
-  } catch (e) {
-    console.error('[KMS] 문서 목록 로드 실패:', e)
-  }
-}
-
 async function loadBookmarks() {
   try {
     const res = await knowledgeArticleApi.getMyBookmarks()
@@ -160,6 +156,61 @@ async function loadBookmarks() {
       .map((item) => ({ ...item, isBookmarked: true }))
   } catch (e) {
     console.error('[KMS] 북마크 목록 로드 실패:', e)
+  }
+}
+
+function filterBookmarkArticles(keyword = '') {
+  const normalizedKeyword = keyword.trim().toLowerCase()
+  if (!normalizedKeyword) {
+    return bookmarkArticles.value
+  }
+
+  return bookmarkArticles.value.filter((article) =>
+    [article.title, article.equipment, article.author, article.category]
+      .join(' ')
+      .toLowerCase()
+      .includes(normalizedKeyword),
+  )
+}
+
+async function loadArticlesPage(query = currentFeedQuery.value) {
+  currentFeedQuery.value = { ...currentFeedQuery.value, ...query }
+
+  if (currentFeedQuery.value.categoryKey === 'bookmarked') {
+    const filtered = filterBookmarkArticles(currentFeedQuery.value.keyword)
+    totalPages.value = Math.max(1, Math.ceil(filtered.length / HUB_PAGE_SIZE))
+    const page = Math.min(Math.max(currentFeedQuery.value.page, 1), totalPages.value)
+    const start = (page - 1) * HUB_PAGE_SIZE
+    knowledgeArticles.value = filtered.slice(start, start + HUB_PAGE_SIZE)
+    return
+  }
+
+  const params = {
+    articleStatus: 'APPROVED',
+    page: Math.max(currentFeedQuery.value.page - 1, 0),
+    size: currentFeedQuery.value.pageSize ?? HUB_PAGE_SIZE,
+  }
+
+  if (currentFeedQuery.value.categoryKey === 'popular') {
+    params.sort = 'popular'
+  } else if (currentFeedQuery.value.categoryKey !== 'all') {
+    params.category = CATEGORY_VALUE_MAP[currentFeedQuery.value.categoryKey]
+  }
+
+  if (currentFeedQuery.value.keyword) {
+    params.searchType = 'articleTitle'
+    params.keyword = currentFeedQuery.value.keyword
+  }
+
+  try {
+    const res = await knowledgeArticleApi.getPagedArticles(params)
+    const pageData = res.data.data ?? {}
+    totalPages.value = Math.max(pageData.totalPages ?? 0, 1)
+    knowledgeArticles.value = (pageData.items ?? []).map(mapToFeedItem)
+  } catch (e) {
+    console.error('[KMS] 문서 페이지 목록 로드 실패:', e)
+    knowledgeArticles.value = []
+    totalPages.value = 1
   }
 }
 
@@ -222,7 +273,7 @@ async function handleAddArticle(data) {
       content:     data.content,
     })
     showAddModal.value = false
-    await loadArticles()
+    await loadArticlesPage()
   } catch (e) {
     console.error('[KMS] 문서 등록 실패:', e)
     window.alert(e.response?.data?.message ?? '문서 등록에 실패했습니다.')
@@ -244,7 +295,7 @@ async function handleSaveDraft(data) {
       content:     data.content,
     })
     showAddModal.value = false
-    await loadArticles()
+    await loadArticlesPage()
   } catch (e) {
     console.error('[KMS] 임시저장 실패:', e)
     window.alert(e.response?.data?.message ?? '임시 저장에 실패했습니다.')
@@ -319,7 +370,7 @@ async function toggleBookmark(article) {
       await knowledgeArticleApi.addBookmark(article.id)
     }
 
-    await Promise.allSettled([loadArticles(), loadBookmarks()])
+    await Promise.allSettled([loadBookmarks(), loadArticlesPage()])
 
     if (selectedArticle.value?.id === article.id) {
       selectedArticle.value = { ...selectedArticle.value, isBookmarked: !article.isBookmarked }
@@ -333,6 +384,10 @@ async function toggleBookmark(article) {
 function closeModal() {
   showAddModal.value = false
 }
+
+function handleFeedQueryChange(query) {
+  void loadArticlesPage(query)
+}
 </script>
 
 <template>
@@ -345,10 +400,12 @@ function closeModal() {
       <KnowledgeHubFeed
         :categories="knowledgeCategories"
         :articles="visibleArticles"
+        :total-pages="totalPages"
         :page-query-ready="isPageQueryReady"
         @open-write="showAddModal = true"
         @open-detail="openDetailModal"
         @toggle-bookmark="toggleBookmark"
+        @query-change="handleFeedQueryChange"
       />
 
       <div class="kh-sidebar">

--- a/src/views/worker/WorkerMyKnowledgeManagementView.vue
+++ b/src/views/worker/WorkerMyKnowledgeManagementView.vue
@@ -337,6 +337,7 @@ async function handleRestoreArticle(article) {
       v-if="showDetailModal && selectedArticle"
       :article="selectedArticle"
       @close="showDetailModal = false"
+      @edit="showDetailModal = false; openEditModal($event)"
       @delete="handleDeleteArticle"
       @restore="handleRestoreArticle"
     />


### PR DESCRIPTION
  - WORKER 지식 등록/수정 모달의 음성 작성 기능을 복구
->   - WORKER 지식 등록 모달에 음성으로 작성 버튼은 있었음
 그런데 클릭 이벤트와 SpeechRecognition 실행 로직이 없어서 아무 동작을 안 했음
 수정 모달은 음성 UI 자체가 빠져 있었음


  - 추천학습/추천 패널과 TL/DL 지식허브 레이아웃을 역할별 화면에서 더 일관되게 보이도록 조정
  - TL/DL 승인 상세 패널의 불필요한 경력 표시를 제거하고 작성자 정보 가독성을 개선
  - ADMIN KMS 지식허브를 다른 역할과 유사한 톤으로 정리하고, 검색/페이지네이션을 추가