### PR TITLE
feat: 평가 화면 기간 연동 및 마감 조회 처리 정리

### DIFF
--- a/src/components/hr/hrmanager/evaluation-approval/HRMApprovalDetail.vue
+++ b/src/components/hr/hrmanager/evaluation-approval/HRMApprovalDetail.vue
@@ -60,6 +60,15 @@ watch(() => props.item?.id, () => {
             {{ item.detail?.secondStageComment || '2차 평가 내용이 없습니다.' }}
           </p>
         </div>
+        <div
+          v-if="readonly && item.detail?.hrConfirmComment"
+          class="hrm-eval-summary__comment-card hrm-eval-summary__comment-card--final"
+        >
+          <p class="hrm-eval-summary__comment-label hrm-eval-summary__comment-label--final">HR 최종 확정 코멘트</p>
+          <p class="hrm-eval-summary__comment">
+            {{ item.detail.hrConfirmComment }}
+          </p>
+        </div>
       </section>
     </template>
 
@@ -203,26 +212,38 @@ watch(() => props.item?.id, () => {
   display: flex;
   gap: 10px;
   flex-wrap: wrap;
+  align-items: stretch;
 }
 
 .hrm-eval-summary__score {
-  min-width: 72px;
+  width: 84px;
+  min-width: 84px;
+  min-height: 78px;
   padding: 10px 12px;
   border-radius: 14px;
   background: rgba(255, 255, 255, 0.92);
   border: 1px solid #e1dbff;
   text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
 }
 
 .hrm-eval-summary__score strong {
   display: block;
   font-size: 20px;
   color: var(--color-primary-800);
+  line-height: 1;
 }
 
 .hrm-eval-summary__score span {
+  display: block;
+  margin-top: 6px;
   font-size: 12px;
   color: var(--color-text-muted);
+  line-height: 1;
 }
 
 .hrm-eval-summary__score--second {
@@ -242,6 +263,11 @@ watch(() => props.item?.id, () => {
 
 .hrm-eval-summary__comment-card--second {
   border-color: #c7deff;
+}
+
+.hrm-eval-summary__comment-card--final {
+  border-color: #d8d1ff;
+  background: #f5f1ff;
 }
 
 .hrm-eval-summary--appeal .hrm-eval-summary__header {
@@ -312,6 +338,10 @@ watch(() => props.item?.id, () => {
 
 .hrm-eval-summary__comment-label--second {
   color: #3a7bd5;
+}
+
+.hrm-eval-summary__comment-label--final {
+  color: #5f50d6;
 }
 
 .hrm-eval-summary__comment {

--- a/src/services/departmentleader/evaluationApi.js
+++ b/src/services/departmentleader/evaluationApi.js
@@ -26,8 +26,10 @@ export function updateDlEvaluation(
 }
 
 /** DL 이의신청 목록 조회 */
-export function fetchDlAppeals() {
-  return hrApi.get('/api/v1/hr/department-leader/appeals')
+export function fetchDlAppeals(periodId) {
+  return hrApi.get('/api/v1/hr/department-leader/appeals', {
+    params: periodId ? { evaluationPeriodId: periodId } : {},
+  })
 }
 
 /** DL 이의신청 상세 조회 */

--- a/src/services/teamleader/evaluationApi.js
+++ b/src/services/teamleader/evaluationApi.js
@@ -19,8 +19,10 @@ export function updateTlEvaluation(evaluateeId, { status, evaluationPeriodId, ev
 }
 
 /** TL 이의신청 목록 조회 */
-export function fetchTlAppeals() {
-  return hrApi.get('/api/v1/hr/team-leader/appeals')
+export function fetchTlAppeals(periodId) {
+  return hrApi.get('/api/v1/hr/team-leader/appeals', {
+    params: periodId ? { evaluationPeriodId: periodId } : {},
+  })
 }
 
 /** TL 이의신청 상세 조회 */

--- a/src/services/workerHrApi.js
+++ b/src/services/workerHrApi.js
@@ -619,9 +619,14 @@ function toEvalStatusViewModel(
   const quantitativeScore = roundToOne(quantitative?.sQuant)
   const qualitativeScore = roundToOne(qualitative?.score)
   const quarterTotals = buildQuarterPointTotals(pointHistory)
-  const overallScore = quarterTotals.length
-    ? quarterTotals[quarterTotals.length - 1].total
-    : null
+  const overallScore = (() => {
+    if (!quarterTotals.length) return null
+    if (status?.evalYear != null && status?.evalSequence != null) {
+      const targetKey = `${status.evalYear}-Q${status.evalSequence}`
+      return quarterTotals.find((q) => q.key === targetKey)?.total ?? null
+    }
+    return quarterTotals[quarterTotals.length - 1].total
+  })()
   const previousHistory = history.find((item) => item?.evalPeriodId !== status?.evalPeriodId) ?? null
 
   const quantitativeDiff = previousHistory ? roundToOne(quantitativeScore - toNumber(previousHistory.quantScore)) : 0

--- a/src/utils/evaluationPeriod.js
+++ b/src/utils/evaluationPeriod.js
@@ -16,9 +16,11 @@ function resolveYearAndMonth(evalYear) {
 }
 
 export function formatEvaluationPeriodLabel(
-  { evalYear, evalSequence } = {},
+  period,
   { fallback = '-' } = {},
 ) {
+  const { evalYear, evalSequence } = period ?? {}
+
   if (evalYear == null || evalSequence == null) return fallback
 
   const { year, month } = resolveYearAndMonth(evalYear)

--- a/src/views/departmentleader/DepartmentLeaderSecondEvaluationView.vue
+++ b/src/views/departmentleader/DepartmentLeaderSecondEvaluationView.vue
@@ -17,10 +17,6 @@ const evalPeriodId = ref(null)
 const periodInfo = ref(null)
 const toast = ref({ show: false, message: '', type: 'success' })
 const activeTab = ref('evaluation')
-const modeTabs = [
-  { key: 'evaluation', label: '평가 관리' },
-  { key: 'appeal', label: '이의신청' },
-]
 const appealSummaries = ref([])
 const selectedAppealId = ref(null)
 const selectedAppealDetail = ref(null)
@@ -126,12 +122,18 @@ const periodLabel = computed(() => {
   const label = formatEvaluationPeriodLabel(periodInfo.value, { fallback: null })
   return label ? `${label} 평가` : null
 })
+const isClosedPeriod = computed(() => Boolean(periodInfo.value?.status) && periodInfo.value.status !== 'IN_PROGRESS')
 let toastTimer = null
 
 const totalCount = computed(() => members.value.length)
 const submittedCount = computed(() => members.value.filter((m) => m.status === 'submitted').length)
 const progressPercent = computed(() => (totalCount.value > 0 ? (submittedCount.value / totalCount.value) * 100 : 0))
-const isSubmitted = computed(() => selectedMember.value?.status === 'submitted')
+const isSubmitted = computed(() => isClosedPeriod.value || selectedMember.value?.status === 'submitted')
+const evaluationPendingCount = computed(() => (isClosedPeriod.value ? 0 : members.value.filter((m) => m.status !== 'submitted').length))
+const modeTabs = computed(() => [
+  { key: 'evaluation', label: '평가 관리', count: evaluationPendingCount.value },
+  { key: 'appeal', label: '이의신청', count: appealSummaries.value.length },
+])
 
 const AVATAR_COLORS = ['#5f50d6', '#269063', '#c08b00', '#b03060', '#2070b0', '#806030']
 
@@ -181,6 +183,7 @@ async function loadTargets() {
       evalSequence: data.evalSequence,
       startDate: data.startDate,
       endDate: data.endDate,
+      status: data.status,
     }
     members.value = data.targets.map(mapTarget)
     if (members.value.length > 0) {
@@ -193,7 +196,7 @@ async function loadTargets() {
 
 async function loadAppeals() {
   try {
-    const res = await fetchDlAppeals()
+    const res = await fetchDlAppeals(evalPeriodId.value)
     const appeals = (unwrap(res) ?? []).map(mapAppealSummary)
     appealSummaries.value = appeals
     if (appeals.length) {
@@ -311,7 +314,7 @@ async function handleApproveAppeal(payload) {
       inputMethod: payload?.inputMethod ?? 'TEXT',
     })
     await approveDlAppeal(selectedAppealId.value, {})
-    const appeals = (unwrap(await fetchDlAppeals()) ?? []).map(mapAppealSummary)
+    const appeals = (unwrap(await fetchDlAppeals(evalPeriodId.value)) ?? []).map(mapAppealSummary)
     appealSummaries.value = appeals
     selectedAppealDetail.value = null
     appealDraftMember.value = null
@@ -333,7 +336,7 @@ async function handleRejectAppeal() {
   try {
     appealActionLoading.value = true
     await rejectDlAppeal(selectedAppealId.value, { reason: '부서장 단계에서 일부 인용으로 종료되었습니다.' })
-    const appeals = (unwrap(await fetchDlAppeals()) ?? []).map(mapAppealSummary)
+    const appeals = (unwrap(await fetchDlAppeals(evalPeriodId.value)) ?? []).map(mapAppealSummary)
     appealSummaries.value = appeals
     selectedAppealDetail.value = null
     appealDraftMember.value = null
@@ -352,6 +355,10 @@ async function handleRejectAppeal() {
 
 async function handleSave(payload) {
   if (!selectedMember.value) return
+  if (isClosedPeriod.value) {
+    showToast('마감된 평가기간은 수정할 수 없습니다.', 'error')
+    return
+  }
   const draftText = payload?.draftText ?? ''
   const inputMethod = payload?.inputMethod ?? 'TEXT'
   try {
@@ -374,6 +381,10 @@ async function handleSave(payload) {
 async function handleSubmit(payload) {
   if (!selectedMember.value) return
   if (isSubmitted.value) return
+  if (isClosedPeriod.value) {
+    showToast('마감된 평가기간은 제출할 수 없습니다.', 'error')
+    return
+  }
   const draftText = payload?.draftText ?? ''
   const inputMethod = payload?.inputMethod ?? 'TEXT'
   try {
@@ -415,18 +426,22 @@ onBeforeUnmount(() => {
     <BaseFilterTabs
       v-model="activeTab"
       :items="modeTabs"
-      variant="chip"
+      variant="underline"
       size="md"
+      :show-count="true"
       class="dl-eval-view__tabs"
     />
 
     <div v-if="activeTab === 'evaluation'" class="dl-eval-view__content">
       <section class="dl-eval-view__progress-card dl-eval-view__progress-card--full">
+        <div v-if="isClosedPeriod" class="dl-eval-view__closed-notice">
+          이 평가 기간은 마감되었습니다. 조회만 가능합니다.
+        </div>
         <div class="dl-eval-view__progress-copy">
           <div>
-            <p class="dl-eval-view__progress-eyebrow">제출 완료 현황</p>
+            <p class="dl-eval-view__progress-eyebrow">{{ isClosedPeriod ? '확정 현황' : '제출 완료 현황' }}</p>
             <strong class="dl-eval-view__progress-title">
-              {{ submittedCount }} / {{ totalCount }}명 제출 완료
+              {{ submittedCount }} / {{ totalCount }}명 {{ isClosedPeriod ? '확정' : '제출 완료' }}
             </strong>
           </div>
           <div v-if="periodLabel" class="dl-eval-view__period-info">
@@ -519,29 +534,68 @@ onBeforeUnmount(() => {
   margin-bottom: 12px;
 }
 
+.dl-eval-view__closed-notice {
+  padding: 10px 14px;
+  background: #fefce8;
+  border: 1px solid #fde68a;
+  border-radius: 10px;
+  font-size: var(--font-size-xs-plus);
+  color: #92400e;
+}
+
 .dl-eval-view__tabs {
   align-self: flex-start;
   margin-bottom: 12px;
-  position: sticky;
-  top: 0;
-  z-index: 2;
-  padding-bottom: 4px;
-  background: var(--color-bg-app);
+  width: auto;
+  padding: 6px;
+  border: 1px solid #ece8ff;
+  border-radius: 18px;
+  background: linear-gradient(180deg, #ffffff 0%, #faf8ff 100%);
+}
+
+.dl-eval-view__tabs :deep(.base-filter-tabs) {
+  gap: 8px;
+  border-bottom: none;
+}
+
+.dl-eval-view__tabs :deep(.base-filter-tabs__item) {
+  height: 40px;
+  padding: 0 14px;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  background: transparent;
+  color: #9c93c9;
+  font-weight: var(--font-weight-bold);
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.dl-eval-view__tabs :deep(.base-filter-tabs__item--active) {
+  color: var(--color-primary-700);
+  border-color: #ddd1ff;
+  background: #f3edff;
 }
 
 .dl-eval-view__tabs :deep(.base-filter-tabs__count) {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 20px;
-  height: 20px;
+  min-width: 22px;
+  height: 22px;
   padding: 0 6px;
+  border-radius: 999px;
+  background: rgba(108, 86, 219, 0.12);
+  color: var(--color-primary-600);
+  font-size: var(--font-size-xs);
+  font-weight: 800;
+}
+
+.dl-eval-view__tabs :deep(.base-filter-tabs__item--active .base-filter-tabs__count) {
+  background: var(--color-primary-600);
+  color: #fff;
 }
 
 .dl-eval-view__tabs :deep(.base-filter-tabs__item:nth-child(2)) {
-  border-color: #f3c3cb;
   color: #c24157;
-  background: #fff5f6;
 }
 
 .dl-eval-view__tabs :deep(.base-filter-tabs__item:nth-child(2) .base-filter-tabs__count) {
@@ -550,9 +604,14 @@ onBeforeUnmount(() => {
 }
 
 .dl-eval-view__tabs :deep(.base-filter-tabs__item:nth-child(2).base-filter-tabs__item--active) {
-  background: #ffe7eb;
-  border-color: #e88998;
   color: #a61d38;
+  border-color: rgba(232, 137, 152, 0.5);
+  background: #fff1f3;
+}
+
+.dl-eval-view__tabs :deep(.base-filter-tabs__item:nth-child(2).base-filter-tabs__item--active .base-filter-tabs__count) {
+  background: #c24157;
+  color: #fff;
 }
 
 .dl-eval-view__tabs :deep(.base-filter-tabs__item:nth-child(2).base-filter-tabs__item--active .base-filter-tabs__count) {

--- a/src/views/hrmanager/HRMApprovalView.vue
+++ b/src/views/hrmanager/HRMApprovalView.vue
@@ -156,6 +156,7 @@ function defaultEvaluationDetail(summary) {
     firstStageComment: '',
     secondStageScore: '-',
     secondStageComment: '',
+    hrConfirmComment: '',
   }
 }
 
@@ -273,6 +274,7 @@ function mergeEvaluationDetail(item, detail) {
       dept: detail.employeeTier ?? '-',
       quarter: `${detail.evaluationLevel ?? 2}차 평가`,
       content: detail.evalComment || '내용 없음',
+      hrConfirmComment: detail.evalComment || '',
       qualScore: detail.score != null ? detail.score.toFixed(1) : '-',
       totalScore: detail.score != null ? detail.score.toFixed(1) : '-',
       firstStageScore: detail.firstStageScore != null ? detail.firstStageScore.toFixed(1) : '-',
@@ -347,6 +349,7 @@ const modeTabs = computed(() => [
   { key: 'evaluation', label: '평가 승인', count: evaluationPendingTotalCount.value },
   { key: 'appeal', label: '이의신청 승인', count: appealPendingTotalCount.value },
 ])
+const currentAppealPeriodId = computed(() => evaluationPeriodSummary.value?.evalPeriodId ?? null)
 
 const isConfirmDisabled = computed(() => {
   if (requiresEvaluationComment.value) {
@@ -366,10 +369,10 @@ const evaluationCommentLength = computed(() => evaluationConfirmComment.value.tr
 
 async function loadAppeals() {
   const [pendingResponse, receivingResponse, reviewingResponse, processedResponse] = await Promise.all([
-    hrApprovalApi.getAppeals({ page: 0, size: 100, status: 'SUBMITTED' }),
-    hrApprovalApi.getAppeals({ page: 0, size: 100, status: 'RECEIVING' }),
-    hrApprovalApi.getAppeals({ page: 0, size: 100, status: 'REVIEWING' }),
-    hrApprovalApi.getAppeals({ page: 0, size: 100, status: 'COMPLETED' }),
+    hrApprovalApi.getAppeals({ page: 0, size: 100, status: 'SUBMITTED', evaluationPeriodId: currentAppealPeriodId.value }),
+    hrApprovalApi.getAppeals({ page: 0, size: 100, status: 'RECEIVING', evaluationPeriodId: currentAppealPeriodId.value }),
+    hrApprovalApi.getAppeals({ page: 0, size: 100, status: 'REVIEWING', evaluationPeriodId: currentAppealPeriodId.value }),
+    hrApprovalApi.getAppeals({ page: 0, size: 100, status: 'COMPLETED', evaluationPeriodId: currentAppealPeriodId.value }),
   ])
 
   const pendingMapped = (pendingResponse.data?.data?.content ?? []).map(mapAppealSummaryToItem)
@@ -400,10 +403,10 @@ async function loadAppeals() {
 
 async function loadAppealCounts() {
   const [pendingResponse, receivingResponse, reviewingResponse, processedResponse] = await Promise.all([
-    hrApprovalApi.getAppeals({ page: 0, size: 1, status: 'SUBMITTED' }),
-    hrApprovalApi.getAppeals({ page: 0, size: 1, status: 'RECEIVING' }),
-    hrApprovalApi.getAppeals({ page: 0, size: 1, status: 'REVIEWING' }),
-    hrApprovalApi.getAppeals({ page: 0, size: 1, status: 'COMPLETED' }),
+    hrApprovalApi.getAppeals({ page: 0, size: 1, status: 'SUBMITTED', evaluationPeriodId: currentAppealPeriodId.value }),
+    hrApprovalApi.getAppeals({ page: 0, size: 1, status: 'RECEIVING', evaluationPeriodId: currentAppealPeriodId.value }),
+    hrApprovalApi.getAppeals({ page: 0, size: 1, status: 'REVIEWING', evaluationPeriodId: currentAppealPeriodId.value }),
+    hrApprovalApi.getAppeals({ page: 0, size: 1, status: 'COMPLETED', evaluationPeriodId: currentAppealPeriodId.value }),
   ])
 
   appealPendingTotalCount.value = pendingResponse.data?.data?.totalCount ?? 0
@@ -421,7 +424,13 @@ async function loadEvaluations() {
 
   const pendingContent = pendingResponse.data?.data?.content ?? []
   const processedContent = processedResponse.data?.data?.content ?? []
-  evaluationPeriodSummary.value = periodResponse.data?.data?.content?.[0] ?? null
+  const inProgressPeriod = periodResponse.data?.data?.content?.[0] ?? null
+  if (inProgressPeriod) {
+    evaluationPeriodSummary.value = inProgressPeriod
+  } else {
+    const confirmedResponse = await hrApprovalApi.getEvaluationPeriods({ status: 'CONFIRMED', page: 0, size: 1 })
+    evaluationPeriodSummary.value = confirmedResponse.data?.data?.content?.[0] ?? null
+  }
 
   evaluationPendingList.value = pendingContent
     .filter(item => normalizeEvaluationLevel(item.evaluationLevel) === 2)
@@ -443,11 +452,10 @@ async function loadCurrentMode() {
   loading.value = true
   error.value = null
   try {
+    await loadEvaluations()
     await loadAppealCounts()
     if (approvalMode.value === 'appeal') {
       await loadAppeals()
-    } else {
-      await loadEvaluations()
     }
   } catch (e) {
     console.error(e)
@@ -600,6 +608,7 @@ async function handleConfirm() {
 
   try {
     if (approvalMode.value === 'evaluation') {
+      const targetName = selectedItem.value.name
       await hrApprovalApi.confirmEvaluation(selectedItem.value.evaluateeId, {
         evaluationPeriodId: selectedItem.value.evaluationPeriodId,
         evalComment: evaluationConfirmComment.value.trim(),
@@ -608,7 +617,7 @@ async function handleConfirm() {
       confirmModal.value.show = false
       evaluationConfirmComment.value = ''
       await loadEvaluations()
-      showToast(`${selectedItem.value.name}님의 평가가 최종 확정되었습니다.`)
+      showToast(`${targetName}님의 평가가 최종 확정되었습니다.`)
       return
     }
 
@@ -652,7 +661,7 @@ async function handleConfirm() {
       class="hrm-approval__mode-tabs"
       :items="modeTabs"
       :model-value="approvalMode"
-      variant="chip"
+      variant="underline"
       :show-count="true"
       @change="approvalMode = $event"
     />
@@ -661,6 +670,9 @@ async function handleConfirm() {
     <div v-else-if="error" class="hrm-approval__error">{{ error }}</div>
     <template v-else>
       <section v-if="approvalMode === 'evaluation'" class="hrm-approval__progress-card">
+        <div v-if="evaluationPeriodSummary && evaluationPeriodSummary.status !== 'IN_PROGRESS'" class="hrm-approval__closed-notice">
+          ⚠️ 이 평가 기간은 마감되었습니다. 조회만 가능하며 추가 확정 처리는 제한될 수 있습니다.
+        </div>
         <div class="hrm-approval__progress-copy">
           <div>
             <p class="hrm-approval__progress-eyebrow">제출 완료 현황</p>
@@ -796,26 +808,56 @@ async function handleConfirm() {
 
 .hrm-approval__mode-tabs {
   align-self: flex-start;
+  width: auto;
+  padding: 6px;
+  border: 1px solid #ece8ff;
+  border-radius: 18px;
+  background: linear-gradient(180deg, #ffffff 0%, #faf8ff 100%);
+}
+
+.hrm-approval__mode-tabs :deep(.base-filter-tabs) {
+  gap: 8px;
+  border-bottom: none;
+}
+
+.hrm-approval__mode-tabs :deep(.base-filter-tabs__item) {
+  height: 40px;
+  padding: 0 14px;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  background: transparent;
+  color: #9c93c9;
+  font-weight: var(--font-weight-bold);
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.hrm-approval__mode-tabs :deep(.base-filter-tabs__item--active) {
+  color: var(--color-primary-700);
+  border-color: #ddd1ff;
+  background: #f3edff;
 }
 
 .hrm-approval__mode-tabs :deep(.base-filter-tabs__count) {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 20px;
-  height: 20px;
+  min-width: 22px;
+  height: 22px;
   padding: 0 6px;
   border-radius: 999px;
-  background: rgba(106, 76, 216, 0.12);
-  color: inherit;
-  font-size: 11px;
+  background: rgba(108, 86, 219, 0.12);
+  color: var(--color-primary-600);
+  font-size: var(--font-size-xs);
   font-weight: 800;
 }
 
+.hrm-approval__mode-tabs :deep(.base-filter-tabs__item--active .base-filter-tabs__count) {
+  background: var(--color-primary-600);
+  color: #fff;
+}
+
 .hrm-approval__mode-tabs :deep(.base-filter-tabs__item:nth-child(2)) {
-  border-color: #f3c3cb;
   color: #c24157;
-  background: #fff5f6;
 }
 
 .hrm-approval__mode-tabs :deep(.base-filter-tabs__item:nth-child(2) .base-filter-tabs__count) {
@@ -824,9 +866,14 @@ async function handleConfirm() {
 }
 
 .hrm-approval__mode-tabs :deep(.base-filter-tabs__item:nth-child(2).base-filter-tabs__item--active) {
-  background: #ffe7eb;
-  border-color: #e88998;
   color: #a61d38;
+  border-color: rgba(232, 137, 152, 0.5);
+  background: #fff1f3;
+}
+
+.hrm-approval__mode-tabs :deep(.base-filter-tabs__item:nth-child(2).base-filter-tabs__item--active .base-filter-tabs__count) {
+  background: #c24157;
+  color: #fff;
 }
 
 .hrm-approval__mode-tabs :deep(.base-filter-tabs__item:nth-child(2).base-filter-tabs__item--active .base-filter-tabs__count) {
@@ -910,6 +957,15 @@ async function handleConfirm() {
   border: 1px solid var(--color-border-default);
   border-radius: 20px;
   background: var(--color-bg-surface);
+}
+
+.hrm-approval__closed-notice {
+  padding: 10px 14px;
+  background: #fefce8;
+  border: 1px solid #fde68a;
+  border-radius: 10px;
+  font-size: var(--font-size-xs-plus);
+  color: #92400e;
 }
 
 .hrm-approval__progress-copy {

--- a/src/views/teamleader/TeamLeaderAiEvaluationView.vue
+++ b/src/views/teamleader/TeamLeaderAiEvaluationView.vue
@@ -14,10 +14,6 @@ import { mapStatus, statusToLabel } from '@/utils/evaluationStatus'
 const AVATAR_TONES = ['purple', 'green', 'gold']
 const STATUS_MAP = { NO_INPUT: 'not_started', DRAFT: 'in_progress', SUBMITTED: 'submitted' }
 const activeTab = ref('evaluation')
-const modeTabs = [
-  { key: 'evaluation', label: '평가 관리' },
-  { key: 'appeal', label: '이의신청' },
-]
 const APPEAL_TYPE_LABEL = {
   SCORE_ERRORS: '점수 오류',
   MISSING_ITEMS: '평가 항목 누락',
@@ -129,6 +125,8 @@ const periodLabel = computed(() => {
   return label ? `${label} 평가` : null
 })
 
+const isClosedPeriod = computed(() => Boolean(periodInfo.value?.status) && periodInfo.value.status !== 'IN_PROGRESS')
+
 const selectedTargetId = ref('')
 const guideOpen = ref(false)
 const recordingState = ref('idle')
@@ -184,6 +182,7 @@ onMounted(async () => {
       evalSequence: data.evalSequence,
       startDate: data.startDate,
       endDate: data.endDate,
+      status: data.status,
     }
     rawTargets.value = data.targets.map(mapTarget)
     data.targets.forEach((t) => {
@@ -203,7 +202,7 @@ onMounted(async () => {
   }
 
   try {
-    const res = await fetchTlAppeals()
+    const res = await fetchTlAppeals(evalPeriodId.value)
     const appeals = (unwrap(res) ?? []).map(mapAppealSummary)
     appealSummaries.value = appeals
     if (appeals.length) {
@@ -242,6 +241,15 @@ const evaluationCompletionRate = computed(() => {
   if (!memberListItems.value.length) return 0
   return Math.round((submittedCount.value / memberListItems.value.length) * 100)
 })
+
+const evaluationPendingCount = computed(
+  () => (isClosedPeriod.value ? 0 : memberListItems.value.filter((target) => target.status !== 'submitted').length),
+)
+
+const modeTabs = computed(() => [
+  { key: 'evaluation', label: '평가 관리', count: evaluationPendingCount.value },
+  { key: 'appeal', label: '이의신청', count: appealSummaries.value.length },
+])
 
 watch(
   memberListItems,
@@ -376,7 +384,7 @@ async function handleSubmitAppealReview() {
       inputMethod: appealDraftInputMethod.value,
     })
     await approveTlAppeal(selectedAppealId.value, {})
-    const appeals = (unwrap(await fetchTlAppeals()) ?? []).map(mapAppealSummary)
+    const appeals = (unwrap(await fetchTlAppeals(evalPeriodId.value)) ?? []).map(mapAppealSummary)
     appealSummaries.value = appeals
     selectedAppealDetail.value = null
     appealReviewing.value = false
@@ -397,7 +405,7 @@ async function handleRejectAppeal() {
   try {
     appealActionLoading.value = true
     await rejectTlAppeal(selectedAppealId.value, { reason: '팀리더 단계에서 기각되었습니다.' })
-    const appeals = (unwrap(await fetchTlAppeals()) ?? []).map(mapAppealSummary)
+    const appeals = (unwrap(await fetchTlAppeals(evalPeriodId.value)) ?? []).map(mapAppealSummary)
     appealSummaries.value = appeals
     selectedAppealDetail.value = null
     appealReviewing.value = false
@@ -443,6 +451,11 @@ async function handleSaveDraft() {
     return
   }
 
+  if (isClosedPeriod.value) {
+    updateFeedback('마감된 평가기간은 수정할 수 없습니다.', 'muted')
+    return
+  }
+
   const currentTarget = rawTargets.value.find((t) => t.id === selectedTargetId.value)
   if (!currentTarget?.evaluationPeriodId) return
   try {
@@ -464,6 +477,11 @@ async function handleSubmitEvaluation() {
 
   if (submittedEvaluations[selectedTargetId.value]) {
     updateFeedback('이미 제출된 평가입니다.', 'muted')
+    return
+  }
+
+  if (isClosedPeriod.value) {
+    updateFeedback('마감된 평가기간은 제출할 수 없습니다.', 'muted')
     return
   }
 
@@ -683,18 +701,22 @@ onBeforeUnmount(() => {
     <BaseFilterTabs
       v-model="activeTab"
       :items="modeTabs"
-      variant="chip"
+      variant="underline"
       size="md"
+      :show-count="true"
       class="teamleader-ai-evaluation-view__tabs"
     />
 
     <section v-if="activeTab === 'evaluation'" class="teamleader-ai-evaluation-view__content">
       <section class="teamleader-ai-evaluation-view__progress-card teamleader-ai-evaluation-view__progress-card--full">
+        <div v-if="isClosedPeriod" class="teamleader-ai-evaluation-view__closed-notice">
+          이 평가 기간은 마감되었습니다. 조회만 가능합니다.
+        </div>
         <div class="teamleader-ai-evaluation-view__progress-copy">
           <div>
-            <p class="teamleader-ai-evaluation-view__progress-eyebrow">제출 완료 현황</p>
+            <p class="teamleader-ai-evaluation-view__progress-eyebrow">{{ isClosedPeriod ? '확정 현황' : '제출 완료 현황' }}</p>
             <strong class="teamleader-ai-evaluation-view__progress-title">
-              {{ submittedCount }} / {{ memberListItems.length }}명 제출 완료
+              {{ submittedCount }} / {{ memberListItems.length }}명 {{ isClosedPeriod ? '확정' : '제출 완료' }}
             </strong>
           </div>
           <div v-if="periodLabel" class="teamleader-ai-evaluation-view__period-info">
@@ -720,14 +742,14 @@ onBeforeUnmount(() => {
         @select-member="handleSelectTarget"
       />
 
-      <TeamLeaderAiEvaluationPanel
-        :selected-target="selectedTarget"
-        :readonly="!!submittedEvaluations[selectedTargetId]"
-        :guide-open="guideOpen"
-        :recording-state="recordingState"
-        :uploaded-file-name="uploadedFileName"
-        :action-disabled="!selectedTargetId || !!submittedEvaluations[selectedTargetId]"
-        @update:converted-text="handleUpdateConvertedText"
+        <TeamLeaderAiEvaluationPanel
+          :selected-target="selectedTarget"
+          :readonly="isClosedPeriod || !!submittedEvaluations[selectedTargetId]"
+          :guide-open="guideOpen"
+          :recording-state="recordingState"
+          :uploaded-file-name="uploadedFileName"
+          :action-disabled="!selectedTargetId || isClosedPeriod || !!submittedEvaluations[selectedTargetId]"
+          @update:converted-text="handleUpdateConvertedText"
         @voice-input="handleVoiceInput"
         @file-selected="handleFileSelected"
         @convert-text="handleConvertText"
@@ -811,29 +833,68 @@ onBeforeUnmount(() => {
   margin-bottom: 12px;
 }
 
+.teamleader-ai-evaluation-view__closed-notice {
+  padding: 10px 14px;
+  background: #fefce8;
+  border: 1px solid #fde68a;
+  border-radius: 10px;
+  font-size: var(--font-size-xs-plus);
+  color: #92400e;
+}
+
 .teamleader-ai-evaluation-view__tabs {
   align-self: flex-start;
   margin-bottom: 12px;
-  position: sticky;
-  top: 0;
-  z-index: 2;
-  padding-bottom: 4px;
-  background: var(--color-bg-app);
+  width: auto;
+  padding: 6px;
+  border: 1px solid #ece8ff;
+  border-radius: 18px;
+  background: linear-gradient(180deg, #ffffff 0%, #faf8ff 100%);
+}
+
+.teamleader-ai-evaluation-view__tabs :deep(.base-filter-tabs) {
+  gap: 8px;
+  border-bottom: none;
+}
+
+.teamleader-ai-evaluation-view__tabs :deep(.base-filter-tabs__item) {
+  height: 40px;
+  padding: 0 14px;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  background: transparent;
+  color: #9c93c9;
+  font-weight: var(--font-weight-bold);
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.teamleader-ai-evaluation-view__tabs :deep(.base-filter-tabs__item--active) {
+  color: var(--color-primary-700);
+  border-color: #ddd1ff;
+  background: #f3edff;
 }
 
 .teamleader-ai-evaluation-view__tabs :deep(.base-filter-tabs__count) {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 20px;
-  height: 20px;
+  min-width: 22px;
+  height: 22px;
   padding: 0 6px;
+  border-radius: 999px;
+  background: rgba(108, 86, 219, 0.12);
+  color: var(--color-primary-600);
+  font-size: var(--font-size-xs);
+  font-weight: 800;
+}
+
+.teamleader-ai-evaluation-view__tabs :deep(.base-filter-tabs__item--active .base-filter-tabs__count) {
+  background: var(--color-primary-600);
+  color: #fff;
 }
 
 .teamleader-ai-evaluation-view__tabs :deep(.base-filter-tabs__item:nth-child(2)) {
-  border-color: #f3c3cb;
   color: #c24157;
-  background: #fff5f6;
 }
 
 .teamleader-ai-evaluation-view__tabs :deep(.base-filter-tabs__item:nth-child(2) .base-filter-tabs__count) {
@@ -842,9 +903,14 @@ onBeforeUnmount(() => {
 }
 
 .teamleader-ai-evaluation-view__tabs :deep(.base-filter-tabs__item:nth-child(2).base-filter-tabs__item--active) {
-  background: #ffe7eb;
-  border-color: #e88998;
   color: #a61d38;
+  border-color: rgba(232, 137, 152, 0.5);
+  background: #fff1f3;
+}
+
+.teamleader-ai-evaluation-view__tabs :deep(.base-filter-tabs__item:nth-child(2).base-filter-tabs__item--active .base-filter-tabs__count) {
+  background: #c24157;
+  color: #fff;
 }
 
 .teamleader-ai-evaluation-view__tabs :deep(.base-filter-tabs__item:nth-child(2).base-filter-tabs__item--active .base-filter-tabs__count) {


### PR DESCRIPTION
 ## 작업 내용
  - HRM/TL/DL 평가 화면에서 평가기간 상태에 따라 조회/편집 동작이 자연스럽게 이어지도록 정리했습니다.
  - 마감된 평가기간(CONFIRMED)에서는 조회만 가능하도록 readonly 처리와 안내 문구를 반영했습니다.
  - HRM/TL/DL 이의제기 목록이 현재 보고 있는 평가기간 기준으로 조회되도록 프런트 연동을 맞췄습니다.
  - HRM 상세에서 확정 코멘트 및 점수 배지 표시를 보강했습니다.

  ## 변경 파일
  - HRMApprovalView
  - HRMApprovalDetail
  - TeamLeaderAiEvaluationView
  - DepartmentLeaderSecondEvaluationView
  - teamleader/departmentleader evaluationApi
  - workerHrApi
  - evaluationPeriod util